### PR TITLE
Fix for issue #231 Result string of indigoData is not properly terminated

### DIFF
--- a/api/src/indigo_molecule.cpp
+++ b/api/src/indigo_molecule.cpp
@@ -2651,7 +2651,7 @@ if (bonds != 0)
     for (i = 0; i < nbonds; i++)
         dsg.bonds.push(bonds[i]);
 if (data != 0)
-    dsg.data.readString(data, false);
+    dsg.data.readString(data, true);
 if (name != 0)
     dsg.name.readString(name, true);
 
@@ -2701,7 +2701,7 @@ INDIGO_END(-1)
 CEXPORT int indigoSetSGroupData(int sgroup, const char* data){INDIGO_BEGIN{DataSGroup& dsg = IndigoDataSGroup::cast(self.getObject(sgroup)).get();
 
 if (data != 0)
-    dsg.data.readString(data, false);
+    dsg.data.readString(data, true);
 
 return 1;
 }

--- a/api/tests/python/ref/todo/231_result_string_of_indigodata_is_not_properly_terminated.py.out
+++ b/api/tests/python/ref/todo/231_result_string_of_indigodata_is_not_properly_terminated.py.out
@@ -1,0 +1,3 @@
+#231 getDataSGroup::name: color
+#231 getDataSGroup::data: 0.155, 0.55, 0.955
+True

--- a/api/tests/python/tests/todo/231_result_string_of_indigodata_is_not_properly_terminated.py
+++ b/api/tests/python/tests/todo/231_result_string_of_indigodata_is_not_properly_terminated.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.append(os.path.normpath(os.path.join(os.path.abspath(__file__), '..', '..', '..', "common")))
+from env_indigo import *
+
+# Issue #231 Result string of indigoData is not properly terminated 
+
+def main():
+    indigo = Indigo()
+    indigo.setOption("molfile-saving-skip-date", True)
+    m = indigo.loadMolecule('InChI=1S/C17H25N3O2/c18-9-14-2-1-3-20(14)15(21)10-19-16-5-12-4-13(6-16)8-17(22,7-12)11-16/h12-14,19,22H,1-8,10-11H2/t12?,13?,14-,16?,17?/m0/s1')
+    sgroup = m.addDataSGroup([0, 1, 2, 3], [], "color", "0.155, 0.55, 0.955")
+    for id in range(m.countDataSGroups()) :
+        sgroup = m.getDataSGroup(id)
+        name = sgroup.description()
+        aString = sgroup.data()
+        if ("color" == name) :
+            print("#231 getDataSGroup::name:", name)
+            print("#231 getDataSGroup::data:", aString)
+            print("0.155, 0.55, 0.955" == aString)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Need to forcibly add terminating zero to `data` Array on reading.
Pros:
1) It is created from zero-terminated C string (`const char *` )
2) Though it was initially designed as Array of bytes and is returned in wrappers as `sbyte *`, it is anyway a string, since no function returns information about its length.
So I conclude it can only be a string, not just an Array of bytes.
