### PR TITLE
Rename `indigo-ketcher.zip` artifact to `indigo-wasm.zip`

### DIFF
--- a/.github/workflows/indigo-ci.yaml
+++ b/.github/workflows/indigo-ci.yaml
@@ -779,7 +779,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: indigo-ketcher
+          name: indigo-wasm
           path: dist/indigo-ketcher*.tgz
 
   build_indigo_utils_x86_64:


### PR DESCRIPTION
Renamed `indigo-ketcher.zip` artifact to `indigo-wasm.zip` similar to other artifacts classified by language/platform/cpu.

Note: when publishing Indigo release 1.7.0 this artifact was manually taken from later build and finally get name `indigo-wasm.zip` 
Note: The package (packed inside the artifact) and module name is kept indigo-ketcher-package.
