### PR TITLE
dotnet: copy dlls for NetFramework (nuget) and force to use x64 platform

### DIFF
--- a/api/dotnet/Indigo.Net.sln
+++ b/api/dotnet/Indigo.Net.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Indigo.Net", "src/Indigo.Net.csproj", "{037E10A5-4233-4243-97C5-1E670C5822C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Indigo.Net", "src\Indigo.Net.csproj", "{037E10A5-4233-4243-97C5-1E670C5822C7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7557}") = "Indigo.Net.Tests", "tests/Indigo.Net.Tests.csproj", "{037E10A5-4233-4243-97C5-1E670C5822C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Indigo.Net.Tests", "tests\Indigo.Net.Tests.csproj", "{037E10A5-4233-4243-97C5-1E670C5822C8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{037E10A5-4233-4243-97C5-1E670C5822C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{037E10A5-4233-4243-97C5-1E670C5822C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{037E10A5-4233-4243-97C5-1E670C5822C7}.Release|Any CPU.Build.0 = Release|Any CPU
-        {037E10A5-4233-4243-97C5-1E670C5822C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {037E10A5-4233-4243-97C5-1E670C5822C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {037E10A5-4233-4243-97C5-1E670C5822C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {037E10A5-4233-4243-97C5-1E670C5822C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{037E10A5-4233-4243-97C5-1E670C5822C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{037E10A5-4233-4243-97C5-1E670C5822C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{037E10A5-4233-4243-97C5-1E670C5822C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{037E10A5-4233-4243-97C5-1E670C5822C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/api/dotnet/NuGet/Indigo.Net.targets
+++ b/api/dotnet/NuGet/Indigo.Net.targets
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidatePlatform" BeforeTargets="Compile">
+    <Error Condition="'$(Platform)' != 'x64'" Text="[Indigo.Net] Project '$(ProjectName)' can only be built for the x64 platform. The current platform is $(Platform)." />
+  </Target>
+
+  <ItemGroup>
+    <Content Condition="'$([MSBuild]::IsOsPlatform(Linux))'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>%(Filename)%(Extension)</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Condition="'$([MSBuild]::IsOsPlatform(OSX))'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>%(Filename)%(Extension)</Link>
+      <Visible>false</Visible>
+    </Content>
+    <Content Condition="'$([MSBuild]::IsOsPlatform(Windows))'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>%(Filename)%(Extension)</Link>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/api/dotnet/NuGet/Indigo.Net.transitive.targets
+++ b/api/dotnet/NuGet/Indigo.Net.transitive.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Ensure projects which depend on projects which depend on Indigo.Net receive this build logic. -->
+  <!-- We still need both "build" and "buildTransitive" directories since "buildTransitive" is only supported starting from nuget 5.0 -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\net461\Indigo.Net.targets" />
+</Project>

--- a/api/dotnet/src/Indigo.Net.csproj
+++ b/api/dotnet/src/Indigo.Net.csproj
@@ -97,10 +97,18 @@
 			<PackagePath>runtimes/win-x64/native/bingo-nosql.dll</PackagePath>
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
+		<Content Include="../NuGet/Indigo.Net.targets">
+			<Pack>true</Pack>
+			<PackagePath>build/net461/Indigo.Net.targets</PackagePath>
+		</Content>
+		<Content Include="../NuGet/Indigo.Net.transitive.targets">
+			<Pack>true</Pack>
+			<PackagePath>buildTransitive/net461/Indigo.Net.targets</PackagePath>
+		</Content>
 	</ItemGroup>
 
 	<Target BeforeTargets="PreBuildEvent" Name="PreBuild">
-		<Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File $(ProjectDir)/prebuild.ps1" />
+		<Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File $(ProjectDir)prebuild.ps1" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
Fixes #450 for NetFramework-based apps

1) It will copy DLLs automatically on build
2) It will show an error for non-x64 projects on build (to show the user a meaningful hint)
![image](https://user-images.githubusercontent.com/1970236/128293421-b2042e5f-2589-4dfe-9a50-cc9df2d21a26.png)
 
In order to test this behavior you can install the nuget package locally via:
1) NetFramework: `Install-Package Indigo.Net -Source <nuget_dir>`
2) NetCore+: `dotnet add package Indigo.Net -s <nuget_dir>`