### PR TITLE
Catch Indigo exceptions on `iterate_file`

### DIFF
--- a/.github/workflows/bingo-elastic-ci.yml
+++ b/.github/workflows/bingo-elastic-ci.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # todo: implement matrix test
         python-version: [ 3.7, 3.8, 3.9 ]
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +24,9 @@ jobs:
         run: pip install poetry
       - name: Install dependencies
         run: poetry install
+        working-directory: api/plugins/bingo-elastic/python
+      - name: Run pylint
+        run: pylint bingo_elastic/
         working-directory: api/plugins/bingo-elastic/python
       - name: Setup elasticsearch
         run: docker run -d -p 9200:9200 --env "discovery.type=single-node" --env "opendistro_security.disabled=true" amazon/opendistro-for-elasticsearch:latest

--- a/.github/workflows/bingo-elastic-ci.yml
+++ b/.github/workflows/bingo-elastic-ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: poetry install
         working-directory: api/plugins/bingo-elastic/python
       - name: Run pylint
-        run: pylint bingo_elastic/
+        run: poetry run pylint bingo_elastic
         working-directory: api/plugins/bingo-elastic/python
       - name: Setup elasticsearch
         run: docker run -d -p 9200:9200 --env "discovery.type=single-node" --env "opendistro_security.disabled=true" amazon/opendistro-for-elasticsearch:latest

--- a/api/plugins/bingo-elastic/python/.gitignore
+++ b/api/plugins/bingo-elastic/python/.gitignore
@@ -4,3 +4,4 @@ precommit.sh
 dbdir
 tests/.pytest_cache
 .DS_Store
+.idea

--- a/api/plugins/bingo-elastic/python/.pylintrc
+++ b/api/plugins/bingo-elastic/python/.pylintrc
@@ -1,0 +1,6 @@
+[MASTER]
+disable=
+    C0114, # missing-module-docstring
+    C0116, # missing-function-docstring
+    C0115, # missing-class-docstring
+    R0903, # too-few-public-methods

--- a/api/plugins/bingo-elastic/python/.pylintrc
+++ b/api/plugins/bingo-elastic/python/.pylintrc
@@ -4,3 +4,4 @@ disable=
     C0116, # missing-function-docstring
     C0115, # missing-class-docstring
     R0903, # too-few-public-methods
+    E1136, # unsubscriptable-object

--- a/api/plugins/bingo-elastic/python/bingo_elastic/elastic.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/elastic.py
@@ -22,7 +22,9 @@ class ElasticRepository:
         port: int = 9200,
         scheme: Str = "",
         http_auth: Optional[Tuple[Str]] = None,
-        ssl_context: Any = None
+        ssl_context: Any = None,
+        request_timeout: int = 60,
+        retry_on_timeout: bool = True
     ) -> None:
         """
         :param host: host or list of hosts
@@ -30,10 +32,14 @@ class ElasticRepository:
         :param scheme: http or https
         :param http_auth:
         :param ssl_context:
+        :param timeout:
+        :param retry_on_timeout:
         """
         arguments = {
             "port": port,
             "scheme": "https" if scheme == "https" else "http",
+            "request_timeout": request_timeout,
+            "retry_on_timeout": retry_on_timeout,
         }
         if type(host) == str:
             arguments["host"] = host

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Generator, Union
+from typing import Callable, Generator, Optional, Union
 
 from indigo import Indigo, IndigoObject
 
