### PR TITLE
#338 Fix errors in CML loader with pseudo atoms

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -70,6 +70,7 @@ if (NOT DEFINED ENV{DISABLE_INDIGO_TESTS})
     DEFINE_TEST(indigo-c-test-shared "tests/c/indigo-test.c" indigo-shared)
     DEFINE_TEST(indigo-c-test-shared-issue-269 "tests/c/indigo-test-issue-269.c;tests/c/indigo-test-data-issue-269.cpp" indigo-shared)
     DEFINE_TEST(indigo-c-test-shared-issue-153 "tests/c/indigo-test-issue-153.c" indigo-shared)
+    DEFINE_TEST(indigo-c-test-shared-issue-338 "tests/c/indigo-test-issue-338.cpp" indigo-shared)
 endif()
 
 add_executable(dlopen-test ${Indigo_SOURCE_DIR}/tests/c/dlopen-test.c)

--- a/api/tests/c/indigo-test-issue-338.cpp
+++ b/api/tests/c/indigo-test-issue-338.cpp
@@ -36,34 +36,38 @@ size_t mismatch(const char* s1, const char* s2)
 int main(void)
 {
     int mol = indigoLoadMoleculeFromString(issue338TestData);
-    if (mol != -1)
+    if (mol == -1)
     {
-        int iter = indigoIterateAtoms(mol);
-        while(indigoHasNext(iter))
-        { 
-            int atom = indigoNext(iter);
-            const char* label = indigoSymbol(atom);
-            bool is_pseudo = indigoIsPseudoatom(atom);
-            int number = is_pseudo ? 0 : indigoAtomicNumber(atom);
-            printf("atom: %s, number: %d, pseudo: %d\n", label, number, is_pseudo);
-        }
-        const char* str_save = indigoCml(mol);
-        const size_t str_save_len = strlen(str_save);
-        size_t pos = mismatch(issue338TestData, str_save);
-        if (str_save_len == issue338TestLength && pos == issue338TestLength)
-        {
-            printf("OK\n");
-        }
-        else
-        {
-            printf("Error: output and input differ at position %zd.\n", pos);
-        }
-        indigoFree(mol);
+        printf("indigoLoadMoleculeFromString failed: %s\n", indigoGetLastError());
+        mol = indigoLoadQueryMoleculeFromString(issue338TestData);
+    }
+    if (mol == -1)
+    {
+        printf("indigoLoadQueryMoleculeFromString() failed: %s\n", indigoGetLastError());
         return 0;
+    }
+
+    int iter = indigoIterateAtoms(mol);
+    while(indigoHasNext(iter))
+    { 
+        int atom = indigoNext(iter);
+        const char* label = indigoSymbol(atom);
+        bool is_pseudo = indigoIsPseudoatom(atom);
+        int number = is_pseudo ? 0 : indigoAtomicNumber(atom);
+        printf("atom: %s, number: %d, pseudo: %d\n", label, number, is_pseudo);
+    }
+    const char* str_save = indigoCml(mol);
+    const size_t str_save_len = strlen(str_save);
+    printf("%s\n", str_save);
+    size_t pos = mismatch(issue338TestData, str_save);
+    if (str_save_len == issue338TestLength && pos == issue338TestLength)
+    {
+        printf("OK\n");
     }
     else
     {
-        printf("Failed: %s\n", indigoGetLastError());
-        return 0;
+        printf("Error: output and input differ at position %zd.\n", pos);
     }
+    indigoFree(mol);
+    return 0;
 }

