### PR TITLE
_Get_container() deprecation fix

### DIFF
--- a/molecule/src/molecule_name_parser.cpp
+++ b/molecule/src/molecule_name_parser.cpp
@@ -531,8 +531,18 @@ void MoleculeNameParser::FragmentNodeBase::print(ostream& out) const
     out << "Type: FragmentNodeBase" << endl;
 
     out << "Multipliers:" << endl;
-    const auto& mul_container = multipliers._Get_container();
-    std::for_each(mul_container.begin(), mul_container.end(), [&out](const Multiplier& multiplier) { out << "\tvalue: " << multiplier.first << endl; });
+    auto muls = multipliers;
+    Multipliers muls_rev;
+    while (!muls.empty())
+    {
+        muls_rev.push(muls.top());
+        muls.pop();
+    }
+    while (!muls_rev.empty())
+    {
+        out << "\tvalue: " << muls_rev.top().first << endl;
+        muls_rev.pop();
+    }
 
     out << "Locants:" << endl;
     for (int locant : locants)


### PR DESCRIPTION
_Get_container() is deprecated in VS-2019.
This PR workarounds it to avoid compile error.

The issue is inside \#ifdef DEBUG section, this is a debugging output only.
Therefore its performance and effectiveness are not a matter.

**No production code is affected**.

