### PR TITLE
Fixed issue #282 Clang formatting problem with macros

### DIFF
--- a/api/plugins/inchi/src/indigo_inchi_api.cpp
+++ b/api/plugins/inchi/src/indigo_inchi_api.cpp
@@ -62,58 +62,70 @@ CEXPORT int indigoInchiResetOptions(void)
     return 0;
 }
 
-CEXPORT int indigoInchiLoadMolecule(const char* inchi_string){INDIGO_BEGIN{InchiWrapper& inchi_wrapper = indigoInchiGetInstance().inchi;
-
-AutoPtr<IndigoMolecule> mol_obj(new IndigoMolecule());
-
-const char* aux_prefix = "AuxInfo";
-auto& tmp = self.getThreadTmpData();
-
-BufferScanner scanner(inchi_string);
-if (Scanner::isSingleLine(scanner))
+CEXPORT int indigoInchiLoadMolecule(const char* inchi_string)
 {
-    scanner.readLine(tmp.string, true);
-
-    if (strncmp(tmp.string.ptr(), aux_prefix, strlen(aux_prefix)) == 0)
-        inchi_wrapper.loadMoleculeFromAux(tmp.string.ptr(), mol_obj->mol);
-    else
-        inchi_wrapper.loadMoleculeFromInchi(tmp.string.ptr(), mol_obj->mol);
-}
-else
-{
-    while (!scanner.isEOF())
+    INDIGO_BEGIN
     {
-        scanner.readLine(tmp.string, true);
-        if (strncmp(tmp.string.ptr(), aux_prefix, strlen(aux_prefix)) == 0)
+        InchiWrapper& inchi_wrapper = indigoInchiGetInstance().inchi;
+
+        AutoPtr<IndigoMolecule> mol_obj(new IndigoMolecule());
+
+        const char* aux_prefix = "AuxInfo";
+        auto& tmp = self.getThreadTmpData();
+
+        BufferScanner scanner(inchi_string);
+        if (Scanner::isSingleLine(scanner))
         {
-            inchi_wrapper.loadMoleculeFromAux(tmp.string.ptr(), mol_obj->mol);
-            break;
+            scanner.readLine(tmp.string, true);
+
+            if (strncmp(tmp.string.ptr(), aux_prefix, strlen(aux_prefix)) == 0)
+                inchi_wrapper.loadMoleculeFromAux(tmp.string.ptr(), mol_obj->mol);
+            else
+                inchi_wrapper.loadMoleculeFromInchi(tmp.string.ptr(), mol_obj->mol);
         }
         else
-            inchi_wrapper.loadMoleculeFromInchi(tmp.string.ptr(), mol_obj->mol);
+        {
+            while (!scanner.isEOF())
+            {
+                scanner.readLine(tmp.string, true);
+                if (strncmp(tmp.string.ptr(), aux_prefix, strlen(aux_prefix)) == 0)
+                {
+                    inchi_wrapper.loadMoleculeFromAux(tmp.string.ptr(), mol_obj->mol);
+                    break;
+                }
+                else
+                    inchi_wrapper.loadMoleculeFromInchi(tmp.string.ptr(), mol_obj->mol);
+            }
+        }
+
+        return self.addObject(mol_obj.release());
     }
+    INDIGO_END(-1);
 }
 
-return self.addObject(mol_obj.release());
-}
-INDIGO_END(-1)
+CEXPORT const char* indigoInchiGetInchi(int molecule)
+{
+    INDIGO_BEGIN
+    {
+        InchiWrapper& inchi_wrapper = indigoInchiGetInstance().inchi;
+        IndigoObject& obj = self.getObject(molecule);
+
+        auto& tmp = self.getThreadTmpData();
+        inchi_wrapper.saveMoleculeIntoInchi(obj.getMolecule(), tmp.string);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
 
-CEXPORT const char* indigoInchiGetInchi(int molecule){INDIGO_BEGIN{InchiWrapper& inchi_wrapper = indigoInchiGetInstance().inchi;
-IndigoObject& obj = self.getObject(molecule);
-
-auto& tmp = self.getThreadTmpData();
-inchi_wrapper.saveMoleculeIntoInchi(obj.getMolecule(), tmp.string);
-return tmp.string.ptr();
-}
-INDIGO_END(0)
-}
-
-CEXPORT const char* indigoInchiGetInchiKey(const char* inchi_string){INDIGO_BEGIN{auto& tmp = self.getThreadTmpData();
-InchiWrapper::InChIKey(inchi_string, tmp.string);
-return tmp.string.ptr();
-}
-INDIGO_END(0)
+CEXPORT const char* indigoInchiGetInchiKey(const char* inchi_string)
+{
+    INDIGO_BEGIN
+    {
+        auto& tmp = self.getThreadTmpData();
+        InchiWrapper::InChIKey(inchi_string, tmp.string);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
 
 CEXPORT const char* indigoInchiGetWarning()

--- a/api/plugins/renderer/src/indigo_render2d.cpp
+++ b/api/plugins/renderer/src/indigo_render2d.cpp
@@ -368,167 +368,175 @@ void indigoRenderGetCdxmlPropertiesKeyAlignment(Array<char>& value)
         value.readString("right", true);
 }
 
-CEXPORT int indigoRender(int object, int output){INDIGO_BEGIN{RenderParams& rp = indigoRendererGetInstance().renderParams;
-// If there are molecules/reactions in the arrays then current call will
-// rendere a grid -> needs to clear it
-rp.clearArrays();
-rp.smart_layout = self.smart_layout;
-
-IndigoObject& obj = self.getObject(object);
-
-if (IndigoBaseMolecule::is(obj))
+CEXPORT int indigoRender(int object, int output)
 {
-    if (obj.getBaseMolecule().isQueryMolecule())
-        rp.mol.reset(new QueryMolecule());
-    else
-        rp.mol.reset(new Molecule());
-    rp.mol->clone_KeepIndices(self.getObject(object).getBaseMolecule());
-    rp.rmode = RENDER_MOL;
-}
-else if (IndigoBaseReaction::is(obj))
-{
-    if (obj.getBaseReaction().isQueryReaction())
-        rp.rxn.reset(new QueryReaction());
-    else
-        rp.rxn.reset(new Reaction());
-    rp.rxn->clone(self.getObject(object).getBaseReaction(), 0, 0, 0);
-    rp.rmode = RENDER_RXN;
-}
-else
-{
-    throw IndigoError("The object provided should be a molecule, a reaction or an array of such");
-}
-
-IndigoObject& out = self.getObject(output);
-if (out.type == IndigoHDCOutput::HDC_OUTPUT)
-{
-    IndigoHDCOutput& hdcOut = (IndigoHDCOutput&)self.getObject(output);
-    rp.rOpt.hdc = hdcOut.dc;
-    rp.rOpt.mode = hdcOut.prn ? MODE_PRN : MODE_HDC;
-}
-else if (out.type == IndigoObject::OUTPUT)
-{
-    rp.rOpt.output = &IndigoOutput::get(out);
-}
-else
-{
-    throw IndigoError("Invalid output object type");
-}
-RenderParamInterface::render(rp);
-return 1;
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoRenderGrid(int objects, int* refAtoms, int nColumns, int output){INDIGO_BEGIN{RenderParams& rp = indigoRendererGetInstance().renderParams;
-rp.clearArrays();
-
-PtrArray<IndigoObject>& objs = IndigoArray::cast(self.getObject(objects)).objects;
-if (rp.rOpt.cdxml_context.get() != NULL)
-{
-    RenderCdxmlContext& context = rp.rOpt.cdxml_context.ref();
-    context.property_data.clear();
-}
-if (IndigoBaseMolecule::is(*objs[0]))
-{
-    for (int i = 0; i < objs.size(); ++i)
+    INDIGO_BEGIN
     {
-        if (objs[i]->getBaseMolecule().isQueryMolecule())
-            rp.mols.add(new QueryMolecule());
-        else
-            rp.mols.add(new Molecule());
-        Array<char>& title = rp.titles.push();
-        if (objs[i]->getProperties().contains(rp.cnvOpt.titleProp.ptr()))
-            title.copy(objs[i]->getProperties().valueBuf(rp.cnvOpt.titleProp.ptr()));
+        RenderParams& rp = indigoRendererGetInstance().renderParams;
+        // If there are molecules/reactions in the arrays then current call will
+        // rendere a grid -> needs to clear it
+        rp.clearArrays();
+        rp.smart_layout = self.smart_layout;
 
-        if (rp.rOpt.mode == DINGO_MODE::MODE_CDXML)
+        IndigoObject& obj = self.getObject(object);
+
+        if (IndigoBaseMolecule::is(obj))
         {
-            if (rp.rOpt.cdxml_context.get() != NULL)
-            {
-
-                RenderCdxmlContext& context = rp.rOpt.cdxml_context.ref();
-                RenderCdxmlContext::PropertyData& data = context.property_data.push();
-
-                auto& properties = objs[i]->getProperties();
-                if (context.propertyNameCaption.size() > 0 && context.propertyValueCaption.size() > 0)
-                    if (properties.contains(context.propertyNameCaption.ptr()))
-                    {
-                        if (properties.contains(context.propertyValueCaption.ptr()))
-                        {
-                            data.propertyName.readString(properties.at(context.propertyNameCaption.ptr()), true);
-                            data.propertyValue.readString(properties.at(context.propertyValueCaption.ptr()), true);
-                        }
-                    }
-            }
+            if (obj.getBaseMolecule().isQueryMolecule())
+                rp.mol.reset(new QueryMolecule());
+            else
+                rp.mol.reset(new Molecule());
+            rp.mol->clone_KeepIndices(self.getObject(object).getBaseMolecule());
+            rp.rmode = RENDER_MOL;
+        }
+        else if (IndigoBaseReaction::is(obj))
+        {
+            if (obj.getBaseReaction().isQueryReaction())
+                rp.rxn.reset(new QueryReaction());
+            else
+                rp.rxn.reset(new Reaction());
+            rp.rxn->clone(self.getObject(object).getBaseReaction(), 0, 0, 0);
+            rp.rmode = RENDER_RXN;
+        }
+        else
+        {
+            throw IndigoError("The object provided should be a molecule, a reaction or an array of such");
         }
 
-        rp.mols.top()->clone_KeepIndices(objs[i]->getBaseMolecule());
-        rp.rmode = RENDER_MOL;
-    }
-}
-else if (IndigoBaseReaction::is(*objs[0]))
-{
-    for (int i = 0; i < objs.size(); ++i)
-    {
-        if (objs[i]->getBaseReaction().isQueryReaction())
-            rp.rxns.add(new QueryReaction());
+        IndigoObject& out = self.getObject(output);
+        if (out.type == IndigoHDCOutput::HDC_OUTPUT)
+        {
+            IndigoHDCOutput& hdcOut = (IndigoHDCOutput&)self.getObject(output);
+            rp.rOpt.hdc = hdcOut.dc;
+            rp.rOpt.mode = hdcOut.prn ? MODE_PRN : MODE_HDC;
+        }
+        else if (out.type == IndigoObject::OUTPUT)
+        {
+            rp.rOpt.output = &IndigoOutput::get(out);
+        }
         else
-            rp.rxns.add(new Reaction());
-        Array<char>& title = rp.titles.push();
-        if (objs[i]->getProperties().contains(rp.cnvOpt.titleProp.ptr()))
-            title.copy(objs[i]->getProperties().valueBuf(rp.cnvOpt.titleProp.ptr()));
-
-        rp.rxns.top()->clone(objs[i]->getBaseReaction(), 0, 0, 0);
-        rp.rmode = RENDER_RXN;
+        {
+            throw IndigoError("Invalid output object type");
+        }
+        RenderParamInterface::render(rp);
+        return 1;
     }
-}
-else
-{
-    throw IndigoError("The array elements should be molecules or reactions");
+    INDIGO_END(-1);
 }
 
-if (refAtoms != NULL)
+CEXPORT int indigoRenderGrid(int objects, int* refAtoms, int nColumns, int output)
 {
-    rp.refAtoms.copy(refAtoms, objs.size());
-}
-
-rp.cnvOpt.gridColumnNumber = nColumns;
-
-bool hasNonemptyTitles = false;
-for (int i = 0; i < rp.titles.size(); ++i)
-{
-    if (rp.titles[i].size() > 0)
+    INDIGO_BEGIN
     {
-        hasNonemptyTitles = true;
-        break;
+        RenderParams& rp = indigoRendererGetInstance().renderParams;
+        rp.clearArrays();
+
+        PtrArray<IndigoObject>& objs = IndigoArray::cast(self.getObject(objects)).objects;
+        if (rp.rOpt.cdxml_context.get() != NULL)
+        {
+            RenderCdxmlContext& context = rp.rOpt.cdxml_context.ref();
+            context.property_data.clear();
+        }
+        if (IndigoBaseMolecule::is(*objs[0]))
+        {
+            for (int i = 0; i < objs.size(); ++i)
+            {
+                if (objs[i]->getBaseMolecule().isQueryMolecule())
+                    rp.mols.add(new QueryMolecule());
+                else
+                    rp.mols.add(new Molecule());
+                Array<char>& title = rp.titles.push();
+                if (objs[i]->getProperties().contains(rp.cnvOpt.titleProp.ptr()))
+                    title.copy(objs[i]->getProperties().valueBuf(rp.cnvOpt.titleProp.ptr()));
+
+                if (rp.rOpt.mode == DINGO_MODE::MODE_CDXML)
+                {
+                    if (rp.rOpt.cdxml_context.get() != NULL)
+                    {
+
+                        RenderCdxmlContext& context = rp.rOpt.cdxml_context.ref();
+                        RenderCdxmlContext::PropertyData& data = context.property_data.push();
+
+                        auto& properties = objs[i]->getProperties();
+                        if (context.propertyNameCaption.size() > 0 && context.propertyValueCaption.size() > 0)
+                            if (properties.contains(context.propertyNameCaption.ptr()))
+                            {
+                                if (properties.contains(context.propertyValueCaption.ptr()))
+                                {
+                                    data.propertyName.readString(properties.at(context.propertyNameCaption.ptr()), true);
+                                    data.propertyValue.readString(properties.at(context.propertyValueCaption.ptr()), true);
+                                }
+                            }
+                    }
+                }
+
+                rp.mols.top()->clone_KeepIndices(objs[i]->getBaseMolecule());
+                rp.rmode = RENDER_MOL;
+            }
+        }
+        else if (IndigoBaseReaction::is(*objs[0]))
+        {
+            for (int i = 0; i < objs.size(); ++i)
+            {
+                if (objs[i]->getBaseReaction().isQueryReaction())
+                    rp.rxns.add(new QueryReaction());
+                else
+                    rp.rxns.add(new Reaction());
+                Array<char>& title = rp.titles.push();
+                if (objs[i]->getProperties().contains(rp.cnvOpt.titleProp.ptr()))
+                    title.copy(objs[i]->getProperties().valueBuf(rp.cnvOpt.titleProp.ptr()));
+
+                rp.rxns.top()->clone(objs[i]->getBaseReaction(), 0, 0, 0);
+                rp.rmode = RENDER_RXN;
+            }
+        }
+        else
+        {
+            throw IndigoError("The array elements should be molecules or reactions");
+        }
+
+        if (refAtoms != NULL)
+        {
+            rp.refAtoms.copy(refAtoms, objs.size());
+        }
+
+        rp.cnvOpt.gridColumnNumber = nColumns;
+
+        bool hasNonemptyTitles = false;
+        for (int i = 0; i < rp.titles.size(); ++i)
+        {
+            if (rp.titles[i].size() > 0)
+            {
+                hasNonemptyTitles = true;
+                break;
+            }
+        }
+        if (!hasNonemptyTitles)
+            rp.titles.clear();
+
+        IndigoObject& out = self.getObject(output);
+        if (out.type == IndigoHDCOutput::HDC_OUTPUT)
+        {
+            IndigoHDCOutput& hdcOut = (IndigoHDCOutput&)self.getObject(output);
+            rp.rOpt.hdc = hdcOut.dc;
+            rp.rOpt.mode = hdcOut.prn ? MODE_PRN : MODE_HDC;
+        }
+        else if (out.type == IndigoObject::OUTPUT)
+        {
+            rp.rOpt.output = &IndigoOutput::get(out);
+        }
+        else
+        {
+            throw IndigoError("Invalid output object type");
+        }
+        RenderParamInterface::render(rp);
+
+        // Release memory for arrays with molecules/reactions
+        rp.clearArrays();
+
+        return 1;
     }
-}
-if (!hasNonemptyTitles)
-    rp.titles.clear();
-
-IndigoObject& out = self.getObject(output);
-if (out.type == IndigoHDCOutput::HDC_OUTPUT)
-{
-    IndigoHDCOutput& hdcOut = (IndigoHDCOutput&)self.getObject(output);
-    rp.rOpt.hdc = hdcOut.dc;
-    rp.rOpt.mode = hdcOut.prn ? MODE_PRN : MODE_HDC;
-}
-else if (out.type == IndigoObject::OUTPUT)
-{
-    rp.rOpt.output = &IndigoOutput::get(out);
-}
-else
-{
-    throw IndigoError("Invalid output object type");
-}
-RenderParamInterface::render(rp);
-
-// Release memory for arrays with molecules/reactions
-rp.clearArrays();
-
-return 1;
-}
-INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 DINGO_MODE indigoRenderGuessOutputFormat(const char* filename)
@@ -574,11 +582,15 @@ CEXPORT int indigoRenderGridToFile(int objects, int* refAtoms, int nColumns, con
     return res;
 }
 
-CEXPORT int indigoRenderReset(){INDIGO_BEGIN{IndigoRenderer& rp = indigoRendererGetInstance();
-rp.init();
-return 1;
-}
-INDIGO_END(-1)
+CEXPORT int indigoRenderReset()
+{
+    INDIGO_BEGIN
+    {
+        IndigoRenderer& rp = indigoRendererGetInstance();
+        rp.init();
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT void indigoRenderResetOptions()
@@ -593,7 +605,7 @@ CEXPORT int indigoRenderWriteHDC(void* hdc, int printingHdc)
     {
         return self.addObject(new IndigoHDCOutput(hdc, printingHdc != 0));
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 class _IndigoRenderingOptionsHandlersSetter

--- a/api/src/indigo_abbreviations_expand.cpp
+++ b/api/src/indigo_abbreviations_expand.cpp
@@ -845,7 +845,7 @@ namespace indigo
 
                 return count;
             }
-            INDIGO_END(-1)
+            INDIGO_END(-1);
         }
 
     } // namespace abbreviations

--- a/api/src/indigo_calc.cpp
+++ b/api/src/indigo_calc.cpp
@@ -59,7 +59,7 @@ CEXPORT int indigoGrossFormula(int object)
             throw IndigoError("incorrect object type for gross formula: %s", indigoObject.debugInfo());
         }
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 static BaseMolecule& _indigoPrepareMass(IndigoObject& obj, MoleculeMass mass)
@@ -79,28 +79,40 @@ static BaseMolecule& _indigoPrepareMass(IndigoObject& obj, MoleculeMass mass)
     }
 }
 
-CEXPORT double indigoMolecularWeight(int molecule){INDIGO_BEGIN{MoleculeMass mass;
-auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
-mass.mass_options = self.mass_options;
-return mass.molecularWeight(mol.asMolecule());
-}
-INDIGO_END(-1)
-}
-
-CEXPORT double indigoMostAbundantMass(int molecule){INDIGO_BEGIN{MoleculeMass mass;
-auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
-mass.mass_options = self.mass_options;
-return mass.mostAbundantMass(mol.asMolecule());
-}
-INDIGO_END(-1)
+CEXPORT double indigoMolecularWeight(int molecule)
+{
+    INDIGO_BEGIN
+    {
+        MoleculeMass mass;
+        auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
+        mass.mass_options = self.mass_options;
+        return mass.molecularWeight(mol.asMolecule());
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT double indigoMonoisotopicMass(int molecule){INDIGO_BEGIN{MoleculeMass mass;
-auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
-mass.mass_options = self.mass_options;
-return mass.monoisotopicMass(mol.asMolecule());
+CEXPORT double indigoMostAbundantMass(int molecule)
+{
+    INDIGO_BEGIN
+    {
+        MoleculeMass mass;
+        auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
+        mass.mass_options = self.mass_options;
+        return mass.mostAbundantMass(mol.asMolecule());
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(-1)
+
+CEXPORT double indigoMonoisotopicMass(int molecule)
+{
+    INDIGO_BEGIN
+    {
+        MoleculeMass mass;
+        auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
+        mass.mass_options = self.mass_options;
+        return mass.monoisotopicMass(mol.asMolecule());
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT const char* indigoMassComposition(int molecule)
@@ -116,5 +128,5 @@ CEXPORT const char* indigoMassComposition(int molecule)
 
         return tmp.string.ptr();
     }
-    INDIGO_END(0)
+    INDIGO_END(0);
 }

--- a/api/src/indigo_io.cpp
+++ b/api/src/indigo_io.cpp
@@ -86,9 +86,13 @@ Output& IndigoOutput::get(IndigoObject& obj)
     throw IndigoError("%s is not an output", obj.debugInfo());
 }
 
-CEXPORT int indigoReadFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoScanner(new FileScanner(self.filename_encoding, filename)));
-}
-INDIGO_END(-1)
+CEXPORT int indigoReadFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoScanner(new FileScanner(self.filename_encoding, filename)));
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoReadString(const char* str)
@@ -100,48 +104,72 @@ CEXPORT int indigoReadString(const char* str)
     INDIGO_END(-1);
 }
 
-CEXPORT int indigoReadBuffer(const char* buffer, int size){INDIGO_BEGIN{return self.addObject(new IndigoScanner(new BufferScanner(buffer, size)));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoLoadString(const char* str){INDIGO_BEGIN{return self.addObject(new IndigoScanner(str));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoLoadBuffer(const char* buffer, int size){INDIGO_BEGIN{return self.addObject(new IndigoScanner(buffer, size));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoWriteFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoOutput(new FileOutput(filename)));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoClose(int output){INDIGO_BEGIN{IndigoObject& obj = self.getObject(output);
-if (obj.type == IndigoObject::OUTPUT)
+CEXPORT int indigoReadBuffer(const char* buffer, int size)
 {
-    IndigoOutput& out = ((IndigoOutput&)obj);
-    out.ptr.reset(nullptr);
-    return 1;
-}
-else if (obj.type == IndigoObject::SAVER)
-{
-    IndigoSaver& saver = ((IndigoSaver&)obj);
-    saver.close();
-    return 1;
-}
-else
-    throw IndigoError("indigoClose(): does not accept %s", obj.debugInfo());
-}
-INDIGO_END(-1)
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoScanner(new BufferScanner(buffer, size)));
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoWriteBuffer(void){INDIGO_BEGIN{return self.addObject(new IndigoOutput());
+CEXPORT int indigoLoadString(const char* str)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoScanner(str));
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(-1)
+
+CEXPORT int indigoLoadBuffer(const char* buffer, int size)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoScanner(buffer, size));
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoWriteFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoOutput(new FileOutput(filename)));
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoClose(int output)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(output);
+        if (obj.type == IndigoObject::OUTPUT)
+        {
+            IndigoOutput& out = ((IndigoOutput&)obj);
+            out.ptr.reset(nullptr);
+            return 1;
+        }
+        else if (obj.type == IndigoObject::SAVER)
+        {
+            IndigoSaver& saver = ((IndigoSaver&)obj);
+            saver.close();
+            return 1;
+        }
+        else
+            throw IndigoError("indigoClose(): does not accept %s", obj.debugInfo());
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoWriteBuffer(void)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoOutput());
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT const char* indigoToString(int handle)

--- a/api/src/indigo_layout.cpp
+++ b/api/src/indigo_layout.cpp
@@ -27,95 +27,99 @@
 #include <algorithm>
 #include <vector>
 
-CEXPORT int indigoLayout(int object){INDIGO_BEGIN{IndigoObject& obj = self.getObject(object);
-int i;
-
-if (IndigoBaseMolecule::is(obj))
+CEXPORT int indigoLayout(int object)
 {
-    BaseMolecule* mol = &obj.getBaseMolecule();
-    Filter f;
-    if (obj.type == IndigoObject::SUBMOLECULE)
+    INDIGO_BEGIN
     {
-        IndigoSubmolecule& submol = (IndigoSubmolecule&)obj;
-        mol = &submol.getOriginalMolecule();
-        f.initNone(mol->vertexEnd());
-        for (int i = 0; i < submol.vertices.size(); i++)
+        IndigoObject& obj = self.getObject(object);
+        int i;
+
+        if (IndigoBaseMolecule::is(obj))
         {
-            f.unhide(submol.vertices[i]);
-        }
-    }
-    MoleculeLayout ml(*mol, self.smart_layout);
-
-    if (obj.type == IndigoObject::SUBMOLECULE)
-    {
-        ml.filter = &f;
-    }
-
-    ml.max_iterations = self.layout_max_iterations;
-    ml.bond_length = 1.6f;
-    ml.layout_orientation = (layout_orientation_value)self.layout_orientation;
-
-    TimeoutCancellationHandler cancellation(self.cancellation_timeout);
-    ml.setCancellationHandler(&cancellation);
-
-    ml.make();
-
-    if (obj.type != IndigoObject::SUBMOLECULE)
-    {
-        // Not for submolecule yet
-        mol->clearBondDirections();
-        try
-        {
-            mol->stereocenters.markBonds();
-            mol->allene_stereo.markBonds();
-        }
-        catch (Exception e)
-        {
-        }
-        for (i = 1; i <= mol->rgroups.getRGroupCount(); i++)
-        {
-            RGroup& rgp = mol->rgroups.getRGroup(i);
-
-            for (int j = rgp.fragments.begin(); j != rgp.fragments.end(); j = rgp.fragments.next(j))
+            BaseMolecule* mol = &obj.getBaseMolecule();
+            Filter f;
+            if (obj.type == IndigoObject::SUBMOLECULE)
             {
-                rgp.fragments[j]->clearBondDirections();
+                IndigoSubmolecule& submol = (IndigoSubmolecule&)obj;
+                mol = &submol.getOriginalMolecule();
+                f.initNone(mol->vertexEnd());
+                for (int i = 0; i < submol.vertices.size(); i++)
+                {
+                    f.unhide(submol.vertices[i]);
+                }
+            }
+            MoleculeLayout ml(*mol, self.smart_layout);
+
+            if (obj.type == IndigoObject::SUBMOLECULE)
+            {
+                ml.filter = &f;
+            }
+
+            ml.max_iterations = self.layout_max_iterations;
+            ml.bond_length = 1.6f;
+            ml.layout_orientation = (layout_orientation_value)self.layout_orientation;
+
+            TimeoutCancellationHandler cancellation(self.cancellation_timeout);
+            ml.setCancellationHandler(&cancellation);
+
+            ml.make();
+
+            if (obj.type != IndigoObject::SUBMOLECULE)
+            {
+                // Not for submolecule yet
+                mol->clearBondDirections();
                 try
                 {
-                    rgp.fragments[j]->stereocenters.markBonds();
-                    rgp.fragments[j]->allene_stereo.markBonds();
+                    mol->stereocenters.markBonds();
+                    mol->allene_stereo.markBonds();
                 }
                 catch (Exception e)
                 {
                 }
+                for (i = 1; i <= mol->rgroups.getRGroupCount(); i++)
+                {
+                    RGroup& rgp = mol->rgroups.getRGroup(i);
+
+                    for (int j = rgp.fragments.begin(); j != rgp.fragments.end(); j = rgp.fragments.next(j))
+                    {
+                        rgp.fragments[j]->clearBondDirections();
+                        try
+                        {
+                            rgp.fragments[j]->stereocenters.markBonds();
+                            rgp.fragments[j]->allene_stereo.markBonds();
+                        }
+                        catch (Exception e)
+                        {
+                        }
+                    }
+                }
             }
         }
-    }
-}
-else if (IndigoBaseReaction::is(obj))
-{
-    BaseReaction& rxn = obj.getBaseReaction();
-    ReactionLayout rl(rxn, self.smart_layout);
-    rl.max_iterations = self.layout_max_iterations;
-    rl.layout_orientation = (layout_orientation_value)self.layout_orientation;
-    rl.bond_length = 1.6f;
-    rl.horizontal_interval_factor = self.layout_horintervalfactor;
+        else if (IndigoBaseReaction::is(obj))
+        {
+            BaseReaction& rxn = obj.getBaseReaction();
+            ReactionLayout rl(rxn, self.smart_layout);
+            rl.max_iterations = self.layout_max_iterations;
+            rl.layout_orientation = (layout_orientation_value)self.layout_orientation;
+            rl.bond_length = 1.6f;
+            rl.horizontal_interval_factor = self.layout_horintervalfactor;
 
-    rl.make();
-    try
-    {
-        rxn.markStereocenterBonds();
+            rl.make();
+            try
+            {
+                rxn.markStereocenterBonds();
+            }
+            catch (Exception e)
+            {
+            }
+        }
+        else
+        {
+            throw IndigoError("The object provided is neither a molecule, nor a reaction");
+        }
+        return 0;
     }
-    catch (Exception e)
-    {
-    }
-}
-else
-{
-    throw IndigoError("The object provided is neither a molecule, nor a reaction");
-}
-return 0;
-}
-INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoClean2d(int object)
@@ -177,5 +181,5 @@ CEXPORT int indigoClean2d(int object)
 
         return 0;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }

--- a/api/src/indigo_loaders.cpp
+++ b/api/src/indigo_loaders.cpp
@@ -469,106 +469,138 @@ IndigoObject* IndigoMultilineSmilesLoader::at(int index)
     return next();
 }
 
-CEXPORT int indigoIterateSDF(int reader){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reader);
+CEXPORT int indigoIterateSDF(int reader)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reader);
 
-return self.addObject(new IndigoSdfLoader(IndigoScanner::get(obj)));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoIterateRDF(int reader){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reader);
-
-return self.addObject(new IndigoRdfLoader(IndigoScanner::get(obj)));
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoSdfLoader(IndigoScanner::get(obj)));
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoIterateSmiles(int reader){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reader);
+CEXPORT int indigoIterateRDF(int reader)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reader);
 
-return self.addObject(new IndigoMultilineSmilesLoader(IndigoScanner::get(obj)));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoTell(int handle){INDIGO_BEGIN{IndigoObject& obj = self.getObject(handle);
-long long size = 0LL;
-
-const int max_int = std::numeric_limits<int>::max();
-
-if (obj.type == IndigoObject::SDF_LOADER)
-    size = ((IndigoSdfLoader&)obj).tell();
-else if (obj.type == IndigoObject::RDF_LOADER)
-    size = ((IndigoRdfLoader&)obj).tell();
-else if (obj.type == IndigoObject::MULTILINE_SMILES_LOADER)
-    size = ((IndigoMultilineSmilesLoader&)obj).tell();
-else if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
-         obj.type == IndigoObject::SMILES_REACTION)
-    size = ((IndigoRdfData&)obj).tell();
-else if (obj.type == IndigoObject::MULTIPLE_CML_LOADER)
-    size = ((IndigoMultipleCmlLoader&)obj).tell();
-else if (obj.type == IndigoObject::CML_MOLECULE)
-    size = ((IndigoCmlMolecule&)obj).tell();
-else if (obj.type == IndigoObject::CML_REACTION)
-    size = ((IndigoCmlReaction&)obj).tell();
-else if (obj.type == IndigoObject::MULTIPLE_CDX_LOADER)
-    size = ((IndigoMultipleCdxLoader&)obj).tell();
-else if (obj.type == IndigoObject::CDX_MOLECULE)
-    size = ((IndigoCdxMolecule&)obj).tell();
-else if (obj.type == IndigoObject::CDX_REACTION)
-    size = ((IndigoCdxReaction&)obj).tell();
-else
-    throw IndigoError("indigoTell(): not applicable to %s", obj.debugInfo());
-
-if (size > max_int)
-    throw IndigoError("indigoTell(): file size exceeds %d bytes. Please use indigoTell64() instead", max_int);
-else
-    return static_cast<int>(size);
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoRdfLoader(IndigoScanner::get(obj)));
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT long long indigoTell64(int handle){INDIGO_BEGIN{IndigoObject& obj = self.getObject(handle);
+CEXPORT int indigoIterateSmiles(int reader)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reader);
 
-if (obj.type == IndigoObject::SDF_LOADER)
-    return ((IndigoSdfLoader&)obj).tell();
-if (obj.type == IndigoObject::RDF_LOADER)
-    return ((IndigoRdfLoader&)obj).tell();
-if (obj.type == IndigoObject::MULTILINE_SMILES_LOADER)
-    return ((IndigoMultilineSmilesLoader&)obj).tell();
-if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
-    obj.type == IndigoObject::SMILES_REACTION)
-    return ((IndigoRdfData&)obj).tell();
-if (obj.type == IndigoObject::MULTIPLE_CML_LOADER)
-    return ((IndigoMultipleCmlLoader&)obj).tell();
-if (obj.type == IndigoObject::CML_MOLECULE)
-    return ((IndigoCmlMolecule&)obj).tell();
-if (obj.type == IndigoObject::CML_REACTION)
-    return ((IndigoCmlReaction&)obj).tell();
-if (obj.type == IndigoObject::MULTIPLE_CDX_LOADER)
-    return ((IndigoMultipleCdxLoader&)obj).tell();
-if (obj.type == IndigoObject::CDX_MOLECULE)
-    return ((IndigoCdxMolecule&)obj).tell();
-if (obj.type == IndigoObject::CDX_REACTION)
-    return ((IndigoCdxReaction&)obj).tell();
-
-throw IndigoError("indigoTell64(): not applicable to %s", obj.debugInfo());
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoMultilineSmilesLoader(IndigoScanner::get(obj)));
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoIterateSDFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoSdfLoader(filename));
-}
-INDIGO_END(-1)
+CEXPORT int indigoTell(int handle)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(handle);
+        long long size = 0LL;
+
+        const int max_int = std::numeric_limits<int>::max();
+
+        if (obj.type == IndigoObject::SDF_LOADER)
+            size = ((IndigoSdfLoader&)obj).tell();
+        else if (obj.type == IndigoObject::RDF_LOADER)
+            size = ((IndigoRdfLoader&)obj).tell();
+        else if (obj.type == IndigoObject::MULTILINE_SMILES_LOADER)
+            size = ((IndigoMultilineSmilesLoader&)obj).tell();
+        else if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
+                 obj.type == IndigoObject::SMILES_REACTION)
+            size = ((IndigoRdfData&)obj).tell();
+        else if (obj.type == IndigoObject::MULTIPLE_CML_LOADER)
+            size = ((IndigoMultipleCmlLoader&)obj).tell();
+        else if (obj.type == IndigoObject::CML_MOLECULE)
+            size = ((IndigoCmlMolecule&)obj).tell();
+        else if (obj.type == IndigoObject::CML_REACTION)
+            size = ((IndigoCmlReaction&)obj).tell();
+        else if (obj.type == IndigoObject::MULTIPLE_CDX_LOADER)
+            size = ((IndigoMultipleCdxLoader&)obj).tell();
+        else if (obj.type == IndigoObject::CDX_MOLECULE)
+            size = ((IndigoCdxMolecule&)obj).tell();
+        else if (obj.type == IndigoObject::CDX_REACTION)
+            size = ((IndigoCdxReaction&)obj).tell();
+        else
+            throw IndigoError("indigoTell(): not applicable to %s", obj.debugInfo());
+
+        if (size > max_int)
+            throw IndigoError("indigoTell(): file size exceeds %d bytes. Please use indigoTell64() instead", max_int);
+        else
+            return static_cast<int>(size);
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoIterateRDFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoRdfLoader(filename));
-}
-INDIGO_END(-1)
+CEXPORT long long indigoTell64(int handle)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(handle);
+
+        if (obj.type == IndigoObject::SDF_LOADER)
+            return ((IndigoSdfLoader&)obj).tell();
+        if (obj.type == IndigoObject::RDF_LOADER)
+            return ((IndigoRdfLoader&)obj).tell();
+        if (obj.type == IndigoObject::MULTILINE_SMILES_LOADER)
+            return ((IndigoMultilineSmilesLoader&)obj).tell();
+        if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
+            obj.type == IndigoObject::SMILES_REACTION)
+            return ((IndigoRdfData&)obj).tell();
+        if (obj.type == IndigoObject::MULTIPLE_CML_LOADER)
+            return ((IndigoMultipleCmlLoader&)obj).tell();
+        if (obj.type == IndigoObject::CML_MOLECULE)
+            return ((IndigoCmlMolecule&)obj).tell();
+        if (obj.type == IndigoObject::CML_REACTION)
+            return ((IndigoCmlReaction&)obj).tell();
+        if (obj.type == IndigoObject::MULTIPLE_CDX_LOADER)
+            return ((IndigoMultipleCdxLoader&)obj).tell();
+        if (obj.type == IndigoObject::CDX_MOLECULE)
+            return ((IndigoCdxMolecule&)obj).tell();
+        if (obj.type == IndigoObject::CDX_REACTION)
+            return ((IndigoCdxReaction&)obj).tell();
+
+        throw IndigoError("indigoTell64(): not applicable to %s", obj.debugInfo());
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoIterateSmilesFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoMultilineSmilesLoader(filename));
+CEXPORT int indigoIterateSDFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoSdfLoader(filename));
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(-1)
+
+CEXPORT int indigoIterateRDFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoRdfLoader(filename));
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoIterateSmilesFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoMultilineSmilesLoader(filename));
+    }
+    INDIGO_END(-1);
 }
 
 IndigoCmlMolecule::IndigoCmlMolecule(Array<char>& data, int index, long long offset) : IndigoRdfData(CML_MOLECULE, data, index, offset)
