### PR TITLE
Disallow create IndigoRecord from empty IndigoObject

### DIFF
--- a/api/plugins/bingo-elastic/java/pom.xml
+++ b/api/plugins/bingo-elastic/java/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.epam.indigo</groupId>
     <artifactId>bingo-elastic</artifactId>
-    <version>1.4.0-beta.63</version>
+    <version>1.4.0-beta.86</version>
     <packaging>jar</packaging>
 
     <name>Bingo Elastic</name>

--- a/api/plugins/bingo-elastic/java/src/main/java/com/epam/indigo/model/IndigoRecord.java
+++ b/api/plugins/bingo-elastic/java/src/main/java/com/epam/indigo/model/IndigoRecord.java
@@ -87,14 +87,21 @@ public class IndigoRecord {
             withName(indigoObject.name());
             operations.add(record -> {
                 List<Integer> fin = new ArrayList<>();
-                String[] oneBits = indigoObject.fingerprint("sim").oneBitsList().split(" ");
+                String simBitList = indigoObject.fingerprint("sim").oneBitsList();
+                String subBitList = indigoObject.fingerprint("sub").oneBitsList();
+                String[] oneBits = simBitList.split(" ");
+
+                if (simBitList.length() == 0 || subBitList.length() == 0) {
+                    throw new BingoElasticException("Building IndigoRecords from empty IndigoObject is not supported");
+                }
+
                 for (String oneBit : oneBits) {
                     fin.add(Integer.parseInt(oneBit));
                 }
                 record.simFingerprint = new ArrayList<>();
                 record.simFingerprint.addAll(fin);
                 fin.clear();
-                oneBits = indigoObject.fingerprint("sub").oneBitsList().split(" ");
+                oneBits = subBitList.split(" ");
                 for (String oneBit : oneBits) {
                     fin.add(Integer.parseInt(oneBit));
                 }

--- a/api/plugins/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/SaveMoleculeFromIndigoRecordTest.java
+++ b/api/plugins/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/SaveMoleculeFromIndigoRecordTest.java
@@ -1,8 +1,12 @@
 package com.epam.indigo.elastic;
 
+import com.epam.indigo.BingoElasticException;
+import com.epam.indigo.Indigo;
+import com.epam.indigo.IndigoObject;
 import com.epam.indigo.elastic.ElasticRepository.ElasticRepositoryBuilder;
 import com.epam.indigo.model.Helpers;
 import com.epam.indigo.model.IndigoRecord;
+import com.epam.indigo.model.IndigoRecord.IndigoRecordBuilder;
 import org.junit.jupiter.api.*;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -11,7 +15,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SaveMoleculeFromIndigoRecordTest {
 
@@ -96,6 +100,20 @@ public class SaveMoleculeFromIndigoRecordTest {
         } catch (Exception exception) {
             Assertions.fail(exception);
         }
+    }
+
+    @Test
+    @DisplayName("Test empty molecule save")
+    public void saveEmptyMolecule() {
+        Indigo session = new Indigo();
+        IndigoObject mol = session.createMolecule();
+        Exception exception = assertThrows(BingoElasticException.class, () -> {
+            (new IndigoRecordBuilder()).withIndigoObject(mol).build();
+        });
+        String expectedMessage = "Building IndigoRecords from empty IndigoObject is not supported";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+
     }
 
 }


### PR DESCRIPTION
This PR closes bug, when user tries to create IndigoRecord from empty IndigoObject

This code throws the `java.lang.NumberFormatException`
```java
Indigo session = new Indigo();
IndigoObject mol = session.createMolecule();
(new IndigoRecordBuilder()).withIndigoObject(mol).build();
```

Code in this PR checks sim and sub fingerprints sizes, if one or both are empty, throws `BingoElasticException` with message `Building IndigoRecords from empty IndigoObject is not supported`

Additionally, this PR catches exception on trying to delete a missing index  using `ElasticRepository.deleteAllRecords()` method. 