### PR TITLE
api: c: fixed *TGroups function declarations

### DIFF
--- a/api/c/indigo/indigo.h
+++ b/api/c/indigo/indigo.h
@@ -448,6 +448,7 @@ CEXPORT int indigoIterateGenericSGroups(int molecule);
 CEXPORT int indigoIterateRepeatingUnits(int molecule);
 CEXPORT int indigoIterateMultipleGroups(int molecule);
 
+CEXPORT int indigoIterateTGroups(int molecule);
 CEXPORT int indigoIterateSGroups(int molecule);
 
 CEXPORT int indigoGetSuperatom(int molecule, int index);
@@ -515,9 +516,9 @@ CEXPORT int indigoAddTemplate(int molecule, int templates, const char* tname);
 CEXPORT int indigoRemoveTemplate(int molecule, const char* tname);
 CEXPORT int indigoFindTemplate(int molecule, const char* tname);
 
-CEXPORT const char* indigoGetSTroupClass(int tgroup);
-CEXPORT const char* indigoGetSTroupName(int tgroup);
-CEXPORT const char* indigoGetSTroupAlias(int tgroup);
+CEXPORT const char* indigoGetTGroupClass(int tgroup);
+CEXPORT const char* indigoGetTGroupName(int tgroup);
+CEXPORT const char* indigoGetTGroupAlias(int tgroup);
 
 CEXPORT int indigoTransformSCSRtoCTAB(int item);
 CEXPORT int indigoTransformCTABtoSCSR(int molecule, int templates);


### PR DESCRIPTION
Fixed typos in declarations.
Also added missing `indigoIterateTGroups` decl.