@@ -701,16 +733,24 @@ IndigoObject* IndigoMultipleCmlLoader::next()
         return new IndigoCmlMolecule(loader->data, counter, offset);
 }
 
-CEXPORT int indigoIterateCML(int reader){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reader);
+CEXPORT int indigoIterateCML(int reader)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reader);
 
-return self.addObject(new IndigoMultipleCmlLoader(IndigoScanner::get(obj)));
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoMultipleCmlLoader(IndigoScanner::get(obj)));
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoIterateCMLFile(const char* filename){INDIGO_BEGIN{return self.addObject(new IndigoMultipleCmlLoader(filename));
-}
-INDIGO_END(-1)
+CEXPORT int indigoIterateCMLFile(const char* filename)
+{
+    INDIGO_BEGIN
+    {
+        return self.addObject(new IndigoMultipleCmlLoader(filename));
+    }
+    INDIGO_END(-1);
 }
 
 IndigoCdxMolecule::IndigoCdxMolecule(Array<char>& data, PropertiesMap& properties, int index, long long offset)
@@ -855,11 +895,15 @@ IndigoObject* IndigoMultipleCdxLoader::at(int index)
         return new IndigoCdxMolecule(loader->data, loader->properties, index, 0);
 }
 
-CEXPORT int indigoIterateCDX(int reader){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reader);
+CEXPORT int indigoIterateCDX(int reader)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reader);
 