--- a/api/tests/c/indigo-test-issue-338.cpp
+++ b/api/tests/c/indigo-test-issue-338.cpp
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <algorithm>
+#include "indigo.h"
+
+const char* issue338TestData = R"(<?xml version="1.0" ?>
+<cml>
+    <molecule title="">
+        <atomArray>
+            <atom id="a0" elementType="C" x2="8.95" y2="-8.525" />
+            <atom id="a1" elementType="C" mrvPseudo="AH" x2="9.816" y2="-9.025" />
+            <atom id="a2" elementType="C" x2="10.6821" y2="-8.525" />
+        </atomArray>
+        <bondArray>
+            <bond atomRefs2="a0 a1" order="1" />
+            <bond atomRefs2="a1 a2" order="1" />
+        </bondArray>
+    </molecule>
+</cml>
+)";
+
+const size_t issue338TestLength = strlen(issue338TestData);
+
+size_t mismatch(const char* s1, const char* s2)
+{
+    size_t i = 0;
+    for (; s1[i] && s2[i]; ++i)
+    {
+        if (s1[i] != s2[i])
+            break;
+    }
+    return i;
+}
+
+int main(void)
+{
+    int mol = indigoLoadMoleculeFromString(issue338TestData);
+    if (mol != -1)
+    {
+        int iter = indigoIterateAtoms(mol);
+        while(indigoHasNext(iter))
+        { 
+            int atom = indigoNext(iter);
+            const char* label = indigoSymbol(atom);
+            bool is_pseudo = indigoIsPseudoatom(atom);
+            int number = is_pseudo ? 0 : indigoAtomicNumber(atom);
+            printf("atom: %s, number: %d, pseudo: %d\n", label, number, is_pseudo);
+        }
+        const char* str_save = indigoCml(mol);
+        const size_t str_save_len = strlen(str_save);
+        size_t pos = mismatch(issue338TestData, str_save);
+        if (str_save_len == issue338TestLength && pos == issue338TestLength)
+        {
+            printf("OK\n");
+        }
+        else
+        {
+            printf("Error: output and input differ at position %zd.\n", pos);
+        }
+        indigoFree(mol);
+        return 0;
+    }
+    else
+    {
+        printf("Failed: %s\n", indigoGetLastError());
+        return 0;
+    }
+}

--- a/api/tests/python/ref/todo/338_convert_cml_format.py.out
+++ b/api/tests/python/ref/todo/338_convert_cml_format.py.out
@@ -1,0 +1,34 @@
+Input molecule:
+ <?xml version="1.0" ?>
+<cml>
+    <molecule title="">
+        <atomArray>
+            <atom id="a0" elementType="C" x2="8.95" y2="-8.525" />
+            <atom id="a1" elementType="C" mrvPseudo="AH" x2="9.816" y2="-9.025" />
+            <atom id="a2" elementType="C" x2="10.6821" y2="-8.525" />
+        </atomArray>
+        <bondArray>
+            <bond atomRefs2="a0 a1" order="1" />
+            <bond atomRefs2="a1 a2" order="1" />
+        </bondArray>
+    </molecule>
+</cml>
+
+Internal molecule:
+Atoms:
+C, number: 6, is pseudo: 0
+AH, number: 0, is pseudo: 1
+C, number: 6, is pseudo: 0
+
+Output molecule:
+ 
+  -INDIGO-03242114422D
+
+  3  2  0  0  0  0  0  0  0  0999 V2000
+    8.9500   -8.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.8160   -9.0250    0.0000 AH  0  0  0  0  0  0  0  0  0  0  0  0
+   10.6821   -8.5250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  1  0  0  0  0
+M  END
+

