### PR TITLE
bingo-postgres: add saver settings for aam. fix #667

### DIFF
--- a/bingo/bingo-core/src/core/ringo_aam.cpp
+++ b/bingo/bingo-core/src/core/ringo_aam.cpp
@@ -86,6 +86,7 @@ void RingoAAM::getResult(Array<char>& buf)
         layout.make();
         _reaction.markStereocenterBonds();
     }
+    _context.setSaverSettings(rcs);
 
     rcs.saveReaction(_reaction);
 }


### PR DESCRIPTION
Fixes #667 