### PR TITLE
_Get_container() deprecation fix in Release as well

### DIFF
--- a/molecule/molecule_name_parser.h
+++ b/molecule/molecule_name_parser.h
@@ -48,9 +48,7 @@
 
 
 
-#ifdef DEBUG
 #include <iostream>
-#endif
 
 #include "base_cpp/non_copyable.h"
 #include "base_cpp/obj_array.h"
@@ -311,9 +309,7 @@ namespace indigo
 
             // Inserts a new node at the end of the list
             void insert(FragmentNode* node);
-#ifdef DEBUG
             virtual void print(std::ostream& out) const;
-#endif
 
             FragmentClassType classType = FragmentClassType::INVALID;
             FragmentNode* parent = nullptr; // A handle to the parent; must not be freed
@@ -329,9 +325,7 @@ namespace indigo
             }
             virtual ~FragmentNodeRoot() = default;
 
-#ifdef DEBUG
             virtual void print(std::ostream& out) const;
-#endif
         }; // class FragmentNodeRoot
 
         typedef std::pair<int, TokenType> Multiplier;
@@ -375,9 +369,7 @@ namespace indigo
             */
             int combineMultipliers();
 
-#ifdef DEBUG
             virtual void print(std::ostream& out) const;
-#endif
 
             Element element;
             Isomerism isomerism = Isomerism::NONE;
@@ -429,9 +421,7 @@ namespace indigo
                 return dynamic_cast<FragmentNodeBase*>(this);
             }
 
-#ifdef DEBUG
             virtual void print(std::ostream& out) const;
-#endif
 
             // Positions of this substituent inside its base
             Positions positions;

--- a/molecule/src/molecule_name_parser.cpp
+++ b/molecule/src/molecule_name_parser.cpp
@@ -509,7 +509,6 @@ void MoleculeNameParser::FragmentNode::insert(FragmentNode* node)
     nodes.push_back(node);
 }
 
-#ifdef DEBUG
 void MoleculeNameParser::FragmentNode::print(ostream& out) const
 {
     out << "Parent: " << parent << endl;
@@ -579,7 +578,6 @@ ostream& operator<<(ostream& out, const MoleculeNameParser::FragmentNode* node) 
    return out;
 }
 #endif
-#endif // DEBUG
 
 MoleculeNameParser::FragmentNodeBase::FragmentNodeBase()
 {

--- a/molecule/src/molecule_name_parser.cpp
+++ b/molecule/src/molecule_name_parser.cpp
@@ -531,8 +531,18 @@ void MoleculeNameParser::FragmentNodeBase::print(ostream& out) const
     out << "Type: FragmentNodeBase" << endl;
 
     out << "Multipliers:" << endl;
-    const auto& mul_container = multipliers._Get_container();
-    std::for_each(mul_container.begin(), mul_container.end(), [&out](const Multiplier& multiplier) { out << "\tvalue: " << multiplier.first << endl; });
+    auto muls = multipliers;
+    Multipliers muls_rev;
+    while (!muls.empty())
+    {
+        muls_rev.push(muls.top());
+        muls.pop();
+    }
+    while (!muls_rev.empty())
+    {
+        out << "\tvalue: " << muls_rev.top().first << endl;
+        muls_rev.pop();
+    }
 
     out << "Locants:" << endl;
     for (int locant : locants)


### PR DESCRIPTION
Removed `#ifdef DEBUG` conditional compilation around `print()` methods.
Now the code does not diverge depending on configuration.
However, print() methods are not used, so this won't affect Release configuration.
This pull request is on top of #294.