--- a/api/tests/python/tests/todo/338_convert_cml_format.py
+++ b/api/tests/python/tests/todo/338_convert_cml_format.py
@@ -1,0 +1,209 @@
+import os
+import sys
+sys.path.append(os.path.normpath(os.path.join(os.path.abspath(__file__), '..', '..', '..', "common")))
+from env_indigo import *
+from threading import local
+import re
+
+tls = local()
+
+##indigo = Indigo()
+
+def printInfo(mol):
+    print("Internal molecule: %s" % mol.name())
+    print("Atoms:")
+    with mol.iterateAtoms() as iterator:
+        while iterator.hasNext() :
+            atom = iterator.next()
+            is_pseudo = atom.isPseudoatom()
+            atomic_number = 0 if (is_pseudo) else atom.atomicNumber()
+            print('%s, number: %d, is pseudo: %d' % (atom.symbol(), atomic_number, is_pseudo))
+
+
+indigo_defaults = {
+    'ignore-stereochemistry-errors': 'true',
+    'smart-layout': 'true',
+    'gross-formula-add-rsites': 'true',
+    'mass-skip-error-on-pseudoatoms': 'false',
+}
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#62
+def indigo_init(options={}):
+    try:
+        tls.indigo = Indigo()
+##      tls.indigo.inchi = IndigoInchi(tls.indigo)
+##      tls.indigo.renderer = IndigoRenderer(tls.indigo)
+        for option, value in indigo_defaults.items():
+            tls.indigo.setOption(option, value)
+        for option, value in options.items():
+            # TODO: Remove this when Indigo API supports smiles type option
+            if option in {'smiles', }:
+                continue
+            tls.indigo.setOption(option, value)
+        return tls.indigo
+    except Exception as e:
+##      indigo_api_logger.error('indigo-init: {0}'.format(e))
+        print('indigo-init: {0}'.format(e))
+        return None
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#80
+class MolData:
+    is_query = False
+    is_rxn = False
+    struct = None
+    substruct = None
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#87
+def is_rxn(molstr):
+    return '>>' in molstr or molstr.startswith('$RXN') or '<reactantList>' in molstr
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#263
+def load_moldata(molstr, indigo=None, options={}, query=False, mime_type=None, selected=[]):
+    if not indigo:
+        try:
+            indigo = indigo_init(options)
+        except Exception as e:
+##          raise HttpException('Problem with Indigo initialization: {0}'.format(e), 501)
+            print('Problem with Indigo initialization: {0}'.format(e))
+
+    md = MolData()
+
+    # TODO: rewrite to use indigo function
+    # params = ''
+    # if mime_type == 'chemical/x-daylight-smarts':
+    #     params = 'smarts'
+    #     md.is_query = True
+
+    # md.struct = indigo.loadStructure(molstr, params)
+    # md.is_query = md.struct.checkQuery()
+
+    if molstr.startswith('InChI'):
+        md.struct = indigo.inchi.loadMolecule(molstr)
+        md.is_rxn = False
+        md.is_query = False
+    else:
+        md.is_rxn = is_rxn(molstr)
+        if mime_type == 'chemical/x-daylight-smarts':
+            md.struct = indigo.loadReactionSmarts(molstr) if md.is_rxn else indigo.loadSmarts(molstr)
+            md.is_query = True
+        else:
+            if not query:
+                try:
+                    md.struct = indigo.loadReaction(molstr) if md.is_rxn else indigo.loadMolecule(molstr)
+                    md.is_query = False
+                except:
+                    message = str(sys.exc_info()[1])
+                    if not re.search('loader.+quer(y|ies)', message):
+                        raise
+                    md.struct = indigo.loadQueryReaction(molstr) if md.is_rxn else indigo.loadQueryMolecule(molstr)
+                    md.is_query = True
+            else:
+                md.struct = indigo.loadQueryReaction(molstr) if md.is_rxn else indigo.loadQueryMolecule(molstr)
+                md.is_query = True
+    return md
+
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#306
+def save_moldata(md, output_format=None, options={}):
+    if output_format in ('chemical/x-mdl-molfile', 'chemical/x-mdl-rxnfile'):
+        return md.struct.rxnfile() if md.is_rxn else md.struct.molfile()
+    elif output_format == 'chemical/x-daylight-smiles':
+        if options.get('smiles') == 'canonical':
+            return md.struct.canonicalSmiles()
+        else:
+            return md.struct.smiles()
+    elif output_format == 'chemical/x-chemaxon-cxsmiles':
+        if options.get('smiles') == 'canonical':
+            return md.struct.canonicalSmiles()
+        else:
+            return md.struct.smiles()
+    elif output_format == 'chemical/x-daylight-smarts':
+        return md.struct.smarts()
+    elif output_format == 'chemical/x-cml':
+        return md.struct.cml()
+    elif output_format == 'chemical/x-inchi':
+        return md.struct.dispatcher.inchi.getInchi(md.struct)
+    elif output_format == 'chemical/x-inchi-aux':
+        res = md.struct.dispatcher.inchi.getInchi(md.struct)
+        aux = md.struct.dispatcher.inchi.getAuxInfo()
+        return "{}\n{}".format(res, aux)
+    raise HttpException("Format %s is not supported" % output_format, 400)
+
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#358
+def get_response(md, output_struct_format, json_output, options):
+    output_mol = save_moldata(md, output_struct_format, options)
+##  LOG_DATA('[RESPONSE]', output_struct_format, options, output_mol.encode('utf-8'))
+
+    if json_output:
+        return jsonify({'struct': output_mol, 'format': output_struct_format}), 200, {'Content-Type': 'application/json'}
+    else:
+        return output_mol ##, 200, {'Content-Type': output_struct_format}
+
+
+# Copy-paste from utils/indigo-service/service/v2/indigo_api.py#545
+    """
+          properties:
+            struct:
+              type: string
+              default: C1=CC=CC=C1
+            output_format:
+              type: string
+              default: chemical/x-mdl-molfile
+              enum:
+                - chemical/x-mdl-rxnfile
+                - chemical/x-mdl-molfile
+                - chemical/x-daylight-smiles
+                - chemical/x-chemaxon-cxsmiles
+                - chemical/x-cml
+                - chemical/x-inchi
+                - chemical/x-iupac
+                - chemical/x-daylight-smarts
+                - chemical/x-inchi-aux'
+    """
+def convert(data:dict):
+##  if request.method == 'POST':
+##      data = IndigoRequestSchema(strict=True).load(get_request_data(request)).data
+
+##      LOG_DATA('[REQUEST] /convert', data['input_format'], data['output_format'], data['struct'].encode('utf-8'), data['options'])
+        md = load_moldata(data['struct'], mime_type=data['input_format'], options=data['options'])
+        printInfo(md.struct)
+        return get_response(md, data['output_format'], data['json_output'], data['options'])
+##  elif request.method == 'GET':
+##
+##      input_dict = {
+##          'struct': request.args['struct'],
+##          'output_format' : request.args['output_format'] if 'output_format' in request.args else 'chemical/x-mdl-molfile',
+##      }
+##
+##
+##      data = IndigoRequestSchema(strict=True).load(input_dict).data
+##
+##      LOG_DATA('[REQUEST] /convert', data['input_format'], data['output_format'], data['struct'].encode('utf-8'), data['options'])
+##      md = load_moldata(data['struct'], mime_type=data['input_format'], options=data['options'])
+##
+##      if 'json_output' in request.args:
+##          data['json_output'] = True
+##      else:
+##          data['json_output'] = False
+##
+##      return get_response(md, data['output_format'], data['json_output'], data['options'])
+
+
+try:
+    with open(joinPath('molecules/file_338.cml'), 'r') as file:
+        str_load = file.read()
+    print("Input molecule:\n", str_load)
+
+    data = {
+        'struct': str_load,
+        'output_format': 'chemical/x-mdl-molfile',
+        'input_format' : 'chemical/x-cml',
+        'json_output' : False,
+        'options' : { 'ignore-stereochemistry-errors':True, }
+    }
+    response = convert(data)
+    
+    print("Output molecule:\n", response)
+except IndigoException as e:
+    print("caught " + getIndigoExceptionText(e))

