### PR TITLE
Add diff.html files to view differences in failed tests

### DIFF
--- a/api/tests/integration/test.py
+++ b/api/tests/integration/test.py
@@ -72,6 +72,10 @@ def write_difference(fn_1, fn_2, fn_3):
             if line2:
                 f_3.write("+ " + line2 + "\n")
     f_3.close()
+    with open("{}.html".format(fn_3), "w") as pretty_file:
+        pretty_diff = difflib.HtmlDiff()
+        html_cont = pretty_diff.make_file(lines_1, lines_2)
+        pretty_file.write(html_cont)
     return difference_counter
 
 


### PR DESCRIPTION
Currently integration tests generated 3 files:
1. .out
2. .std
3. .diff

The `.diff` file contains only difference between `.out` and `.std` without context (line numbers, etc). To check real difference between `.out` and `.std` developer should use external tools.

This PR adds an another file in `out` directory: `.diff.html` with full content. 

Example output (truncated):

<img width="1287" alt="Screen Shot 2021-06-18 at 10 19 35 PM" src="https://user-images.githubusercontent.com/4924485/122609713-19fb6400-d087-11eb-9803-639d9be9e5e4.png">