@@ -7,7 +7,9 @@ from bingo_elastic.model.record import IndigoRecord
 
 
 def iterate_file(
-    file: Path, iterator: str = None
+    file: Path,
+    iterator: str = None,
+    error_handler: Optional[Callable[[object, BaseException], None]] = None,
 ) -> Generator[IndigoRecord, None, None]:
     """
     :param file:
@@ -15,6 +17,8 @@ def iterate_file(
                      If iterator is not set, trying to determine
                      iterator by file extension
     :type iterator: str
+    :param error_handler: lambda for catching exceptions
+    :type error_handler: Optional[Callable[[object, BaseException], None]]
     :return:
     """
     iterators = {
@@ -31,18 +35,39 @@ def iterate_file(
 
     indigo_object: IndigoObject
     for indigo_object in getattr(Indigo(), iterator_fn)(str(file)):
-        yield IndigoRecord(indigo_object=indigo_object)
+        yield IndigoRecord(
+            indigo_object=indigo_object, error_handler=error_handler
+        )
 
 
-def iterate_sdf(file: Union[Path, str]) -> Generator:
-    yield from iterate_file(Path(file) if type(file) == str else file, "sdf")
-
-
-def iterate_smiles(file: Union[Path, str]) -> Generator:
+def iterate_sdf(
+    file: Union[Path, str],
+    error_handler: Optional[Callable[[object, BaseException], None]] = None,
+) -> Generator:
     yield from iterate_file(
-        Path(file) if type(file) == str else file, "smiles"
+        Path(file) if isinstance(file, str) else file,
+        "sdf",
+        error_handler=error_handler,
     )
 
 
-def iterate_cml(file: Union[Path, str]) -> Generator:
-    yield from iterate_file(Path(file) if type(file) == str else file, "cml")
+def iterate_smiles(
+    file: Union[Path, str],
+    error_handler: Optional[Callable[[object, BaseException], None]] = None,
+) -> Generator:
+    yield from iterate_file(
+        Path(file) if isinstance(file, str) else file,
+        "smiles",
+        error_handler=error_handler,
+    )
+
+
+def iterate_cml(
+    file: Union[Path, str],
+    error_handler: Optional[Callable[[object, BaseException], None]] = None,
+) -> Generator:
+    yield from iterate_file(
+        Path(file) if isinstance(file, str) else file,
+        "cml",
+        error_handler=error_handler,
+    )

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
@@ -1,13 +1,9 @@
-import logging
 from pathlib import Path
 from typing import Generator, Union
 
 from indigo import Indigo, IndigoObject
 
 from bingo_elastic.model.record import IndigoRecord
-
-
-logger = logging.getLogger("bingo_elastic")
 
 
 def iterate_file(
@@ -35,10 +31,7 @@ def iterate_file(
 
     indigo_object: IndigoObject
     for indigo_object in getattr(Indigo(), iterator_fn)(str(file)):
-        try:
-            yield IndigoRecord(indigo_object=indigo_object)
-        except Exception as err_:
-            logger.exception(err_)
+        yield IndigoRecord(indigo_object=indigo_object)
 
 
 def iterate_sdf(file: Union[Path, str]) -> Generator:

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/helpers.py
@@ -1,9 +1,13 @@
+import logging
 from pathlib import Path
 from typing import Generator, Union
 
 from indigo import Indigo, IndigoObject
 
 from bingo_elastic.model.record import IndigoRecord
+
+
+logger = logging.getLogger("bingo_elastic")
 
 
 def iterate_file(
@@ -31,7 +35,10 @@ def iterate_file(
 
     indigo_object: IndigoObject
     for indigo_object in getattr(Indigo(), iterator_fn)(str(file)):
-        yield IndigoRecord(indigo_object=indigo_object)
+        try:
+            yield IndigoRecord(indigo_object=indigo_object)
+        except Exception as err_:
+            logger.exception(err_)
 
 
 def iterate_sdf(file: Union[Path, str]) -> Generator:

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
@@ -1,17 +1,40 @@
+from uuid import uuid4
+
 import indigo
-import logging
-from typing import Dict, List
+from typing import Dict, List, Tuple
+from contextvars import ContextVar
 
 from indigo import Indigo, IndigoObject
 
-logger = logging.getLogger("bingo_elastic")
+
+class RecordErrorStack:
+    def __init__(self):
+        self.__stack = []
+
+    def put(self, record_id: str, error: Exception) -> None:
+        self.__stack.append((record_id, error))
+
+    def pop(self) -> Tuple[str, Exception]:
+        return self.__stack.pop()
+
+    def view(self):
+        for record_id, error in self.__stack[::-1]:
+            yield record_id, error
+
+    def __len__(self):
+        return len(self.__stack)
+
+
+record_errors: ContextVar[RecordErrorStack] = ContextVar(
+    "error_context", default=RecordErrorStack()
+)
 
 
 class WithElasticResponse:
     def __set__(self, instance: object, value: Dict):
         el_src = value["_source"]
-        setattr(instance, "name", el_src.get("name"))
-        setattr(instance, "cmf", el_src.get("cmf"))
+        for key, value in el_src.items():
+            setattr(instance, key, value)
 
 
 class WithIndigoObject:
@@ -32,27 +55,29 @@ class WithIndigoObject:
                 ]
                 setattr(instance, f"{fp}_fingerprint", fp_)
                 setattr(instance, f"{fp}_fingerprint_len", len(fp_))
-            except ValueError:
-                pass
-            except indigo.IndigoException:
-                pass
+            except ValueError as err_:
+                record_errors.get().put(instance.record_id, err_)
+            except indigo.IndigoException as err_:
+                record_errors.get().put(instance.record_id, err_)
 
         setattr(instance, "name", value.name())
         try:
-            setattr(instance, "cmf",
-                    " ".join(map(str, list(value.serialize()))))
+            setattr(
+                instance, "cmf", " ".join(map(str, list(value.serialize())))
+            )
         except indigo.IndigoException:
-            pass
+            record_errors.get().put(instance.record_id, err_)
 
 
 class IndigoRecord:
 
-    cmf = None
-    name = None
-    sim_fingerprint = None
-    sub_fingerprint = None
+    cmf: bytes = None
+    name: str = None
+    sim_fingerprint: List[str] = None
+    sub_fingerprint: List[str] = None
     indigo_object = WithIndigoObject()
     elastic_response = WithElasticResponse()
+    record_id: str = None
 
     def __init__(self, **kwargs) -> None:
         """
@@ -66,7 +91,7 @@ class IndigoRecord:
         :param sub_fingerprint: similarity fingerprint (sub)
         :type sub_fingerprint: List[int]
         """
-
+        self.record_id = uuid4().hex
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -74,4 +99,4 @@ class IndigoRecord:
         return self.__dict__
 
     def as_indigo_object(self, session: Indigo):
-        return session.unserialize(list(map(int, self.cmf.split(" "))))
+        return session.deserialize(list(map(int, self.cmf.split(" "))))

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
@@ -1,3 +1,4 @@
+import indigo
 import logging
 from typing import Dict, List
 
@@ -21,6 +22,8 @@ class WithIndigoObject:
         )
         for fp in fps:
             try:
+                setattr(instance, f"{fp}_fingerprint", [])
+                setattr(instance, f"{fp}_fingerprint_len", 0)
                 fp_ = [
                     int(feature)
                     for feature in value.fingerprint(fp)
@@ -30,12 +33,16 @@ class WithIndigoObject:
                 setattr(instance, f"{fp}_fingerprint", fp_)
                 setattr(instance, f"{fp}_fingerprint_len", len(fp_))
             except ValueError:
-                raise ValueError(
-                    "Building IndigoRecords from empty "
-                    "IndigoObject is not supported"
-                )
+                pass
+            except indigo.IndigoException:
+                pass
+
         setattr(instance, "name", value.name())
-        setattr(instance, "cmf", " ".join(map(str, list(value.serialize()))))
+        try:
+            setattr(instance, "cmf",
+                    " ".join(map(str, list(value.serialize()))))
+        except indigo.IndigoException:
+            pass
 
 
 class IndigoRecord:

--- a/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
+++ b/api/plugins/bingo-elastic/python/bingo_elastic/model/record.py
@@ -5,11 +5,11 @@ import indigo
 from indigo import Indigo, IndigoObject
 
 
+# pylint: disable=unused-argument
 def skip_errors(instance: object, err: BaseException) -> None:
     """
     Empty handler to skip errors
     """
-    pass
 
 
 def check_error(instance: object, error: BaseException) -> None:

--- a/api/plugins/bingo-elastic/python/poetry.lock
+++ b/api/plugins/bingo-elastic/python/poetry.lock
@@ -116,13 +116,14 @@ python-versions = "*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.1.1"
+version = "3.3.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -225,7 +226,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "py"
-version = "1.9.0"
+version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
@@ -405,8 +406,8 @@ elasticsearch = [
     {file = "epam.indigo-1.4.1-py3-none-win_amd64.whl", hash = "sha256:d96ac686d1776a6900953bf6aff4ad1e114ba017aea66999c848f8b5d9c37d65"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
-    {file = "importlib_metadata-3.1.1.tar.gz", hash = "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"},
+    {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
+    {file = "importlib_metadata-3.3.0.tar.gz", hash = "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed"},
 ]
 isort = [
     {file = "isort-5.6.4-py3-none-any.whl", hash = "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7"},
@@ -476,8 +477,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},

--- a/api/plugins/bingo-elastic/python/poetry.lock
+++ b/api/plugins/bingo-elastic/python/poetry.lock
@@ -108,7 +108,7 @@ requests = ["requests (>=2.4.0,<3.0.0)"]
 
 [[package]]
 name = "epam.indigo"
-version = "1.4.0b0"
+version = "1.4.1"
 description = "Indigo universal cheminformatics toolkit"
 category = "main"
 optional = false
@@ -116,7 +116,7 @@ python-versions = "*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.0.0"
+version = "3.1.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -127,7 +127,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "isort"
@@ -362,7 +362,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e87c49ea8689a71718c2313a32e441b99427d56785b27badba22758ded36db7c"
+content-hash = "24b2ef0f733e821c851f72bd6c9e77e034b9be957fb4827935b47df26f896e6b"
 
 [metadata.files]
 appdirs = [
@@ -401,20 +401,13 @@ elasticsearch = [
     {file = "elasticsearch-7.10.0.tar.gz", hash = "sha256:9053ca99bc9db84f5d80e124a79a32dfa0f7079b2112b546a03241c0dbeda36d"},
 ]
 "epam.indigo" = [
-    {file = "epam.indigo-1.4.0b0-py2-none-macosx_10_7_intel.whl", hash = "sha256:d13068e02759b147eaea0ef88454ec7e3b81c80d6601aeee078dd0c2bcae501f"},
-    {file = "epam.indigo-1.4.0b0-py2-none-manylinux1_i686.whl", hash = "sha256:d5d53a28400df1c832d72f5241d1e142326b919b1d4a3a5cdea2067d19af41af"},
-    {file = "epam.indigo-1.4.0b0-py2-none-manylinux1_x86_64.whl", hash = "sha256:3c56087291b301f4d7105395d5d2c805fe5af49b63a0b808f27b7ec96bebdd01"},
-    {file = "epam.indigo-1.4.0b0-py2-none-win32.whl", hash = "sha256:2d04682d9e9204e9ad7c6ad56fd2174e1cfd492b8c58671c272570128ee7951d"},
-    {file = "epam.indigo-1.4.0b0-py2-none-win_amd64.whl", hash = "sha256:865713b5775e89d8a446cf0bb45ff8a955b012260b4de17e9c739f4f6bb52d34"},
-    {file = "epam.indigo-1.4.0b0-py3-none-macosx_10_7_intel.whl", hash = "sha256:8988b0608cc1f72feebdef025c85dfbf6b93f9b7fa89d3b58ce481ff86b6827b"},
-    {file = "epam.indigo-1.4.0b0-py3-none-manylinux1_i686.whl", hash = "sha256:831ab4cfdb568b137d6ad6d11bf1adcf68b7d7742ab9f77cf7ee1a1f4d0554b1"},
-    {file = "epam.indigo-1.4.0b0-py3-none-manylinux1_x86_64.whl", hash = "sha256:cdfa6bcae37144bacf6a3a91282bd1174b1c378819bdb79b279bd0ad854b41c2"},
-    {file = "epam.indigo-1.4.0b0-py3-none-win32.whl", hash = "sha256:ee792810df4eee90d69c88d3f2a07b852b36f9f9de2215ee38612c54784a9cd8"},
-    {file = "epam.indigo-1.4.0b0-py3-none-win_amd64.whl", hash = "sha256:fc422dc1d0923f5fe98eab72f6912b9cda3a394b2887c1b27daf9960460df650"},
+    {file = "epam.indigo-1.4.1-py3-none-macosx_10_7_intel.whl", hash = "sha256:9669d7320b549f185aae44343fd298fdd95e2d214b6be39946c4573529592fbd"},
+    {file = "epam.indigo-1.4.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:9740d377c18084d39895186a9b4017be93e907623f348512b40a58db2b7eaef2"},
+    {file = "epam.indigo-1.4.1-py3-none-win_amd64.whl", hash = "sha256:d96ac686d1776a6900953bf6aff4ad1e114ba017aea66999c848f8b5d9c37d65"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.0.0-py2.py3-none-any.whl", hash = "sha256:fc3b3f9697703d3833d2803162d60cbe8b9f57b5da5e6496ac81e3cb82bd8d9c"},
-    {file = "importlib_metadata-3.0.0.tar.gz", hash = "sha256:d582eb5c35b2f16c78e365e0f89e369f36af38fdaad0146208aa973c693ba247"},
+    {file = "importlib_metadata-3.1.0-py2.py3-none-any.whl", hash = "sha256:590690d61efdd716ff82c39ca9a9d4209252adfe288a4b5721181050acbd4175"},
+    {file = "importlib_metadata-3.1.0.tar.gz", hash = "sha256:d9b8a46a0885337627a6430db287176970fff18ad421becec1d64cfc763c2099"},
 ]
 isort = [
     {file = "isort-5.6.4-py3-none-any.whl", hash = "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7"},

--- a/api/plugins/bingo-elastic/python/tests/model/test_record.py
+++ b/api/plugins/bingo-elastic/python/tests/model/test_record.py
@@ -21,8 +21,15 @@ def test_create(indigo_fixture):
     assert len(indigo_record.cmf) == 140
 
 
+def test_create_without_fingerprint(indigo_fixture):
+    mol = indigo_fixture.loadMolecule("[H][H]")
+    indigo_record = record.IndigoRecord(indigo_object=mol)
+    assert len(indigo_record.sim_fingerprint) == 0
+    assert len(indigo_record.sub_fingerprint) == 0
+
+
 def test_create_with_name(
-    indigo_fixture, resource_loader: Callable[[str], str]
+        indigo_fixture, resource_loader: Callable[[str], str]
 ):
     mol = indigo_fixture.loadMoleculeFromFile(
         resource_loader("resources/composition1.mol")

--- a/api/plugins/bingo-elastic/python/tests/model/test_record.py
+++ b/api/plugins/bingo-elastic/python/tests/model/test_record.py
@@ -1,14 +1,16 @@
 from typing import Callable
 
-import pytest
-
 from bingo_elastic.model import record
 
 
 def test_empty_create(indigo_fixture):
     mol = indigo_fixture.createMolecule()
-    with pytest.raises(ValueError):
-        record.IndigoRecord(indigo_object=mol)
+    err_instance = record.record_errors.get()
+    assert not len(err_instance)
+    record.IndigoRecord(indigo_object=mol)
+    assert len(err_instance)
+    record_id, error = err_instance.pop()
+    assert isinstance(error, ValueError)
 
 
 def test_create(indigo_fixture):

--- a/api/plugins/bingo-elastic/python/tests/test_elastic.py
+++ b/api/plugins/bingo-elastic/python/tests/test_elastic.py
@@ -131,3 +131,32 @@ def test_wildcard_search(
     result = elastic_repository.filter(name=WildcardQuery("Comp*"))
     for item in result:
         assert item.name == "Composition1"
+
+
+def test_custom_fields(
+    elastic_repository: ElasticRepository,
+    indigo_fixture: Indigo,
+    loaded_sdf: IndigoRecord,
+    resource_loader: Callable[[str], str],
+):
+
+    mol = indigo_fixture.loadMoleculeFromFile(
+        resource_loader("resources/composition1.mol")
+    )
+    rec = IndigoRecord(indigo_object=mol,
+                       PUBCHEM_IUPAC_INCHIKEY="RDHQFKQIGNGIED-UHFFFAOYSA-N")
+    elastic_repository.index_record(rec)
+    time.sleep(1)
+    result = elastic_repository.filter(
+        PUBCHEM_IUPAC_INCHIKEY="RDHQFKQIGNGIED-UHFFFAOYSA-N"
+    )
+    for item in result:
+        assert item.PUBCHEM_IUPAC_INCHIKEY == "RDHQFKQIGNGIED-UHFFFAOYSA-N"
+
+
+#TODO: create pubchem test
+# def test_pubchem(indigo_fixture: Indigo,
+#                  resource_loader: Callable[[str], str],):
+#     iterator = iterate_file(Path(resource_loader("resources/pubchem_1.sdf")))
+#     for item in iterator:
+#         pass

--- a/api/plugins/bingo-elastic/python/tests/test_elastic.py
+++ b/api/plugins/bingo-elastic/python/tests/test_elastic.py
@@ -154,6 +154,23 @@ def test_custom_fields(
         assert item.PUBCHEM_IUPAC_INCHIKEY == "RDHQFKQIGNGIED-UHFFFAOYSA-N"
 
 
+def test_search_empty_fingerprint(
+    elastic_repository: ElasticRepository,
+    indigo_fixture: Indigo,
+    loaded_sdf: IndigoRecord,
+    resource_loader: Callable[[str], str],
+):
+    mol = indigo_fixture.loadMolecule("[H][H]")
+    rec = IndigoRecord(indigo_object=mol)
+    elastic_repository.index_record(rec)
+    time.sleep(1)
+    result = elastic_repository.filter(exact=rec)
+    assert (
+            "[H][H]" == next(result).as_indigo_object(indigo_fixture).canonicalSmiles()
+    )
+
+
+
 #TODO: create pubchem test
 # def test_pubchem(indigo_fixture: Indigo,
 #                  resource_loader: Callable[[str], str],):


### PR DESCRIPTION
Now, when IndigoException raises during `iterate_file`, iteration stops with this exception. 

This fix should avoid stop iteration.

What options are:

- Log all errors to stderr
- Accumulate errors and return in another object
- Log error into IndigoRecord 

Open questions:
- Should we save IndigoRecords without fingerprints, when all bits in fingerprint are 0?
- Should we save IndigoRecords without cmf, when IndigoObject cannot be created?


Other fixes:
- Add isort and pylint checks 
- Add check if `poetry update` changes `poetry.lock` file 
