### PR TITLE
Issue #520: core: replace RedBlackMap and RedBlackSet implementation

### DIFF
--- a/bingo/bingo-core/src/core/bingo_context.h
+++ b/bingo/bingo-core/src/core/bingo_context.h
@@ -19,6 +19,8 @@
 #ifndef __bingo_context__
 #define __bingo_context__
 
+#include <map>
+
 #include "base_cpp/nullable.h"
 #include "bingo_version.h"
 #include "lzw/lzw_dictionary.h"
@@ -81,7 +83,7 @@ namespace indigo
 
         PtrArray<TautomerRule> tautomer_rules;
 
-        RedBlackMap<int, double> relative_atomic_mass_map;
+        std::map<int, double> relative_atomic_mass_map;
 
         void setLoaderSettings(MoleculeAutoLoader& loader);
         void setLoaderSettings(ReactionAutoLoader& loader);

--- a/bingo/oracle/src/oracle/bingo_oracle_context.cpp
+++ b/bingo/oracle/src/oracle/bingo_oracle_context.cpp
@@ -497,7 +497,7 @@ void BingoOracleContext::atomicMassLoad(OracleEnv& env)
         if (relative_atomic_mass_map.find(elem) != relative_atomic_mass_map.end())
             throw Error("element '%s' duplication in atomic mass list", element_str.ptr());
 
-        relative_atomic_mass_map.insert(std::pair<int, double> {elem, mass});
+        relative_atomic_mass_map.insert(std::pair<int, double>{elem, mass});
         buffer += pos;
 
         while (*buffer == ' ')
@@ -510,7 +510,7 @@ void BingoOracleContext::atomicMassLoad(OracleEnv& env)
     if (relative_atomic_mass_map.size() != 0)
     {
         env.dbgPrintfTS("Relative atomic mass read: ");
-        for (const auto& pair :relative_atomic_mass_map)
+        for (const auto& pair : relative_atomic_mass_map)
         {
             int elem = pair.first;
             float mass = pair.second;

--- a/bingo/oracle/src/oracle/bingo_oracle_context.cpp
+++ b/bingo/oracle/src/oracle/bingo_oracle_context.cpp
@@ -494,10 +494,10 @@ void BingoOracleContext::atomicMassLoad(OracleEnv& env)
     while (sscanf(buffer, "%s%f%n", element_str.ptr(), &mass, &pos) > 1)
     {
         int elem = Element::fromString(element_str.ptr());
-        if (relative_atomic_mass_map.find(elem))
+        if (relative_atomic_mass_map.find(elem) != relative_atomic_mass_map.end())
             throw Error("element '%s' duplication in atomic mass list", element_str.ptr());
 
-        relative_atomic_mass_map.insert(elem, mass);
+        relative_atomic_mass_map.insert(std::pair<int, double> {elem, mass});
         buffer += pos;
 
         while (*buffer == ' ')
@@ -510,10 +510,10 @@ void BingoOracleContext::atomicMassLoad(OracleEnv& env)
     if (relative_atomic_mass_map.size() != 0)
     {
         env.dbgPrintfTS("Relative atomic mass read: ");
-        for (int i = relative_atomic_mass_map.begin(); i != relative_atomic_mass_map.end(); i = relative_atomic_mass_map.next(i))
+        for (const auto& pair :relative_atomic_mass_map)
         {
-            int elem = relative_atomic_mass_map.key(i);
-            float mass = relative_atomic_mass_map.value(i);
+            int elem = pair.first;
+            float mass = pair.second;
             env.dbgPrintf("%s %g; ", Element::toString(elem), mass);
         }
         env.dbgPrintf("\n");

--- a/core/indigo-core/molecule/molecule_mass.h
+++ b/core/indigo-core/molecule/molecule_mass.h
@@ -20,7 +20,10 @@
 #define __molecule_mass_h__
 #include "base_cpp/red_black.h"
 #include "molecule/molecule_mass_options.h"
+
 #include <set>
+#include <map>
+
 namespace indigo
 {
 
@@ -30,6 +33,8 @@ namespace indigo
     class MoleculeMass
     {
         DECL_ERROR;
+
+        const double* _relativeAtomicMassByNumber(int number) const;
 
     protected:
         struct _ElemCounter
@@ -44,7 +49,7 @@ namespace indigo
         MoleculeMass();
         MassOptions mass_options;
 
-        const RedBlackMap<int, double>* relative_atomic_mass_map;
+        const std::map<int, double>* relative_atomic_mass_map;
 
         /* Mass of a molecule calculated using the average mass of each
          * element weighted for its natural isotopic abundance

--- a/core/indigo-core/molecule/molecule_mass.h
+++ b/core/indigo-core/molecule/molecule_mass.h
@@ -21,8 +21,8 @@
 #include "base_cpp/red_black.h"
 #include "molecule/molecule_mass_options.h"
 
-#include <set>
 #include <map>
+#include <set>
 
 namespace indigo
 {

--- a/core/indigo-core/molecule/src/molecule_mass.cpp
+++ b/core/indigo-core/molecule/src/molecule_mass.cpp
@@ -29,7 +29,7 @@ IMPL_ERROR(MoleculeMass, "mass");
 
 MoleculeMass::MoleculeMass()
 {
-    relative_atomic_mass_map = NULL;
+    relative_atomic_mass_map = nullptr;
 }
 
 double MoleculeMass::molecularWeight(Molecule& mol)
@@ -70,13 +70,9 @@ double MoleculeMass::molecularWeight(Molecule& mol)
 
         if (isotope == 0)
         {
-            double* value = 0;
-            if (relative_atomic_mass_map != NULL)
-            {
-                value = relative_atomic_mass_map->at2(number);
-            }
+            auto* value = _relativeAtomicMassByNumber(number);
 
-            if (value == 0)
+            if (value == nullptr)
             {
                 elements_count[number]++;
             }
@@ -364,12 +360,7 @@ void MoleculeMass::massComposition(Molecule& mol, Array<char>& str)
         }
         else
         {
-            double* value = 0;
-            if (relative_atomic_mass_map != NULL)
-            {
-                value = relative_atomic_mass_map->at2(number);
-            }
-
+            auto* value = _relativeAtomicMassByNumber(number);
             if (value)
             {
                 relativeMass[number] += *value;
@@ -419,4 +410,15 @@ void MoleculeMass::massComposition(Molecule& mol, Array<char>& str)
         }
     }
     output.writeChar(0);
+}
+
+const double* MoleculeMass::_relativeAtomicMassByNumber(int number) const
+{
+    if (!relative_atomic_mass_map)
+    {
+        return nullptr;
+    }
+
+    const auto it = relative_atomic_mass_map->find(number);
+    return it != relative_atomic_mass_map->end() ? &(it->second) : nullptr;
 }


### PR DESCRIPTION
Issue #520: core: replace RedBlackMap and RedBlackSet implementation with standard containers

Partial implementation: BingoContext and MoleculeMass are updated