--- a/api/tests/python/tests/todo/338_convert_cml_format.py
+++ b/api/tests/python/tests/todo/338_convert_cml_format.py
@@ -10,7 +10,7 @@ tls = local()
 ##indigo = Indigo()
 
 def printInfo(mol):
-    print("Internal molecule: %s" % mol.name())
+    print("Internal molecule:")
     print("Atoms:")
     with mol.iterateAtoms() as iterator:
         while iterator.hasNext() :
@@ -200,10 +200,10 @@ try:
         'output_format': 'chemical/x-mdl-molfile',
         'input_format' : 'chemical/x-cml',
         'json_output' : False,
-        'options' : { 'ignore-stereochemistry-errors':True, }
+        'options' : { }
     }
     response = convert(data)
     
-    print("Output molecule:\n", response)
+    print("\nOutput molecule:\n", response)
 except IndigoException as e:
     print("caught " + getIndigoExceptionText(e))

--- a/api/tests/python/tests/todo/molecules/file_338.cml
+++ b/api/tests/python/tests/todo/molecules/file_338.cml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<cml>
+    <molecule title="">
+        <atomArray>
+            <atom id="a0" elementType="C" x2="8.95" y2="-8.525" />
+            <atom id="a1" elementType="C" mrvPseudo="AH" x2="9.816" y2="-9.025" />
+            <atom id="a2" elementType="C" x2="10.6821" y2="-8.525" />
+        </atomArray>
+        <bondArray>
+            <bond atomRefs2="a0 a1" order="1" />
+            <bond atomRefs2="a1 a2" order="1" />
+        </bondArray>
+    </molecule>
+</cml>

