### PR TITLE
Indigo build fails (indigo::Exception::Exception() is private within this context)

### DIFF
--- a/bingo/bingo-core-c/src/bingo_core_c_parallel.cpp
+++ b/bingo/bingo-core-c/src/bingo_core_c_parallel.cpp
@@ -183,7 +183,7 @@ void IndexingCommand::execute(OsCommandResult& result_)
         {
             // Check unhandled exceptions
             e.appendMessage(" ERROR ON id=%d", ids[i]);
-            e.throwSelf();
+            throw;
         }
     }
 }

--- a/bingo/bingo-core/src/core/bingo_error.h
+++ b/bingo/bingo-core/src/core/bingo_error.h
@@ -26,18 +26,16 @@ using namespace indigo;
 class BingoError : public Exception
 {
 public:
-    explicit BingoError(const char* format, ...)
+    explicit BingoError(const char* format, ...) : Exception("core: ")
     {
         va_list args;
 
         va_start(args, format);
-        _init("core", format, args);
+        const size_t len = strlen(_message);
+        vsnprintf(_message + len, sizeof(_message) - len, format, args);
         va_end(args);
     }
-    BingoError(const BingoError& other) : Exception()
-    {
-        other._cloneTo(this);
-    }
+    BingoError(const BingoError& other) = default;
 };
 
 #endif

--- a/bingo/bingo-core/src/core/bingo_error.h
+++ b/bingo/bingo-core/src/core/bingo_error.h
@@ -29,13 +29,13 @@ public:
     explicit BingoError(const char* format, ...) : Exception("core: ")
     {
         va_list args;
-
         va_start(args, format);
         const size_t len = strlen(_message);
         vsnprintf(_message + len, sizeof(_message) - len, format, args);
         va_end(args);
     }
     BingoError(const BingoError& other) = default;
+    BingoError() = delete;
 };
 
 #endif

--- a/bingo/postgres/src/pg_common/bingo_pg_common.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_common.h
@@ -10,6 +10,7 @@
 #include "base_c/bitarray.h"
 #include "base_cpp/array.h"
 #include "base_cpp/auto_ptr.h"
+#include "base_cpp/exception.h"
 #include "base_cpp/output.h"
 #include "base_cpp/scanner.h"
 #include "base_cpp/tlscont.h"
@@ -459,14 +460,16 @@ private:
 class DLLEXPORT BingoPgError : public indigo::Exception
 {
 public:
-    explicit BingoPgError(const char* format, ...)
+    explicit BingoPgError(const char* format, ...) : indigo::Exception("bingo :")
     {
         va_list args;
-
         va_start(args, format);
-        _init("bingo", format, args);
+        const size_t len = strlen(_message);
+        vsnprintf(_message + len, sizeof(_message) - len, format, args);
         va_end(args);
     }
+    BingoPgError(const BingoPgError& other) = default;
+    BingoPgError() = delete;
 };
 
 #define CORE_HANDLE_ERROR(res, success_res, suffix, message)                                                                                                   \


### PR DESCRIPTION
Dear Indigo team,
compilation from source fails for me.
Thank you in advance


> export BINGO_PG_DIR=path_to_postgresql_installation

> $BINGO_PG_DIR/bin/psql --version
psql (PostgreSQL) 13.2

> cat /etc/SUSE-brand 
openSUSE
VERSION = 15.3

> uname -a
Linux node8333 5.3.18-55-default #1 SMP Mon Apr 12 13:17:48 UTC 2021 (4897c7e) x86_64 x86_64 x86_64 GNU/Linux

> python -V
Python 3.9.4

> cmake --version
cmake version 3.17.0

> g++ --version
g++ (SUSE Linux) 7.5.0

> java --version
openjdk 11.0.10 2021-01-19

> git clone https://github.com/epam/Indigo.git
> cd Indigo
> python build_scripts/bingo-release.py --preset=linux64 --dbms=postgres
cmake -G "Unix Makefiles" -DSUBSYSTEM_NAME=x64 -DCMAKE_BUILD_TYPE=Release /tmp/Indigo/build_scripts/bingo-postgres
-- System-specific folder name: Linux
-- Subsystem-specific folder name: x64
-- CMAKE_C_FLAGS -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h  -m64
-- CMAKE_CXX_FLAGS -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h  -m64 -std=c++11
-- Common output dir: /tmp/Indigo/build/pg_UnixMakefiles_ReleaseSUBSYSTEM_NAME_x64/dist/Linux/x64
-- Using local ZLib library
-- BingoCore version is 1.9.1.r127
-- CMAKE_C_FLAGS -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h  -m64 -m64
-- CMAKE_CXX_FLAGS -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h -include /tmp/Indigo/common/cmake/../hacks/gcc_preinclude.h  -m64 -std=c++11 -m64 -std=c++11
-- BingoPostgres version is 1.9.1.r127-gc5684e9c linux64
-- Postgres found at /tmp/postgresql/include/server
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/Indigo/build/pg_UnixMakefiles_ReleaseSUBSYSTEM_NAME_x64
...
[ 70%] Building C object inchi/CMakeFiles/inchi.dir/INCHI_BASE/src/ichi_bns.c.o
In file included from /tmp/Indigo/bingo/bingo-core/src/core/bingo_index.h:26:0,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.h:24,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.cpp:19:
/tmp/Indigo/bingo/bingo-core/src/core/bingo_error.h: In constructor ‘BingoError::BingoError(const char*, ...)’:
/tmp/Indigo/bingo/bingo-core/src/core/bingo_error.h:30:5: error: ‘indigo::Exception::Exception()’ is private within this context
     {
     ^
In file included from /tmp/Indigo/common/base_cpp/array.h:29:0,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.h:22,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.cpp:19:
/tmp/Indigo/common/base_cpp/exception.h:34:9: note: declared private here
         Exception() = delete;
         ^~~~~~~~~
In file included from /tmp/Indigo/bingo/bingo-core/src/core/bingo_index.h:26:0,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.h:24,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.cpp:19:
/tmp/Indigo/bingo/bingo-core/src/core/bingo_error.h:30:5: error: use of deleted function ‘indigo::Exception::Exception()’
     {
     ^
In file included from /tmp/Indigo/common/base_cpp/array.h:29:0,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.h:22,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.cpp:19:
/tmp/Indigo/common/base_cpp/exception.h:34:9: note: declared here
         Exception() = delete;
         ^~~~~~~~~
In file included from /tmp/Indigo/bingo/bingo-core/src/core/bingo_index.h:26:0,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.h:24,
                 from /tmp/Indigo/bingo/bingo-core/src/core/mango_index.cpp:19:
/tmp/Indigo/bingo/bingo-core/src/core/bingo_error.h:34:9: error: ‘_init’ was not declared in this scope
         _init("core", format, args);
         ^~~~~
/tmp/Indigo/bingo/bingo-core/src/core/bingo_error.h:34:9: note: suggested alternative: ‘uint’
         _init("core", format, args);
         ^~~~~
         uint
etc...