### PR TITLE
 #1252 SMARTS loader load grouped components as separate molecules

### DIFF
--- a/api/tests/integration/ref/rsmiles/rsmiles_smarts.py.out
+++ b/api/tests/integration/ref/rsmiles/rsmiles_smarts.py.out
@@ -1,0 +1,1 @@
+SMARTS component-level grouping load ok

--- a/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
+++ b/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
@@ -15,4 +15,3 @@ rxn1 = indigo.loadReactionSmarts("([#8:1].[#6:2])>>([#8:1].[#6:2])")
 assert rxn1.countReactants() == 1
 assert rxn1.countProducts() == 1
 print("SMARTS component-level grouping load ok")
-

--- a/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
+++ b/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(
+    os.path.normpath(
+        os.path.join(os.path.abspath(__file__), "..", "..", "..", "common")
+    )
+)
+from env_indigo import *
+
+indigo = Indigo()
+
+
+rxn1 = indigo.loadReactionSmarts("([#8:1].[#6:2])>>([#8:1].[#6:2])")
+assert rxn1.countReactants() == 1
+assert rxn1.countProducts() == 1
+print("SMARTS component-level grouping load ok")
+

--- a/core/indigo-core/graph/src/graph_decomposer.cpp
+++ b/core/indigo-core/graph/src/graph_decomposer.cpp
@@ -72,7 +72,7 @@ int GraphDecomposer::decompose(const Filter* filter, const Filter* edge_filter, 
         int top = 1, bottom = 0;
 
         queue[0] = vertex_idx;
-        while (top != bottom)
+        while (top != bottom) // while queue not empty
         {
             auto v_bottom_id = queue[bottom];
             const Vertex& vertex = _graph.getVertex(v_bottom_id);
@@ -92,10 +92,10 @@ int GraphDecomposer::decompose(const Filter* filter, const Filter* edge_filter, 
                 if (edge_filter != 0 && !edge_filter->valid(vertex.neiEdge(i)))
                     continue;
 
-                if (_component_ids[other] == -1)
+                if (_component_ids[other] == -1) // if other unused
                 {
-                    queue[top++] = other;
-                    _component_ids[other] = -2;
+                    queue[top++] = other;       // queue.push(other)
+                    _component_ids[other] = -2; // mark as in_queue
                 }
 
                 if (_component_ids[other] == -2)
@@ -129,7 +129,7 @@ int GraphDecomposer::decompose(const Filter* filter, const Filter* edge_filter, 
                     }
                 }
             }
-            bottom++;
+            bottom++; // queue.pop()
         }
 
         n_comp++;

--- a/core/indigo-core/tests/tests/reaction.cpp
+++ b/core/indigo-core/tests/tests/reaction.cpp
@@ -91,3 +91,12 @@ TEST_F(IndigoCoreReactionTest, aliases_complex)
         saverReactionJson(reaction).c_str());
     */
 }
+
+TEST_F(IndigoCoreReactionTest, smarts_reaction)
+{
+    QueryReaction qr;
+    std::string smarts_in = "([#8:1].[#6:2])>>([#8:1].[#6:2])";
+    loadQueryReaction(smarts_in.c_str(), qr);
+    ASSERT_EQ(qr.reactantsCount(), 1);
+    ASSERT_EQ(qr.productsCount(), 1);
+}


### PR DESCRIPTION
 Fix SMARTS loader to preven decompositiont of grouped component to
 separate molecules.