### PR TITLE
#1111 api: add method for copying RGroups for Java and .NET

### DIFF
--- a/api/dotnet/src/IndigoLib.cs
+++ b/api/dotnet/src/IndigoLib.cs
@@ -1193,5 +1193,8 @@ namespace com.epam.indigo
 
         [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
         public static extern int indigoDbgBreakpoint();
+
+        [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
+        public static extern int indigoCopyRGroups(int molecule_from, int molecule_to);
     }
 }

--- a/api/dotnet/src/IndigoObject.cs
+++ b/api/dotnet/src/IndigoObject.cs
@@ -2154,5 +2154,11 @@ namespace com.epam.indigo
             dispatcher.setSessionID();
             return dispatcher.checkResult(IndigoLib.indigoDbgInternalType(self));
         }
+
+        public int copyRGroups(IndigoObject other)
+        {
+            dispatcher.setSessionID();
+            return dispatcher.checkResult(IndigoLib.indigoCopyRGroups(other.self, self));
+        }
     }
 }

--- a/api/dotnet/tests/IndigoTest.cs
+++ b/api/dotnet/tests/IndigoTest.cs
@@ -124,5 +124,21 @@ M  END
             Assert.IsTrue(cml.Contains("бензол"));
             Assert.IsFalse(cml.Contains("??????"));
         }
+
+        [TestMethod]
+        public void IndigoTestCopyRGroup()
+        {
+            using var indigo = new Indigo();
+            IndigoObject mol_with_rg = indigo.loadMolecule(
+                "C%91C.[*:1]%91 |$;;_R1$,RG:_R1={F%91.Cl%92.Br%93.[*:1]%91.[*:1]%92.[*:1]%93 |$;;;_AP1;_AP1;_AP1$|}|"
+            );
+            Assert.IsTrue(mol_with_rg.countRGroups() == 1);
+            IndigoObject mol_with_no_rg = indigo.loadMolecule(
+                "C%91C.[*:1]%91 |$;;_R1$|"
+            );
+            Assert.IsTrue(mol_with_no_rg.countRGroups() == 0);
+            mol_with_rg.copyRGroups(mol_with_no_rg);
+            Assert.IsTrue(mol_with_no_rg.countRGroups() == 1);
+        }
     }
 }

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
@@ -835,4 +835,6 @@ public interface IndigoLib extends Library {
     int indigoDbgBreakpoint();
 
     Pointer indigoDbgInternalType(int object);
+
+    int indigoCopyRGroups(int molecule_from, int molecule_to);
 }

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -1864,4 +1864,9 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
         dispatcher.setSessionID();
         return Indigo.checkResultString(this, lib.indigoDbgInternalType(self));
     }
+
+    public int copyRGroups(IndigoObject other) {
+        dispatcher.setSessionID();
+        return Indigo.checkResult(this, lib.indigoCopyRGroups(other.self, self));
+    }
 }

--- a/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
+++ b/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
@@ -31,4 +31,20 @@ public class IndigoTests {
                 indigoObject.fingerprint().oneBitsList(),
                 "same one bits as in string 1698 1719 1749 1806 1909 1914 1971 205");
     }
+
+    @Test
+    @DisplayName("Copies R-group from one molecule to another")
+    void testCopyRGroups() {
+        Indigo indigo = new Indigo();
+        IndigoObject molWithRg = indigo.loadMolecule(
+            "C%91C.[*:1]%91 |$;;_R1$,RG:_R1={F%91.Cl%92.Br%93.[*:1]%91.[*:1]%92.[*:1]%93 |$;;;_AP1;_AP1;_AP1$|}|"
+        );
+        assertEquals(molWithRg.countRGroups(), 1);
+        IndigoObject molWithNoRg = indigo.loadMolecule(
+            "C%91C.[*:1]%91 |$;;_R1$|"
+        );
+        assertEquals(molWithNoRg.countRGroups(), 0);
+        molWithRg.copyRGroups(molWithNoRg);
+        assertEquals(molWithNoRg.countRGroups(), 1);
+    }
 }


### PR DESCRIPTION
Added copyRGroups method to Java and .NET APIs, as requested in #1111. Similar to #1098 