### PR TITLE
hotfix: fix descriptors endpoint. fix loadMolecule by format

### DIFF
--- a/api/http/README.md
+++ b/api/http/README.md
@@ -29,7 +29,7 @@ It's a common way to version `indigo_service` API in your environment.
 4. Validate molecules: `stereo3D`, `ambiguousH`, `badValence`, `chirality`, `query`,
    `rGroups`, `stereo`, `valence`
 5. Molecule descriptors: `countAlleneCenters`, `countAtoms`, `countAttachmentPoints`, `countBonds`,
-   `countCatalysts`, `countComponents`, `countDataSGroups`, `countGeneridcSGrpoups`, `countHeavyAtoms`,
+   `countCatalysts`, `countComponents`, `countDataSGroups`, `countGenericSGroups`, `countHeavyAtoms`,
    `countHydrogens`, `countImplicitHydrogens`, `countMolecules`, `countMultipleGroups`, `countProducts`,
    `countPseudoatoms`, `countRGroups`, `countRSites`, `countReactants`, `countRepeatingUnits`, `countSSSR`,
    `countStereocenters`, `countSuperatoms`, `isChiral`, `isHighlighted`, `molecularWeight`, `monoisotopicMass`,

--- a/api/http/indigo_service/jsonapi.py
+++ b/api/http/indigo_service/jsonapi.py
@@ -494,7 +494,7 @@ class Descriptors(str, Enum):
     COUNT_CATALYSTS = "countCatalysts"
     COUNT_COMPONENTS = "countComponents"
     COUNT_DATA_S_GROUPS = "countDataSGroups"
-    COUNT_GENERIC_S_GROUPS = "countGeneridcSGrpoups"
+    COUNT_GENERIC_S_GROUPS = "countGenericSGroups"
     COUNT_HEAVY_ATOMS = "countHeavyAtoms"
     COUNT_HYDROGENS = "countHydrogens"
     COUNT_IMPLICIT_HYDROGENS = "countImplicitHydrogens"

--- a/api/http/indigo_service/service.py
+++ b/api/http/indigo_service/service.py
@@ -31,7 +31,14 @@ def extract_compounds(
 ) -> List[IndigoObject]:
     result = []
     for compound, compound_type in pairs:
-        if compound_type == jsonapi.CompoundFormat.AUTO:
+        if compound_type in {
+            jsonapi.CompoundFormat.AUTO,
+            jsonapi.CompoundFormat.SMILES,
+            jsonapi.CompoundFormat.MOLFILE,
+            jsonapi.CompoundFormat.CML,
+            jsonapi.CompoundFormat.INCHI,
+            jsonapi.CompoundFormat.KET,
+        }:
             indigo_object = indigo().loadMolecule(compound)
         elif compound_type == jsonapi.CompoundFormat.SMARTS:
             indigo_object = indigo().loadSmarts(compound)
@@ -134,4 +141,4 @@ def validate(compound: IndigoObject, validation: jsonapi.Validations) -> str:
 def get_descriptor(
     compound: IndigoObject, descriptor: jsonapi.Descriptors
 ) -> str:
-    return str(getattr(compound, descriptor.NAME)())
+    return str(getattr(compound, descriptor.value)())


### PR DESCRIPTION
Fixes 2 bugs

Empty response on descriptors request
```
{
  "data": {
    "type": "descriptor",
    "attributes": {
      "compound": {
        "structure": "CNC"
      },
      "descriptors": [
        "molecularWeight"
      ]
    }
  }
}
```

500 error on request with `format: "smiles"`