### PR TITLE
Issue #520: core: replace RedBlackMap for Molecule3dConstraints

### DIFF
--- a/core/indigo-core/molecule/molecule_3d_constraints.h
+++ b/core/indigo-core/molecule/molecule_3d_constraints.h
@@ -19,8 +19,9 @@
 #ifndef __molecule_3d_constraints__
 #define __molecule_3d_constraints__
 
+#include <map>
+
 #include "base_cpp/ptr_array.h"
-#include "base_cpp/red_black.h"
 #include "base_cpp/tlscont.h"
 #include "math/algebra.h"
 
@@ -382,9 +383,9 @@ namespace indigo
         typedef Molecule3dConstraints MC;
 
         // can't have comma-containing type names in macro declarations below
-        typedef RedBlackMap<int, Vec3f> MapV;
-        typedef RedBlackMap<int, Line3f> MapL;
-        typedef RedBlackMap<int, Plane3f> MapP;
+        typedef std::map<int, Vec3f> MapV;
+        typedef std::map<int, Line3f> MapL;
+        typedef std::map<int, Plane3f> MapP;
 
         CP_DECL;
         TL_CP_DECL(MapV, _cache_v);

--- a/core/indigo-core/molecule/src/molecule_3d_constraints.cpp
+++ b/core/indigo-core/molecule/src/molecule_3d_constraints.cpp
@@ -576,8 +576,10 @@ bool Molecule3dConstraintsChecker::check(BaseMolecule& target, const int* mappin
 
 void Molecule3dConstraintsChecker::_cache(int idx)
 {
-    if (_cache_v.find(idx) || _cache_l.find(idx) || _cache_p.find(idx))
+    if (_cache_v.find(idx) != _cache_v.end() || _cache_l.find(idx) != _cache_l.end() || _cache_p.find(idx) != _cache_p.end())
+    {
         return;
+    }
 
     const MC::Base& base = _constraints.at(idx);
 
@@ -586,7 +588,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
     case MC::POINT_ATOM: {
         int atom_idx = ((const Molecule3dConstraints::PointByAtom&)base).atom_idx;
 
-        _cache_v.insert(idx, _target->getAtomXyz(_mapping[atom_idx]));
+        _cache_v.emplace(idx, _target->getAtomXyz(_mapping[atom_idx]));
         break;
     }
     case MC::POINT_DISTANCE: {
@@ -608,7 +610,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
 
         res.lineCombin(beg, dir, constr.distance);
 
-        _cache_v.insert(idx, res);
+        _cache_v.emplace(idx, res);
         break;
     }
     case MC::POINT_PERCENTAGE: {
@@ -630,7 +632,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
 
         res.lineCombin2(beg, 1.f - constr.percentage, end, constr.percentage);
 
-        _cache_v.insert(idx, res);
+        _cache_v.emplace(idx, res);
         break;
     }
     case MC::POINT_NORMALE: {
@@ -645,7 +647,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
         Vec3f res;
 
         res.lineCombin(org, norm.dir, constr.distance);
-        _cache_v.insert(idx, res);
+        _cache_v.emplace(idx, res);
         break;
     }
     case MC::POINT_CENTROID: {
@@ -666,7 +668,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
         }
 
         res.scale(1.f / constr.point_ids.size());
-        _cache_v.insert(idx, res);
+        _cache_v.emplace(idx, res);
         break;
     }
     case MC::LINE_NORMALE: {
@@ -686,7 +688,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
         res.dir.copy(plane.getNorm());
         res.org.copy(projection);
 
-        _cache_l.insert(idx, res);
+        _cache_l.emplace(idx, res);
         break;
     }
     case MC::LINE_BEST_FIT: {
@@ -708,7 +710,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
 
         res.bestFit(points.size(), points.ptr(), 0);
 
-        _cache_l.insert(idx, res);
+        _cache_l.emplace(idx, res);
         break;
     }
     case MC::PLANE_BEST_FIT: {
@@ -730,7 +732,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
 
         res.bestFit(points.size(), points.ptr(), 0);
 
-        _cache_p.insert(idx, res);
+        _cache_p.emplace(idx, res);
         break;
     }
     case MC::PLANE_POINT_LINE: {
@@ -746,7 +748,7 @@ void Molecule3dConstraintsChecker::_cache(int idx)
 
         res.byPointAndLine(point, line);
 
-        _cache_p.insert(idx, res);
+        _cache_p.emplace(idx, res);
         break;
     }
     default:


### PR DESCRIPTION
Issue #520: core: replace RedBlackMap and RedBlackSet implementation
Partial implementation: Molecule3dConstraints is updated