### PR TITLE
Fixed bingo SQL installl scripts path after #50

### DIFF
--- a/bingo/postgres/bingo-pg-install.bat
+++ b/bingo/postgres/bingo-pg-install.bat
@@ -105,15 +105,15 @@ echo     Set OutStream = FS.OpenTextFile(FileName, 8, True) >> replace.vbs
 echo     OutStream.Write Contents >> replace.vbs
 echo End Function >> replace.vbs
 @rem Generate install script
-cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\bingo_schema.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\bingo_pg.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\bingo_internal.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\mango_internal.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\mango_pg.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\ringo_internal.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\ringo_pg.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\bingo_am.sql.in bingo_install.sql
-cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\bingo_config.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\common\bingo_schema.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\common\bingo_pg.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\common\bingo_internal.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\common\mango_internal.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\common\mango_pg.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\common\ringo_internal.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\common\ringo_pg.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\%BINGO_PG_VERSION%\bingo_am.sql.in bingo_install.sql
+cscript //b replace.vbs BINGO_PATHNAME %libdir%/bingo_postgres sql\common\bingo_config.sql.in bingo_install.sql
 @rem Generate uninstall script
 if exist bingo_uninstall.sql del bingo_uninstall.sql
 cscript //b replace.vbs BINGO_SCHEMANAME %schemaname% sql\bingo_uninstall.quick.sql.in bingo_uninstall.sql 

--- a/bingo/postgres/bingo-pg-install.sh
+++ b/bingo/postgres/bingo-pg-install.sh
@@ -92,20 +92,20 @@ fi
 
 
 # Generate install script
-sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/bingo_schema.sql.in  >bingo_install.sql
-sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/bingo_internal.sql.in >>bingo_install.sql
-sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/bingo_pg.sql.in  >>bingo_install.sql
+sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/common/bingo_schema.sql.in  >bingo_install.sql
+sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/common/bingo_internal.sql.in >>bingo_install.sql
+sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/common/bingo_pg.sql.in  >>bingo_install.sql
 
-sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/mango_internal.sql.in >>bingo_install.sql
-sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/mango_pg.sql.in       >>bingo_install.sql
+sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/common/mango_internal.sql.in >>bingo_install.sql
+sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/common/mango_pg.sql.in       >>bingo_install.sql
 
-sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/ringo_internal.sql.in >>bingo_install.sql
-sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/ringo_pg.sql.in       >>bingo_install.sql
+sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/common/ringo_internal.sql.in >>bingo_install.sql
+sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/common/ringo_pg.sql.in       >>bingo_install.sql
 
-sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/bingo_am.sql.in     >>bingo_install.sql
-sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/bingo_config.sql.in >>bingo_install.sql
+sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql//${BINGO_PG_VERSION}/bingo_am.sql.in     >>bingo_install.sql
+sed 's,BINGO_PATHNAME,'$libdir'/'$bingo_pg_name',g' <sql/common/bingo_config.sql.in >>bingo_install.sql
 
 #Generate uninstall script
-sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/bingo_uninstall.quick.sql.in >bingo_uninstall.sql
+sed 's,BINGO_SCHEMANAME,'$schema_name',g'         <sql/common/bingo_uninstall.quick.sql.in >bingo_uninstall.sql
 
 


### PR DESCRIPTION
#50 introduced Postgres versioning of build but installation SQL scripts hasn't been changed.
I checked it on Mac OS X, so I might be worth checking it on Windows.