### PR TITLE
ci: bingo: add bingo-postgres 13 for all OS and 14 for Linux and macOS

### DIFF
--- a/.github/workflows/indigo-ci.yaml
+++ b/.github/workflows/indigo-ci.yaml
@@ -970,7 +970,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_major_version: [ "10", "11", "12", "13", "14" ]
+        postgres_major_version: [ "10", "11", "12", "13" ]
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -982,7 +982,7 @@ jobs:
         run: git fetch --tags -f
       - name: Setup Postgres
         run: |
-          $pg_version = switch(${{ matrix.postgres_major_version }}) { "14" { "14.2" } "13" { "13.6" } "12" { "12.10" } "11" { "11.15" } "10" { "10.20" } }
+          $pg_version = switch(${{ matrix.postgres_major_version }}) { "13" { "13.6" } "12" { "12.10" } "11" { "11.15" } "10" { "10.20" } }
           curl -O https://get.enterprisedb.com/postgresql/postgresql-${pg_version}-1-windows-x64-binaries.zip
           Expand-Archive postgresql-${pg_version}-1-windows-x64-binaries.zip
           mv postgresql-${pg_version}-1-windows-x64-binaries/pgsql pgsql

--- a/.github/workflows/indigo-ci.yaml
+++ b/.github/workflows/indigo-ci.yaml
@@ -908,7 +908,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_major_version: [ 10, 11, 12]
+        postgres_major_version: [ 10, 11, 12, 13, 14 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -970,7 +970,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_major_version: [ "10", "11", "12" ]
+        postgres_major_version: [ "10", "11", "12", "13", "14" ]
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -982,7 +982,7 @@ jobs:
         run: git fetch --tags -f
       - name: Setup Postgres
         run: |
-          $pg_version = switch(${{ matrix.postgres_major_version }}) { "12" { "12.8" } "11" { "11.13" } "10" { "10.18" } "9.6" { "9.6.23" } }
+          $pg_version = switch(${{ matrix.postgres_major_version }}) { "14" { "14.2" } "13" { "13.6" } "12" { "12.10" } "11" { "11.15" } "10" { "10.20" } }
           curl -O https://get.enterprisedb.com/postgresql/postgresql-${pg_version}-1-windows-x64-binaries.zip
           Expand-Archive postgresql-${pg_version}-1-windows-x64-binaries.zip
           mv postgresql-${pg_version}-1-windows-x64-binaries/pgsql pgsql
@@ -1003,7 +1003,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_major_version: [ 10, 11, 12 ]
+        postgres_major_version: [ 10, 11, 12, 13, 14 ]
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -1015,7 +1015,7 @@ jobs:
         run: git fetch --tags -f
       - name: Setup Postgres
         run: |
-          case ${{ matrix.postgres_major_version }} in 12) pg_version=12.8;; "11") pg_version=11.13;; 10) pg_version=10.18;; 9.6) pg_version=9.6.23;; esac;
+          case ${{ matrix.postgres_major_version }} in 14) pg_version=14.2;; 13) pg_version=13.6;; 12) pg_version=12.10;; 11) pg_version=11.15;; 10) pg_version=10.20;; esac;
           curl -O https://get.enterprisedb.com/postgresql/postgresql-${pg_version}-1-osx-binaries.zip
           unzip postgresql-${pg_version}-1-osx-binaries.zip
           mv pgsql/include/zlib.h pgsql/include/zlib.h.bck


### PR DESCRIPTION
Postgres for bingo_build steps were updated to the current versions (including minor versions for windows and macOS).