### PR TITLE
Add more specific reaction test files

### DIFF
--- a/api/plugins/bingo-elastic/java/src/main/java/com/epam/indigo/model/fields/Field.java
+++ b/api/plugins/bingo-elastic/java/src/main/java/com/epam/indigo/model/fields/Field.java
@@ -8,4 +8,8 @@ final public class Field {
         field = object;
     }
 
+    @Override
+    public String toString() {
+        return field.toString();
+    }
 }


### PR DESCRIPTION
This PR fixes bug with indigo reaction java failing test

Test checks that CMF returned by EuclidSimilarityMatch (same TverskySimilarityMatch) will be similar with target. In some cases it is not. 

This fix just selects more specific reaction file as target, not random one. 