-return self.addObject(new IndigoMultipleCdxLoader(IndigoScanner::get(obj)));
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoMultipleCdxLoader(IndigoScanner::get(obj)));
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoIterateCDXFile(const char* filename)
@@ -868,5 +912,5 @@ CEXPORT int indigoIterateCDXFile(const char* filename)
     {
         return self.addObject(new IndigoMultipleCdxLoader(filename));
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }

--- a/api/src/indigo_mapping.cpp
+++ b/api/src/indigo_mapping.cpp
@@ -62,43 +62,47 @@ IndigoObject* IndigoReactionMapping::clone()
     return res_ptr.release();
 }
 
-CEXPORT int indigoMapAtom(int handle, int atom){INDIGO_BEGIN{IndigoObject& obj = self.getObject(handle);
-IndigoAtom& ia = IndigoAtom::cast(self.getObject(atom));
-
-if (obj.type == IndigoObject::MAPPING)
+CEXPORT int indigoMapAtom(int handle, int atom)
 {
-    IndigoMapping& mapping = (IndigoMapping&)obj;
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(handle);
+        IndigoAtom& ia = IndigoAtom::cast(self.getObject(atom));
 
-    int mapped = mapping.mapping[ia.idx];
-    if (mapped < 0)
-        return 0;
-    return self.addObject(new IndigoAtom(mapping.to, mapped));
-}
-if (obj.type == IndigoObject::REACTION_MAPPING)
-{
-    IndigoReactionMapping& mapping = (IndigoReactionMapping&)obj;
+        if (obj.type == IndigoObject::MAPPING)
+        {
+            IndigoMapping& mapping = (IndigoMapping&)obj;
 
-    int mol_idx = mapping.from.findMolecule(&ia.mol);
+            int mapped = mapping.mapping[ia.idx];
+            if (mapped < 0)
+                return 0;
+            return self.addObject(new IndigoAtom(mapping.to, mapped));
+        }
+        if (obj.type == IndigoObject::REACTION_MAPPING)
+        {
+            IndigoReactionMapping& mapping = (IndigoReactionMapping&)obj;
 
-    if (mol_idx == -1)
-        throw IndigoError("indigoMapAtom(): input atom not found in the reaction");
+            int mol_idx = mapping.from.findMolecule(&ia.mol);
 
-    if (mapping.mol_mapping[mol_idx] < 0)
-        // can happen for catalysts
-        return 0;
+            if (mol_idx == -1)
+                throw IndigoError("indigoMapAtom(): input atom not found in the reaction");
 
-    BaseMolecule& mol = mapping.to.getBaseMolecule(mapping.mol_mapping[mol_idx]);
-    int idx = mapping.mappings[mol_idx][ia.idx];
+            if (mapping.mol_mapping[mol_idx] < 0)
+                // can happen for catalysts
+                return 0;
 
-    if (idx < 0)
-        return 0;
+            BaseMolecule& mol = mapping.to.getBaseMolecule(mapping.mol_mapping[mol_idx]);
+            int idx = mapping.mappings[mol_idx][ia.idx];
 
-    return self.addObject(new IndigoAtom(mol, idx));
-}
+            if (idx < 0)
+                return 0;
 
-throw IndigoError("indigoMapAtom(): not applicable to %s", obj.debugInfo());
-}
-INDIGO_END(-1)
+            return self.addObject(new IndigoAtom(mol, idx));
+        }
+
+        throw IndigoError("indigoMapAtom(): not applicable to %s", obj.debugInfo());
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoMapBond(int handle, int bond)
@@ -158,7 +162,7 @@ CEXPORT int indigoMapBond(int handle, int bond)
 
         throw IndigoError("indigoMapBond(): not applicable to %s", obj.debugInfo());
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 void _indigoHighlightSubstructure(BaseMolecule& query, BaseMolecule& mol, Array<int>& qmapping, Array<int>& mapping)
@@ -225,5 +229,5 @@ CEXPORT int indigoHighlightedTarget(int item)
 
         throw IndigoError("indigoHighlightedTarget(): no idea what to do with %s", obj.debugInfo());
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }

