### PR TITLE
bingo-mssql: added checks for edge cases during installation

### DIFF
--- a/bingo/.gitignore
+++ b/bingo/.gitignore
@@ -1,0 +1,14 @@
+sqlserver/bin
+sqlserver/obj
+
+sqlserver/sqlserver_script_generator/bin
+sqlserver/sqlserver_script_generator/obj
+
+sqlserver/sql/assembly
+!sqlserver/sql/assembly/*.txt
+
+sqlserver/Resources
+!sqlserver/Resources/*/*.txt
+
+sqlserver/sql/bingo_saved_params.bat
+bingo-core/src/core/bingo_version.h

--- a/bingo/sqlserver/sql/bingo_drop.sql
+++ b/bingo/sqlserver/sql/bingo_drop.sql
@@ -11,6 +11,10 @@ go
 drop event notification $(bingo)_$(database)_logout_notify on server;
 go
 
+if (select count(*) from sys.server_triggers where name = '$(bingo)_$(database)_prevent_db_drop') = 1
+	DROP TRIGGER $(bingo)_$(database)_prevent_db_drop ON ALL SERVER;
+go
+
 drop route $(bingo)_notify_route;
 go
 


### PR DESCRIPTION
This pull request addresses several issues mentioned in https://github.com/epam/Indigo/issues/352

1. Added DDL trigger for database drop check - otherwise, a database could be dropped manually without bingo deinstallation and the same problem will appear (with service broker events flood)
2.  It is necessary to generate new service_broker_guid when any other database has identical active service_broker_guid (target database might be used as a template and be created via backup, so that's why duplications are possible and in addition, the same service_broker_guid might be enabled on another db)
3. When the user installs backup without bingo on a database with bingo (with a new service_broker_guid) there will be a registered event notification on the previous service_broker_guid. In that case installation script now removes this event notification and installs a new one.

also added some gitignore rules for bingo-related files