### PR TITLE
Refactoring: Optimize adding atoms and bonds arrays

### DIFF
--- a/api/src/indigo_molecule.cpp
+++ b/api/src/indigo_molecule.cpp
@@ -2781,12 +2781,12 @@ CEXPORT int indigoAddDataSGroup(int molecule, int natoms, int* atoms, int nbonds
         int idx = mol.sgroups.addSGroup(SGroup::SG_TYPE_DAT);
         DataSGroup& dsg = (DataSGroup&)mol.sgroups.getSGroup(idx);
         int i;
-        if (atoms != 0)
-            for (i = 0; i < natoms; i++)
-                dsg.atoms.push(atoms[i]);
-        if (bonds != 0)
-            for (i = 0; i < nbonds; i++)
-                dsg.bonds.push(bonds[i]);
+        if (atoms != NULL)
+            dsg.atoms.concat(atoms, natoms);
+
+        if (bonds != NULL)
+            dsg.bonds.concat(bonds, nbonds);
+
         if (data != 0)
             dsg.data.readString(data, true);
         if (name != 0)
@@ -2805,11 +2805,11 @@ CEXPORT int indigoAddSuperatom(int molecule, int natoms, int* atoms, const char*
         int idx = mol.sgroups.addSGroup(SGroup::SG_TYPE_SUP);
         Superatom& satom = (Superatom&)mol.sgroups.getSGroup(idx);
         satom.subscript.appendString(name, true);
-        if (atoms == 0)
+        if (atoms == NULL)
             throw IndigoError("indigoAddSuperatom(): atoms were not specified");
 
-        for (int i = 0; i < natoms; i++)
-            satom.atoms.push(atoms[i]);
+        else
+            satom.atoms.concat(atoms, natoms);
 
         return self.addObject(new IndigoSuperatom(mol, idx));
     }

--- a/api/src/indigo_molecule.cpp
+++ b/api/src/indigo_molecule.cpp
@@ -2781,15 +2781,15 @@ CEXPORT int indigoAddDataSGroup(int molecule, int natoms, int* atoms, int nbonds
         int idx = mol.sgroups.addSGroup(SGroup::SG_TYPE_DAT);
         DataSGroup& dsg = (DataSGroup&)mol.sgroups.getSGroup(idx);
         int i;
-        if (atoms != NULL)
+        if (atoms != nullptr)
             dsg.atoms.concat(atoms, natoms);
 
-        if (bonds != NULL)
+        if (bonds != nullptr)
             dsg.bonds.concat(bonds, nbonds);
 
-        if (data != 0)
+        if (data != nullptr)
             dsg.data.readString(data, true);
-        if (name != 0)
+        if (name != nullptr)
             dsg.name.readString(name, true);
 
         return self.addObject(new IndigoDataSGroup(mol, idx));
@@ -2805,7 +2805,7 @@ CEXPORT int indigoAddSuperatom(int molecule, int natoms, int* atoms, const char*
         int idx = mol.sgroups.addSGroup(SGroup::SG_TYPE_SUP);
         Superatom& satom = (Superatom&)mol.sgroups.getSGroup(idx);
         satom.subscript.appendString(name, true);
-        if (atoms == NULL)
+        if (atoms == nullptr)
             throw IndigoError("indigoAddSuperatom(): atoms were not specified");
 
         else

--- a/common/base_cpp/array.h
+++ b/common/base_cpp/array.h
@@ -37,13 +37,13 @@ namespace indigo
     public:
         DECL_TPL_ERROR(ArrayError);
 
-        Array() : _reserved(0), _length(0), _array(NULL)
+        Array() : _reserved(0), _length(0), _array(nullptr)
         {
         }
 
         ~Array()
         {
-            if (_array != NULL)
+            if (_array != nullptr)
             {
                 free(_array);
             }
@@ -67,17 +67,17 @@ namespace indigo
             {
                 if (_length < 1)
                 {
-                    if (_array != NULL)
+                    if (_array != nullptr)
                     {
                         free(_array);
-                        _array = NULL;
+                        _array = nullptr;
                     }
                 }
 
                 T* oldptr = _array;
 
                 _array = (T*)realloc(_array, sizeof(T) * to_reserve);
-                if (_array == NULL)
+                if (_array == nullptr)
                 {
                     _array = oldptr;
                     throw Error("reserve(): no memory");

--- a/common/base_cpp/array.h
+++ b/common/base_cpp/array.h
@@ -37,11 +37,8 @@ namespace indigo
     public:
         DECL_TPL_ERROR(ArrayError);
 
-        explicit Array()
+        Array() : _reserved(0), _length(0), _array(NULL)
         {
-            _reserved = 0;
-            _length = 0;
-            _array = NULL;
         }
 
         ~Array()
@@ -49,7 +46,6 @@ namespace indigo
             if (_array != NULL)
             {
                 free(_array);
-                _array = NULL;
             }
         }
 
@@ -60,9 +56,9 @@ namespace indigo
 
         void reserve(int to_reserve)
         {
-            // Addtional check for unexpectedly large memory allocations (larger than 512 Mb)
+            // Addtional check for unexpectedly large memory allocations (larger than 1 GB)
             if (to_reserve * sizeof(T) >= 1 << 30)
-                throw Error("memory to reserve (%d x %d) is large than allowed threshold", to_reserve, (int)sizeof(T));
+                throw Error("memory to reserve (%d x %d) is larger than the allowed threshold", to_reserve, (int)sizeof(T));
 
             if (to_reserve <= 0)
                 throw Error("to_reserve = %d", to_reserve);
@@ -71,8 +67,11 @@ namespace indigo
             {
                 if (_length < 1)
                 {
-                    free(_array);
-                    _array = NULL;
+                    if (_array != NULL)
+                    {
+                        free(_array);
+                        _array = NULL;
+                    }
                 }
 
                 T* oldptr = _array;
@@ -98,6 +97,7 @@ namespace indigo
             if (_length > 0)
                 memset(_array, 0xFF, _length * sizeof(T));
         }
+
         void fill(const T& value)
         {
             for (int i = 0; i < size(); i++)
@@ -144,6 +144,7 @@ namespace indigo
         {
             return _length;
         }
+
         int sizeInBytes(void) const
         {
             return _length * sizeof(T);

--- a/common/base_cpp/array.h
+++ b/common/base_cpp/array.h
@@ -37,7 +37,7 @@ namespace indigo
     public:
         DECL_TPL_ERROR(ArrayError);
 
-        Array() : _reserved(0), _length(0), _array(nullptr)
+        explicit Array() : _reserved(0), _length(0), _array(nullptr)
         {
         }
 


### PR DESCRIPTION
- Instead inefficient `Array::push()` one-by-one element, which can cause up to log2(n) reallocations, use `Array::concat`, which reallocates once and then `memcpy` array to array. 
- Some language polishing for `class Array`.
