### PR TITLE
api: java: fix load native libs

### DIFF
--- a/api/java/src/main/java/com/epam/indigo/IndigoUtils.java
+++ b/api/java/src/main/java/com/epam/indigo/IndigoUtils.java
@@ -113,18 +113,18 @@ public class IndigoUtils {
     static String getDllPath() {
         String path;
         if (Platform.isWindows()) {
-            path = "Win" + File.separator;
+            path = "Win/";
             if (Platform.is64Bit()) path += "x64";
             else path += "x86";
         } else if (Platform.isMac()) {
-            path = "Mac" + File.separator;
+            path = "Mac/";
             path += "10." + detectMacMinorVersion(path);
         } else if (Platform.isLinux()) {
-            path = "Linux" + File.separator;
+            path = "Linux/";
             if (Platform.is64Bit()) path += "x64";
             else path += "x86";
         } else if (Platform.isSolaris()) {
-            path = "Sun" + File.separator;
+            path = "Sun/";
             if (Platform.is64Bit()) path += "sparc64";
             else path += "sparc32";
         } else throw new Error("Operating system not recognized");


### PR DESCRIPTION
The name of a resource is a '/'-separated path name that identifies the resource. It means that when specifying the resource file to load, you have to use the forward slash / to separate the path. Since in Windows the value of File.separator is backward slash \, Java won't be able to find the resource file. To make it portable to Windows and some other platforms, you should not use File.separator when loading resource files. Use / instead.

[Class.html#getResourceAsStream(java.lang.String)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getResourceAsStream(java.lang.String))