### PR TITLE
Add action to trigger gitlab tests with SRC_REV

### DIFF
--- a/.github/workflows/gitlab_tests.yml
+++ b/.github/workflows/gitlab_tests.yml
@@ -1,0 +1,15 @@
+name: gitlab_tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger gitlab pipeline
+      shell: bash
+      env:
+        GITLAB_PROJECTS_ID: 7023
+        GITLAB_PIPELINE_TOKEN: ${{ secrets.GITLAB_PIPELINE_TOKEN }}
+      run: |
+        curl -X POST -F token=$GITLAB_PIPELINE_TOKEN  -F ref=master -F "variables[SRC_REV]=$GITHUB_SHA" https://git.epam.com/api/v4/projects/$GITLAB_PROJECTS_ID/trigger/pipeline


### PR DESCRIPTION
Before merge:

- review https://git.epam.com/epm-lsop/indigo-tests/-/merge_requests/8
- add new secret variable ([doc](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)): GITLAB_PIPELINE_TOKEN

This PR cannot be tested on fork:

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.