--- a/api/src/indigo_misc.cpp
+++ b/api/src/indigo_misc.cpp
@@ -49,15 +49,19 @@
     if (__min3(r, g, b) < 0 || __max3(r, g, b) > 1.0 + 1e-6)                                                                                                   \
     throw IndigoError("Some of the color components are out of range [0..1]")
 
-CEXPORT int indigoAromatize(int object){INDIGO_BEGIN{IndigoObject& obj = self.getObject(object);
+CEXPORT int indigoAromatize(int object)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(object);
 
-if (IndigoBaseMolecule::is(obj))
-    return obj.getBaseMolecule().aromatize(self.arom_options) ? 1 : 0;
-if (IndigoBaseReaction::is(obj))
-    return obj.getBaseReaction().aromatize(self.arom_options) ? 1 : 0;
-throw IndigoError("Only molecules and reactions can be aromatized");
-}
-INDIGO_END(-1)
+        if (IndigoBaseMolecule::is(obj))
+            return obj.getBaseMolecule().aromatize(self.arom_options) ? 1 : 0;
+        if (IndigoBaseReaction::is(obj))
+            return obj.getBaseReaction().aromatize(self.arom_options) ? 1 : 0;
+        throw IndigoError("Only molecules and reactions can be aromatized");
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoDearomatize(int object)
@@ -75,7 +79,7 @@ CEXPORT int indigoDearomatize(int object)
             return obj.getBaseReaction().dearomatize(arom_options) ? 1 : 0;
         throw IndigoError("Only molecules and reactions can be dearomatized");
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 #define INDIGO_SET_OPTION(SUFFIX, TYPE)                                                                                                                        \
@@ -86,7 +90,7 @@ CEXPORT int indigoDearomatize(int object)
             indigoGetOptionManager().callOptionHandler##SUFFIX(name, value);                                                                                   \
             return 1;                                                                                                                                          \
         }                                                                                                                                                      \