--- a/molecule/src/cml_loader.cpp
+++ b/molecule/src/cml_loader.cpp
@@ -256,7 +256,11 @@ void CmlLoader::_loadMoleculeElement(TiXmlHandle& handle)
         const char* pseudo = elem->Attribute("mrvPseudo");
 
         if (pseudo != 0)
+        {
+            if (_qmol == 0)
+                throw Error("Pseudo atom is allowed only for queries");
             a.label = pseudo;
+        }
 
         const char* alias = elem->Attribute("mrvAlias");
 
@@ -477,7 +481,8 @@ void CmlLoader::_loadMoleculeElement(TiXmlHandle& handle)
                 AutoPtr<QueryMolecule::Atom> atom;
                 int qhcount = -1;
 
-                if (label == ELEM_PSEUDO)
+                // #338: see above: label was kept Carbon for pseudo atoms AH, QH, XH, MH, X, M
+                if (label == ELEM_PSEUDO || (label == ELEM_C && !a.label.empty()))
                 {
                     if (!a.label.empty())
                         atom.reset(new QueryMolecule::Atom(QueryMolecule::ATOM_PSEUDO, a.label.c_str()));

--- a/molecule/src/cml_loader.cpp
+++ b/molecule/src/cml_loader.cpp
@@ -399,7 +399,8 @@ void CmlLoader::_loadMoleculeElement(TiXmlHandle& handle)
             {
                 idx = _mol->addAtom(label);
 
-                if (label == ELEM_PSEUDO)
+                // #338: see above: label was kept Carbon for pseudo atoms AH, QH, XH, MH, X, M
+                if (label == ELEM_PSEUDO || (label == ELEM_C && !a.label.empty()))
                 {
                     if (!a.label.empty())
                         _mol->setPseudoAtom(idx, a.label.c_str());

--- a/utils/indigo-service/service/v2/indigo_api.py
+++ b/utils/indigo-service/service/v2/indigo_api.py
@@ -573,13 +573,9 @@ def convert():
                 - chemical/x-inchi-aux'
     responses:
       200:
-        description: Aromatized molecule
-        schema:
-          $ref: "#/definitions/indigo_api_aromatize_post_IndigoResponse"
+        description: Convert format of molecule file
       400:
         description: 'A problem with supplied client data'
-        schema:
-          $ref: "#/definitions/indigo_api_aromatize_post_Error"
     """
     if request.method == 'POST':
         data = IndigoRequestSchema(strict=True).load(get_request_data(request)).data


### PR DESCRIPTION
* Loading CML format: throw an exception on pseudo atom, if not query. This forces the caller to retry loading as QueryMolecule.
* Set Pseudo Atom property also for Carbon, which `elementType` was kept "C" at previous steps for pseudo atoms: AH, QH, XH, MH, X, M.
* Python test that repeats the essential logic of indigo-service /v2/convert.
* C++ test for debugging.