### PR TITLE
Fix Python Bindings for Cygwin

### DIFF
--- a/api/plugins/bingo/python/bingo.py
+++ b/api/plugins/bingo/python/bingo.py
@@ -100,9 +100,9 @@ class Bingo(object):
 
     @staticmethod
     def _getLib(indigo):
-        if os.name == 'posix' and not platform.mac_ver()[0]:
+        if os.name == 'posix' and not platform.mac_ver()[0] and not platform.system().startswith("CYGWIN"):
             _lib = CDLL(indigo.dllpath + "/libbingo.so")
-        elif os.name == 'nt':
+        elif os.name == 'nt' or platform.system().startswith("CYGWIN"):
             _lib = CDLL(indigo.dllpath + "/bingo.dll")
         elif platform.mac_ver()[0]:
             _lib = CDLL(indigo.dllpath + "/libbingo.dylib")

--- a/api/plugins/inchi/python/indigo_inchi.py
+++ b/api/plugins/inchi/python/indigo_inchi.py
@@ -18,9 +18,9 @@ class IndigoInchi(object):
     def __init__(self, indigo):
         self.indigo = indigo
 
-        if os.name == 'posix' and not platform.mac_ver()[0]:
+        if os.name == 'posix' and not platform.mac_ver()[0] and not platform.system().startswith("CYGWIN"):
             self._lib = CDLL(indigo.dllpath + "/libindigo-inchi.so")
-        elif os.name == 'nt':
+        elif os.name == 'nt' or platform.system().startswith("CYGWIN"):
             self._lib = CDLL(indigo.dllpath + "\indigo-inchi.dll")
         elif platform.mac_ver()[0]:
             self._lib = CDLL(indigo.dllpath + "/libindigo-inchi.dylib")

--- a/api/plugins/renderer/python/indigo_renderer.py
+++ b/api/plugins/renderer/python/indigo_renderer.py
@@ -18,9 +18,9 @@ class IndigoRenderer(object):
     def __init__(self, indigo):
         self.indigo = indigo
 
-        if os.name == 'posix' and not platform.mac_ver()[0]:
+        if os.name == 'posix' and not platform.mac_ver()[0] and not platform.system().startswith("CYGWIN"):
             self._lib = CDLL(indigo.dllpath + "/libindigo-renderer.so")
-        elif os.name == 'nt':
+        elif os.name == 'nt' or platform.system().startswith("CYGWIN"):
             self._lib = CDLL(indigo.dllpath + "\indigo-renderer.dll")
         elif platform.mac_ver()[0]:
             self._lib = CDLL(indigo.dllpath + "/libindigo-renderer.dylib")

--- a/api/python/indigo.py
+++ b/api/python/indigo.py
@@ -1259,7 +1259,7 @@ class Indigo(object):
             if not dirname:
                 dirname = '.'
             path = dirname + '/lib'
-        if os.name == 'posix' and not platform.mac_ver()[0]:
+        if os.name == 'posix' and not platform.mac_ver()[0] and not platform.system().startswith("CYGWIN"):
             arch = platform.architecture()[0]
             path += "/Linux"
             if arch == '32bit':
@@ -1269,7 +1269,7 @@ class Indigo(object):
             else:
                 raise IndigoException("unknown platform " + arch)
             Indigo._lib = CDLL(path + "/libindigo.so", mode=RTLD_GLOBAL)
-        elif os.name == 'nt':
+        elif os.name == 'nt' or platform.system().startswith("CYGWIN"):
             arch = platform.architecture()[0]
             path += "/Win"
             if arch == '32bit':


### PR DESCRIPTION
Enable correct detection of Windows/NT for Cygwin Python distributions.

Since os.name=='posix' for cygwin, it was incorrectly being detected as linux. This check ensures that Cygwin is treated as windows in Python. It should have no impact on any other system.

Tested by creating an empty Indigo() object without any errors. I did not test further functionality.