### PR TITLE
#1135 C library macro - va_end() is missing before return statement

### DIFF
--- a/bingo/oracle/src/oracle/ora_wrap.cpp
+++ b/bingo/oracle/src/oracle/ora_wrap.cpp
@@ -599,7 +599,10 @@ bool OracleStatement::executeSingleInt(int& result, OracleEnv& env, const char* 
     statement.prepare();
     statement.defineIntByPos(1, &result);
     if (!statement.executeAllowNoData())
+    {
+        va_end(args);
         return false;
+    }
     va_end(args);
     return true;
 }
@@ -616,7 +619,10 @@ bool OracleStatement::executeSingleFloat(float& result, OracleEnv& env, const ch
     statement.prepare();
     statement.defineFloatByPos(1, &result);
     if (!statement.executeAllowNoData())
+    {
+        va_end(args);
         return false;
+    }
     va_end(args);
     return true;
 }
@@ -636,6 +642,7 @@ bool OracleStatement::executeSingleString(Array<char>& result, OracleEnv& env, c
     if (!statement.executeAllowNoData())
     {
         result.clear();
+        va_end(args);
         return false;
     }
     va_end(args);
@@ -659,8 +666,10 @@ bool OracleStatement::executeSingleBlob(Array<char>& result, OracleEnv& env, con
 
     statement.defineBlobByPos(1, lob);
     if (!statement.executeAllowNoData())
+    {
+        va_end(args);
         return false;
-
+    }
     va_end(args);
 
     if (statement.gotNull(1)) // null LOB?
@@ -685,10 +694,16 @@ bool OracleStatement::executeSingleClob(Array<char>& result, OracleEnv& env, con
 
     statement.defineClobByPos(1, lob);
     if (!statement.executeAllowNoData())
+    {
+        va_end(args);
         return false;
+    }
 
     if (statement.gotNull(1)) // null LOB?
+    {
+        va_end(args);
         return false;
+    }
 
     va_end(args);
     lob.readAll(result, false);


### PR DESCRIPTION
This commit adds a few bug fixes that was found by cppcheck