-        INDIGO_END(-1)                                                                                                                                         \
+        INDIGO_END(-1);                                                                                                                                        \
     }
 
 INDIGO_SET_OPTION(, const char*)
@@ -94,65 +98,110 @@ INDIGO_SET_OPTION(Int, int)
 INDIGO_SET_OPTION(Bool, int)
 INDIGO_SET_OPTION(Float, float)
 
-CEXPORT int indigoSetOptionColor(const char* name, float r, float g, float b){INDIGO_BEGIN{indigoGetOptionManager().callOptionHandlerColor(name, r, g, b);
-return 1;
+CEXPORT int indigoSetOptionColor(const char* name, float r, float g, float b)
+{
+    INDIGO_BEGIN
+    {
+        indigoGetOptionManager().callOptionHandlerColor(name, r, g, b);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(-1)
-}
-CEXPORT int indigoSetOptionXY(const char* name, int x, int y){INDIGO_BEGIN{indigoGetOptionManager().callOptionHandlerXY(name, x, y);
-return 1;
-}
-INDIGO_END(-1)
-}
-
-CEXPORT const char* indigoGetOption(const char* name){INDIGO_BEGIN{auto& tmp = self.getThreadTmpData();
-indigoGetOptionManager().getOptionValueStr(name, tmp.string);
-return tmp.string.ptr();
-}
-INDIGO_END(0)
-}
-
-CEXPORT int indigoGetOptionInt(const char* name, int* value){INDIGO_BEGIN{if (value){indigoGetOptionManager().getOptionValueInt(name, *value);
-return 1;
-}
-}
-INDIGO_END(-1)
+CEXPORT int indigoSetOptionXY(const char* name, int x, int y)
+{
+    INDIGO_BEGIN
+    {
+        indigoGetOptionManager().callOptionHandlerXY(name, x, y);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoGetOptionBool(const char* name, int* value){INDIGO_BEGIN{if (value){indigoGetOptionManager().getOptionValueBool(name, *value);
-return 1;
-}
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoGetOptionFloat(const char* name, float* value){INDIGO_BEGIN{if (value){indigoGetOptionManager().getOptionValueFloat(name, *value);
-return 1;
-}
-}
-INDIGO_END(-1)
+CEXPORT const char* indigoGetOption(const char* name)
+{
+    INDIGO_BEGIN
+    {
+        auto& tmp = self.getThreadTmpData();
+        indigoGetOptionManager().getOptionValueStr(name, tmp.string);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
 
-CEXPORT int indigoGetOptionColor(const char* name, float* r, float* g,
-                                 float* b){INDIGO_BEGIN{if (r && g && b){indigoGetOptionManager().getOptionValueColor(name, *r, *g, *b);
-return 1;
-}
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoGetOptionXY(const char* name, int* x, int* y){INDIGO_BEGIN{if (x && y){indigoGetOptionManager().getOptionValueXY(name, *x, *y);
-return 1;
-}
-}
-INDIGO_END(-1)
+CEXPORT int indigoGetOptionInt(const char* name, int* value)
+{
+    INDIGO_BEGIN
+    {
+        if (value)
+        {
+            indigoGetOptionManager().getOptionValueInt(name, *value);
+            return 1;
+        }
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT const char* indigoGetOptionType(const char* name){INDIGO_BEGIN{auto& tmp = self.getThreadTmpData();
-indigoGetOptionManager().getOptionType(name, tmp.string);
-return tmp.string.ptr();
+CEXPORT int indigoGetOptionBool(const char* name, int* value)
+{
+    INDIGO_BEGIN
+    {
+        if (value)
+        {
+            indigoGetOptionManager().getOptionValueBool(name, *value);
+            return 1;
+        }
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(0)
+
+CEXPORT int indigoGetOptionFloat(const char* name, float* value)
+{
+    INDIGO_BEGIN
+    {
+        if (value)
+        {
+            indigoGetOptionManager().getOptionValueFloat(name, *value);
+            return 1;
+        }
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoGetOptionColor(const char* name, float* r, float* g, float* b)
+{
+    INDIGO_BEGIN
+    {
+        if (r && g && b)
+        {
+            indigoGetOptionManager().getOptionValueColor(name, *r, *g, *b);
+            return 1;
+        }
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoGetOptionXY(const char* name, int* x, int* y)
+{
+    INDIGO_BEGIN
+    {
+        if (x && y)
+        {
+            indigoGetOptionManager().getOptionValueXY(name, *x, *y);
+            return 1;
+        }
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT const char* indigoGetOptionType(const char* name)
+{
+    INDIGO_BEGIN
+    {
+        auto& tmp = self.getThreadTmpData();
+        indigoGetOptionManager().getOptionType(name, tmp.string);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
 
 CEXPORT int indigoResetOptions()
@@ -169,7 +218,7 @@ CEXPORT int indigoResetOptions()
         }
         return 1;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 void _indigoCheckBadValence(Molecule& mol)
@@ -403,7 +452,7 @@ CEXPORT int indigoUnfoldHydrogens(int item)
 
         return 1;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 static bool _removeHydrogens(Molecule& mol)
@@ -434,24 +483,28 @@ static bool _removeHydrogens(Molecule& mol)
     return to_remove.size() > 0;
 }
 
-CEXPORT int indigoFoldHydrogens(int item){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-
-if (IndigoBaseMolecule::is(obj))
-    _removeHydrogens(obj.getMolecule());
-else if (IndigoBaseReaction::is(obj))
+CEXPORT int indigoFoldHydrogens(int item)
 {
-    int i;
-    Reaction& rxn = obj.getReaction();
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
 
-    for (i = rxn.begin(); i != rxn.end(); i = rxn.next(i))
-        _removeHydrogens(rxn.getMolecule(i));
-}
-else
-    throw IndigoError("indigoFoldHydrogens(): %s given", obj.debugInfo());
+        if (IndigoBaseMolecule::is(obj))
+            _removeHydrogens(obj.getMolecule());
+        else if (IndigoBaseReaction::is(obj))
+        {
+            int i;
+            Reaction& rxn = obj.getReaction();
 
-return 1;
-}
-INDIGO_END(-1)
+            for (i = rxn.begin(); i != rxn.end(); i = rxn.next(i))
+                _removeHydrogens(rxn.getMolecule(i));
+        }
+        else
+            throw IndigoError("indigoFoldHydrogens(): %s given", obj.debugInfo());
+
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoSetName(int handle, const char* name)
@@ -480,38 +533,46 @@ CEXPORT const char* indigoName(int handle)
     INDIGO_END(0);
 }
 
-CEXPORT const char* indigoRawData(int handler){INDIGO_BEGIN{IndigoObject& obj = self.getObject(handler);
-
-auto& tmp = self.getThreadTmpData();
-
-if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
-    obj.type == IndigoObject::SMILES_REACTION || obj.type == IndigoObject::CML_MOLECULE || obj.type == IndigoObject::CML_REACTION ||
-    obj.type == IndigoObject::CDX_MOLECULE || obj.type == IndigoObject::CDX_REACTION)
+CEXPORT const char* indigoRawData(int handler)
 {
-    IndigoRdfData& data = (IndigoRdfData&)obj;
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(handler);
 
-    tmp.string.copy(data.getRawData());
+        auto& tmp = self.getThreadTmpData();
+
+        if (obj.type == IndigoObject::RDF_MOLECULE || obj.type == IndigoObject::RDF_REACTION || obj.type == IndigoObject::SMILES_MOLECULE ||
+            obj.type == IndigoObject::SMILES_REACTION || obj.type == IndigoObject::CML_MOLECULE || obj.type == IndigoObject::CML_REACTION ||
+            obj.type == IndigoObject::CDX_MOLECULE || obj.type == IndigoObject::CDX_REACTION)
+        {
+            IndigoRdfData& data = (IndigoRdfData&)obj;
+
+            tmp.string.copy(data.getRawData());
+        }
+        else if (obj.type == IndigoObject::PROPERTY)
+            tmp.string.readString(((IndigoProperty&)obj).getValue(), false);
+        else if (obj.type == IndigoObject::DATA_SGROUP)
+        {
+            tmp.string.copy(((IndigoDataSGroup&)obj).get().data);
+        }
+        else
+            throw IndigoError("%s does not have raw data", obj.debugInfo());
+        tmp.string.push(0);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
-else if (obj.type == IndigoObject::PROPERTY)
-    tmp.string.readString(((IndigoProperty&)obj).getValue(), false);
-else if (obj.type == IndigoObject::DATA_SGROUP)
+
+CEXPORT int indigoRemove(int item)
 {
-    tmp.string.copy(((IndigoDataSGroup&)obj).get().data);
-}
-else
-    throw IndigoError("%s does not have raw data", obj.debugInfo());
-tmp.string.push(0);
-return tmp.string.ptr();
-}
-INDIGO_END(0)
-}
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
 
-CEXPORT int indigoRemove(int item){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-
-obj.remove();
-return 1;
-}
-INDIGO_END(-1)
+        obj.remove();
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoAt(int item, int index)
@@ -582,56 +643,67 @@ CEXPORT int indigoCount(int item)
     INDIGO_END(-1);
 }
 
-CEXPORT int indigoSerialize(int item, byte** buf, int* size){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-auto& tmp = self.getThreadTmpData();
-ArrayOutput out(tmp.string);
-
-if (IndigoBaseMolecule::is(obj))
+CEXPORT int indigoSerialize(int item, byte** buf, int* size)
 {
-    Molecule& mol = obj.getMolecule();
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
+        auto& tmp = self.getThreadTmpData();
+        ArrayOutput out(tmp.string);
 
-    IcmSaver saver(out);
-    saver.save_xyz = mol.have_xyz;
-    saver.save_bond_dirs = true;
-    saver.save_highlighting = true;
-    saver.save_ordering = self.preserve_ordering_in_serialize;
-    saver.saveMolecule(mol);
+        if (IndigoBaseMolecule::is(obj))
+        {
+            Molecule& mol = obj.getMolecule();
+
+            IcmSaver saver(out);
+            saver.save_xyz = mol.have_xyz;
+            saver.save_bond_dirs = true;
+            saver.save_highlighting = true;
+            saver.save_ordering = self.preserve_ordering_in_serialize;
+            saver.saveMolecule(mol);
+        }
+        else if (IndigoBaseReaction::is(obj))
+        {
+            Reaction& rxn = obj.getReaction();
+            IcrSaver saver(out);
+            saver.save_xyz = BaseReaction::haveCoord(rxn);
+            saver.save_bond_dirs = true;
+            saver.save_highlighting = true;
+            saver.save_ordering = self.preserve_ordering_in_serialize;
+            saver.saveReaction(rxn);
+        }
+
+        *buf = (byte*)tmp.string.ptr();
+        *size = tmp.string.size();
+        return 1;
+    }
+    INDIGO_END(-1);
 }
-else if (IndigoBaseReaction::is(obj))
+
+CEXPORT int indigoUnserialize(const byte* buf, int size)
 {
-    Reaction& rxn = obj.getReaction();
-    IcrSaver saver(out);
-    saver.save_xyz = BaseReaction::haveCoord(rxn);
-    saver.save_bond_dirs = true;
-    saver.save_highlighting = true;
-    saver.save_ordering = self.preserve_ordering_in_serialize;
-    saver.saveReaction(rxn);
-}
-
-*buf = (byte*)tmp.string.ptr();
-*size = tmp.string.size();
-return 1;
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoUnserialize(const byte* buf, int size){INDIGO_BEGIN{if (IcmSaver::checkVersion((const char*)buf)){BufferScanner scanner(buf, size);
-IcmLoader loader(scanner);
-AutoPtr<IndigoMolecule> im(new IndigoMolecule());
-loader.loadMolecule(im->mol);
-return self.addObject(im.release());
-}
-else if (IcrSaver::checkVersion((const char*)buf))
-{
-    BufferScanner scanner(buf, size);
-    IcrLoader loader(scanner);
-    AutoPtr<IndigoReaction> ir(new IndigoReaction());
-    loader.loadReaction(ir->rxn);
-    return self.addObject(ir.release());
-}
-else throw IndigoError("indigoUnserialize(): format not recognized");
-}
-INDIGO_END(-1)
+    INDIGO_BEGIN
+    {
+        if (IcmSaver::checkVersion((const char*)buf))
+        {
+            BufferScanner scanner(buf, size);
+            IcmLoader loader(scanner);
+            AutoPtr<IndigoMolecule> im(new IndigoMolecule());
+            loader.loadMolecule(im->mol);
+            return self.addObject(im.release());
+        }
+        else if (IcrSaver::checkVersion((const char*)buf))
+        {
+            BufferScanner scanner(buf, size);
+            IcrLoader loader(scanner);
+            AutoPtr<IndigoReaction> ir(new IndigoReaction());
+            loader.loadReaction(ir->rxn);
+            return self.addObject(ir.release());
+        }
+        else
+            throw IndigoError("indigoUnserialize(): format not recognized");
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoClear(int item)

--- a/api/src/indigo_properties.cpp
+++ b/api/src/indigo_properties.cpp
@@ -19,54 +19,70 @@
 #include "indigo_properties.h"
 #include "base_cpp/properties_map.h"
 
-CEXPORT int indigoHasProperty(int handle, const char* prop){
-    INDIGO_BEGIN{if (prop == 0 || *prop == 0) throw IndigoError("indigoHasProperty(): null or empty property given");
+CEXPORT int indigoHasProperty(int handle, const char* prop)
+{
+    INDIGO_BEGIN
+    {
+        if (prop == 0 || *prop == 0)
+            throw IndigoError("indigoHasProperty(): null or empty property given");
 
-IndigoObject& obj = self.getObject(handle);
+        IndigoObject& obj = self.getObject(handle);
 
-auto& props = obj.getProperties();
+        auto& props = obj.getProperties();
 
-return props.contains(prop);
-}
-INDIGO_END(-1)
-}
-
-CEXPORT const char* indigoGetProperty(int handle, const char* prop){
-    INDIGO_BEGIN{if (prop == 0 || *prop == 0) throw IndigoError("indigoGetProperty(): null or empty property given");
-
-IndigoObject& obj = self.getObject(handle);
-auto& props = obj.getProperties();
-
-auto& tmp = self.getThreadTmpData();
-tmp.string.readString(props.at(prop), true);
-return tmp.string.ptr();
-}
-INDIGO_END(0)
+        return props.contains(prop);
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoSetProperty(int handle, const char* prop, const char* value){
-    INDIGO_BEGIN{if (prop == 0 || *prop == 0) throw IndigoError("indigoSetProperty(): null or empty property given");
+CEXPORT const char* indigoGetProperty(int handle, const char* prop)
+{
+    INDIGO_BEGIN
+    {
+        if (prop == 0 || *prop == 0)
+            throw IndigoError("indigoGetProperty(): null or empty property given");
 
-if (value == 0)
-    value = "";
+        IndigoObject& obj = self.getObject(handle);
+        auto& props = obj.getProperties();
 
-IndigoObject& obj = self.getObject(handle);
-auto& props = obj.getProperties();
-props.insert(prop, value);
-return 1;
+        auto& tmp = self.getThreadTmpData();
+        tmp.string.readString(props.at(prop), true);
+        return tmp.string.ptr();
+    }
+    INDIGO_END(0);
 }
-INDIGO_END(-1)
+
+CEXPORT int indigoSetProperty(int handle, const char* prop, const char* value)
+{
+    INDIGO_BEGIN
+    {
+        if (prop == 0 || *prop == 0)
+            throw IndigoError("indigoSetProperty(): null or empty property given");
+
+        if (value == 0)
+            value = "";
+
+        IndigoObject& obj = self.getObject(handle);
+        auto& props = obj.getProperties();
+        props.insert(prop, value);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoRemoveProperty(int handle, const char* prop){
-    INDIGO_BEGIN{if (prop == 0 || *prop == 0) throw IndigoError("indigoRemoveProperty(): null or empty property given");
+CEXPORT int indigoRemoveProperty(int handle, const char* prop)
+{
+    INDIGO_BEGIN
+    {
+        if (prop == 0 || *prop == 0)
+            throw IndigoError("indigoRemoveProperty(): null or empty property given");
 
-IndigoObject& obj = self.getObject(handle);
-auto& props = obj.getProperties();
-props.remove(prop);
-return 1;
-}
-INDIGO_END(-1)
+        IndigoObject& obj = self.getObject(handle);
+        auto& props = obj.getProperties();
+        props.remove(prop);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 IndigoPropertiesIter::IndigoPropertiesIter(indigo::PropertiesMap& props) : IndigoObject(PROPERTIES_ITER), _props(props)
@@ -122,12 +138,16 @@ IndigoObject* IndigoPropertiesIter::next()
     return new IndigoProperty(_props, _idx);
 }
 
-CEXPORT int indigoIterateProperties(int handle){INDIGO_BEGIN{IndigoObject& obj = self.getObject(handle);
-auto& props = obj.getProperties();
+CEXPORT int indigoIterateProperties(int handle)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(handle);
+        auto& props = obj.getProperties();
 
-return self.addObject(new IndigoPropertiesIter(props));
-}
-INDIGO_END(-1)
+        return self.addObject(new IndigoPropertiesIter(props));
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoClearProperties(int handle)
@@ -140,5 +160,5 @@ CEXPORT int indigoClearProperties(int handle)
         props.clear();
         return 0;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }

--- a/api/src/indigo_reaction.cpp
+++ b/api/src/indigo_reaction.cpp
@@ -336,51 +336,63 @@ IndigoObject* IndigoQueryReaction::clone()
     return cloneFrom(*this);
 }
 
-int _indigoIterateReaction(int reaction, int subtype){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reaction);
-BaseReaction& rxn = obj.getBaseReaction();
-
-try
+int _indigoIterateReaction(int reaction, int subtype)
 {
-    MonomersProperties& map = obj.getMonomersProperties();
-    return self.addObject(new IndigoReactionIter(rxn, map, subtype));
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reaction);
+        BaseReaction& rxn = obj.getBaseReaction();
+
+        try
+        {
+            MonomersProperties& map = obj.getMonomersProperties();
+            return self.addObject(new IndigoReactionIter(rxn, map, subtype));
+        }
+        catch (Exception&)
+        {
+            return self.addObject(new IndigoReactionIter(rxn, subtype));
+        }
+    }
+    INDIGO_END(-1);
 }
-catch (Exception&)
+
+CEXPORT int indigoLoadReaction(int source)
 {
-    return self.addObject(new IndigoReactionIter(rxn, subtype));
-}
-}
-INDIGO_END(-1)
-}
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(source);
+        Scanner& scanner = IndigoScanner::get(obj);
 
-CEXPORT int indigoLoadReaction(int source){INDIGO_BEGIN{IndigoObject& obj = self.getObject(source);
-Scanner& scanner = IndigoScanner::get(obj);
+        ReactionAutoLoader loader(scanner);
 
-ReactionAutoLoader loader(scanner);
+        loader.stereochemistry_options = self.stereochemistry_options;
+        loader.treat_x_as_pseudoatom = self.treat_x_as_pseudoatom;
+        loader.ignore_noncritical_query_features = self.ignore_noncritical_query_features;
 
-loader.stereochemistry_options = self.stereochemistry_options;
-loader.treat_x_as_pseudoatom = self.treat_x_as_pseudoatom;
-loader.ignore_noncritical_query_features = self.ignore_noncritical_query_features;
-
-AutoPtr<IndigoReaction> rxnptr(new IndigoReaction());
-loader.loadReaction(rxnptr->rxn);
-return self.addObject(rxnptr.release());
-}
-INDIGO_END(-1)
+        AutoPtr<IndigoReaction> rxnptr(new IndigoReaction());
+        loader.loadReaction(rxnptr->rxn);
+        return self.addObject(rxnptr.release());
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoLoadQueryReaction(int source){INDIGO_BEGIN{IndigoObject& obj = self.getObject(source);
-Scanner& scanner = IndigoScanner::get(obj);
+CEXPORT int indigoLoadQueryReaction(int source)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(source);
+        Scanner& scanner = IndigoScanner::get(obj);
 
-ReactionAutoLoader loader(scanner);
+        ReactionAutoLoader loader(scanner);
 
-loader.stereochemistry_options = self.stereochemistry_options;
-loader.treat_x_as_pseudoatom = self.treat_x_as_pseudoatom;
+        loader.stereochemistry_options = self.stereochemistry_options;
+        loader.treat_x_as_pseudoatom = self.treat_x_as_pseudoatom;
 
-AutoPtr<IndigoQueryReaction> rxnptr(new IndigoQueryReaction());
-loader.loadQueryReaction(rxnptr->rxn);
-return self.addObject(rxnptr.release());
-}
-INDIGO_END(-1)
+        AutoPtr<IndigoQueryReaction> rxnptr(new IndigoQueryReaction());
+        loader.loadQueryReaction(rxnptr->rxn);
+        return self.addObject(rxnptr.release());
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoIterateReactants(int reaction)
@@ -498,20 +510,24 @@ CEXPORT int indigoCountMolecules(int handle)
     INDIGO_END(-1);
 }
 
-CEXPORT int indigoGetMolecule(int reaction, int index){INDIGO_BEGIN{IndigoObject& obj = self.getObject(reaction);
-BaseReaction& rxn = obj.getBaseReaction();
+CEXPORT int indigoGetMolecule(int reaction, int index)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(reaction);
+        BaseReaction& rxn = obj.getBaseReaction();
 
-try
-{
-    MonomersProperties& map = obj.getMonomersProperties();
-    return self.addObject(new IndigoReactionMolecule(rxn, map, index));
-}
-catch (Exception&)
-{
-    return self.addObject(new IndigoReactionMolecule(rxn, index));
-}
-}
-INDIGO_END(-1)
+        try
+        {
+            MonomersProperties& map = obj.getMonomersProperties();
+            return self.addObject(new IndigoReactionMolecule(rxn, map, index));
+        }
+        catch (Exception&)
+        {
+            return self.addObject(new IndigoReactionMolecule(rxn, index));
+        }
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoMapMolecule(int handle, int molecule)
@@ -535,7 +551,7 @@ CEXPORT int indigoMapMolecule(int handle, int molecule)
 
         return self.addObject(new IndigoReactionMolecule(mapping.to, target_index));
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 static int readAAMOptions(const char* mode, ReactionAutomapper& ram)

--- a/api/src/indigo_savers.cpp
+++ b/api/src/indigo_savers.cpp
@@ -151,7 +151,7 @@ CEXPORT int indigoSdfAppend(int output, int molecule)
         IndigoSdfSaver::append(out, obj);
         return 1;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 //
@@ -255,7 +255,7 @@ CEXPORT int indigoSmilesAppend(int output, int item)
         out.flush();
         return 1;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 //
@@ -390,18 +390,26 @@ void IndigoCmlSaver::_appendFooter()
     appendFooter(_output);
 }
 
-CEXPORT int indigoCmlHeader(int output){INDIGO_BEGIN{Output& out = IndigoOutput::get(self.getObject(output));
-IndigoCmlSaver::appendHeader(out);
-return 1;
-}
-INDIGO_END(-1)
+CEXPORT int indigoCmlHeader(int output)
+{
+    INDIGO_BEGIN
+    {
+        Output& out = IndigoOutput::get(self.getObject(output));
+        IndigoCmlSaver::appendHeader(out);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoCmlFooter(int output){INDIGO_BEGIN{Output& out = IndigoOutput::get(self.getObject(output));
-IndigoCmlSaver::appendFooter(out);
-return 1;
-}
-INDIGO_END(-1)
+CEXPORT int indigoCmlFooter(int output)
+{
+    INDIGO_BEGIN
+    {
+        Output& out = IndigoOutput::get(self.getObject(output));
+        IndigoCmlSaver::appendFooter(out);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoCmlAppend(int output, int item)
@@ -413,7 +421,7 @@ CEXPORT int indigoCmlAppend(int output, int item)
         IndigoCmlSaver::append(out, obj);
         return 1;
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }
 
 //
@@ -483,131 +491,166 @@ void IndigoRdfSaver::_appendHeader()
     appendHeader(_output);
 }
 
-CEXPORT int indigoRdfHeader(int output){INDIGO_BEGIN{Output& out = IndigoOutput::get(self.getObject(output));
-IndigoRdfSaver::appendHeader(out);
-return 1;
-}
-INDIGO_END(-1)
+CEXPORT int indigoRdfHeader(int output)
+{
+    INDIGO_BEGIN
+    {
+        Output& out = IndigoOutput::get(self.getObject(output));
+        IndigoRdfSaver::appendHeader(out);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoRdfAppend(int output, int item){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-Output& out = IndigoOutput::get(self.getObject(output));
-IndigoRdfSaver::append(out, obj);
-return 1;
-}
-INDIGO_END(-1)
+CEXPORT int indigoRdfAppend(int output, int item)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
+        Output& out = IndigoOutput::get(self.getObject(output));
+        IndigoRdfSaver::append(out, obj);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 //
 // Saving functions
 //
-CEXPORT int indigoCreateSaver(int output, const char* format){INDIGO_BEGIN{Output& out = IndigoOutput::get(self.getObject(output));
-return self.addObject(IndigoSaver::create(out, format));
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoCreateFileSaver(const char* filename,
-                                  const char* format){INDIGO_BEGIN{AutoPtr<FileOutput> output(new FileOutput(self.filename_encoding, filename));
-AutoPtr<IndigoSaver> saver(IndigoSaver::create(output.ref(), format));
-saver->acquireOutput(output.release());
-return self.addObject(saver.release());
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoSaveMolfile(int molecule, int output){INDIGO_BEGIN{IndigoObject& obj = self.getObject(molecule);
-Output& out = IndigoOutput::get(self.getObject(output));
-
-IndigoSdfSaver::appendMolfile(out, obj);
-out.flush();
-return 1;
-}
-INDIGO_END(-1)
-}
-
-CEXPORT int indigoSaveCml(int item, int output){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-Output& out = IndigoOutput::get(self.getObject(output));
-
-if (IndigoBaseMolecule::is(obj))
+CEXPORT int indigoCreateSaver(int output, const char* format)
 {
-    CmlSaver saver(out);
-
-    BaseMolecule& mol = obj.getBaseMolecule();
-
-    if (mol.isQueryMolecule())
-        saver.saveQueryMolecule(mol.asQueryMolecule());
-    else
-        saver.saveMolecule(mol.asMolecule());
-
-    out.flush();
-    return 1;
+    INDIGO_BEGIN
+    {
+        Output& out = IndigoOutput::get(self.getObject(output));
+        return self.addObject(IndigoSaver::create(out, format));
+    }
+    INDIGO_END(-1);
 }
-if (IndigoBaseReaction::is(obj))
+
+CEXPORT int indigoCreateFileSaver(const char* filename, const char* format)
 {
-    Reaction& rxn = obj.getReaction();
-    ReactionCmlSaver saver(out);
-
-    saver.saveReaction(rxn);
-    out.flush();
-    return 1;
-}
-throw IndigoError("indigoSaveCml(): expected molecule or reaction, got %s", obj.debugInfo());
-}
-INDIGO_END(-1)
+    INDIGO_BEGIN
+    {
+        AutoPtr<FileOutput> output(new FileOutput(self.filename_encoding, filename));
+        AutoPtr<IndigoSaver> saver(IndigoSaver::create(output.ref(), format));
+        saver->acquireOutput(output.release());
+        return self.addObject(saver.release());
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoSaveMDLCT(int item, int output){INDIGO_BEGIN{IndigoObject& obj = self.getObject(item);
-QS_DEF(Array<char>, buf);
-ArrayOutput out(buf);
-
-if (IndigoBaseMolecule::is(obj))
-    IndigoSdfSaver::appendMolfile(out, obj);
-else if (IndigoBaseReaction::is(obj))
-    IndigoRdfSaver::appendRXN(out, obj);
-
-Output& out2 = IndigoOutput::get(self.getObject(output));
-
-BufferScanner scanner(buf);
-QS_DEF(Array<char>, line);
-
-while (!scanner.isEOF())
+CEXPORT int indigoSaveMolfile(int molecule, int output)
 {
-    scanner.readLine(line, false);
-    if (line.size() > 255)
-        throw IndigoError("indigoSaveMDLCT: line too big (%d)", line.size());
-    out2.writeChar(line.size());
-    out2.writeArray(line);
-}
-return 1;
-}
-INDIGO_END(-1)
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(molecule);
+        Output& out = IndigoOutput::get(self.getObject(output));
+
+        IndigoSdfSaver::appendMolfile(out, obj);
+        out.flush();
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoSaveRxnfile(int reaction, int output){INDIGO_BEGIN{BaseReaction& rxn = self.getObject(reaction).getBaseReaction();
-Output& out = IndigoOutput::get(self.getObject(output));
+CEXPORT int indigoSaveCml(int item, int output)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
+        Output& out = IndigoOutput::get(self.getObject(output));
 
-RxnfileSaver saver(out);
-self.initRxnfileSaver(saver);
-if (rxn.isQueryReaction())
-    saver.saveQueryReaction(rxn.asQueryReaction());
-else
-    saver.saveReaction(rxn.asReaction());
-out.flush();
-return 1;
-}
-INDIGO_END(-1)
+        if (IndigoBaseMolecule::is(obj))
+        {
+            CmlSaver saver(out);
+
+            BaseMolecule& mol = obj.getBaseMolecule();
+
+            if (mol.isQueryMolecule())
+                saver.saveQueryMolecule(mol.asQueryMolecule());
+            else
+                saver.saveMolecule(mol.asMolecule());
+
+            out.flush();
+            return 1;
+        }
+        if (IndigoBaseReaction::is(obj))
+        {
+            Reaction& rxn = obj.getReaction();
+            ReactionCmlSaver saver(out);
+
+            saver.saveReaction(rxn);
+            out.flush();
+            return 1;
+        }
+        throw IndigoError("indigoSaveCml(): expected molecule or reaction, got %s", obj.debugInfo());
+    }
+    INDIGO_END(-1);
 }
 
-CEXPORT int indigoAppend(int saver_id, int object){INDIGO_BEGIN{IndigoObject& obj = self.getObject(object);
-IndigoObject& saver_obj = self.getObject(saver_id);
-if (saver_obj.type != IndigoObject::SAVER)
-    throw IndigoError("indigoAppend() is only applicable to saver objects. %s object was passed as a saver", saver_obj.debugInfo());
-IndigoSaver& saver = (IndigoSaver&)saver_obj;
-saver.appendObject(obj);
-return 1;
+CEXPORT int indigoSaveMDLCT(int item, int output)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
+        QS_DEF(Array<char>, buf);
+        ArrayOutput out(buf);
+
+        if (IndigoBaseMolecule::is(obj))
+            IndigoSdfSaver::appendMolfile(out, obj);
+        else if (IndigoBaseReaction::is(obj))
+            IndigoRdfSaver::appendRXN(out, obj);
+
+        Output& out2 = IndigoOutput::get(self.getObject(output));
+
+        BufferScanner scanner(buf);
+        QS_DEF(Array<char>, line);
+
+        while (!scanner.isEOF())
+        {
+            scanner.readLine(line, false);
+            if (line.size() > 255)
+                throw IndigoError("indigoSaveMDLCT: line too big (%d)", line.size());
+            out2.writeChar(line.size());
+            out2.writeArray(line);
+        }
+        return 1;
+    }
+    INDIGO_END(-1);
 }
-INDIGO_END(-1)
+
+CEXPORT int indigoSaveRxnfile(int reaction, int output)
+{
+    INDIGO_BEGIN
+    {
+        BaseReaction& rxn = self.getObject(reaction).getBaseReaction();
+        Output& out = IndigoOutput::get(self.getObject(output));
+
+        RxnfileSaver saver(out);
+        self.initRxnfileSaver(saver);
+        if (rxn.isQueryReaction())
+            saver.saveQueryReaction(rxn.asQueryReaction());
+        else
+            saver.saveReaction(rxn.asReaction());
+        out.flush();
+        return 1;
+    }
+    INDIGO_END(-1);
+}
+
+CEXPORT int indigoAppend(int saver_id, int object)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(object);
+        IndigoObject& saver_obj = self.getObject(saver_id);
+        if (saver_obj.type != IndigoObject::SAVER)
+            throw IndigoError("indigoAppend() is only applicable to saver objects. %s object was passed as a saver", saver_obj.debugInfo());
+        IndigoSaver& saver = (IndigoSaver&)saver_obj;
+        saver.appendObject(obj);
+        return 1;
+    }
+    INDIGO_END(-1);
 }
 
 CEXPORT int indigoSaveCdxml(int item, int output)
@@ -651,5 +694,5 @@ CEXPORT int indigoSaveCdxml(int item, int output)
         }
         throw IndigoError("indigoSaveCdxml(): expected molecule or reaction, got %s", obj.debugInfo());
     }
-    INDIGO_END(-1)
+    INDIGO_END(-1);
 }

--- a/api/src/indigo_tautomer_enumerator.cpp
+++ b/api/src/indigo_tautomer_enumerator.cpp
@@ -19,18 +19,22 @@
 #include "indigo_tautomer_enumerator.h"
 #include "indigo_molecule.h"
 
-CEXPORT int indigoIterateTautomers(int molecule, const char* options){INDIGO_BEGIN{Molecule& mol = self.getObject(molecule).getMolecule();
+CEXPORT int indigoIterateTautomers(int molecule, const char* options)
+{
+    INDIGO_BEGIN
+    {
+        Molecule& mol = self.getObject(molecule).getMolecule();
 
-TautomerMethod method;
-if (strncasecmp(options, "INCHI", 5) == 0)
-    method = INCHI;
-else if (strncasecmp(options, "RSMARTS", 7) == 0)
-    method = RSMARTS;
-else
-    method = RSMARTS;
-return self.addObject(new IndigoTautomerIter(mol, method));
-}
-INDIGO_END(-1)
+        TautomerMethod method;
+        if (strncasecmp(options, "INCHI", 5) == 0)
+            method = INCHI;
+        else if (strncasecmp(options, "RSMARTS", 7) == 0)
+            method = RSMARTS;
+        else
+            method = RSMARTS;
+        return self.addObject(new IndigoTautomerIter(mol, method));
+    }
+    INDIGO_END(-1);
 }
 
 IndigoTautomerIter::IndigoTautomerIter(Molecule& molecule, TautomerMethod method) : IndigoObject(TAUTOMER_ITER), _enumerator(molecule, method), _complete(false)


### PR DESCRIPTION
Fixed issue #282 Clang formatting problem with macros by adding ; (semicolon) after `INDIGO_END()`. 
Reformatted affected files.
