### PR TITLE
#1254 SMARTS with component-level grouping saved without '()'

### DIFF
--- a/api/cpp/tests/basic/reaction.cpp
+++ b/api/cpp/tests/basic/reaction.cpp
@@ -29,7 +29,7 @@ TEST(Reaction, automapReactionSmarts)
     const auto& session = IndigoSession::create();
     auto reaction = session->loadReaction("[C:1]=[C:2][C:3].[C:4]=[C:5][C:6]>>[C:3][C:2]=[C:5][C:6]");
     reaction.automap(IndigoAutomapMode::CLEAR);
-    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6] |^3:0,3,^1:1,4,7,8|", reaction.smarts().c_str());
+    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6]", reaction.smarts().c_str());
 }
 
 TEST(Reaction, automapQueryReactionSmarts)
@@ -37,5 +37,5 @@ TEST(Reaction, automapQueryReactionSmarts)
     const auto& session = IndigoSession::create();
     auto reaction = session->loadQueryReaction("[C:1]=[C:2][C:3].[C:4]=[C:5][C:6]>>[C:3][C:2]=[C:5][C:6] |$;;R1;;;R2;R1;;;R2$|");
     reaction.automap(IndigoAutomapMode::CLEAR);
-    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6] |$;;R1;;;R2;R1;;;R2$|", reaction.smarts().c_str());
+    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6]", reaction.smarts().c_str());
 }

--- a/api/tests/integration/ref/formats/smarts.py.out
+++ b/api/tests/integration/ref/formats/smarts.py.out
@@ -6,3 +6,6 @@ CC[C+5]CCCCC
 CC[C+5]CCCCC
 **** Load and Save as Query with not list ****
 [#6]-[#6]-[!#5!#6!#7]-[#6]-[#6]-[#6]-[#6]-[#6]-[#6]
+**** Load and Save as Query with component-level grouping ****
+([#8].[#6]) is ok. smarts_in==smarts_out
+([#8].[#6]).([#8].[#6]) is ok. smarts_in==smarts_out

--- a/api/tests/integration/ref/rsmiles/rsmiles_smarts.py.out
+++ b/api/tests/integration/ref/rsmiles/rsmiles_smarts.py.out
@@ -1,1 +1,2 @@
 SMARTS component-level grouping load ok
+SMARTS component-level grouping save ok

--- a/api/tests/integration/tests/formats/smarts.py
+++ b/api/tests/integration/tests/formats/smarts.py
@@ -20,11 +20,11 @@ def test_smarts_load_save(smarts_in):
     m = indigo.loadSmarts(smarts_in)
     smarts_out = m.smarts()
     if smarts_in == smarts_out:
-        print("smarts_in==smarts_out")
+        print("%s is ok. smarts_in==smarts_out" % smarts_in)
     else:
         print("smarts_in!=smarts_out")
         print(" smarts_in=%s", smarts_in)
-        print("smarts_out=%s", smarts_in)
+        print("smarts_out=%s", smarts_out)
 
 
 molstr = """
@@ -93,5 +93,6 @@ print("**** Load and Save as Query with not list ****")
 m = indigo.loadQueryMolecule(notlist)
 print(m.smarts())
 
-test_smarts_load_save("([#8:1].[#6:2])")
-test_smarts_load_save("([#8:1].[#6:2]).([#8:1].[#6:2])")
+print("**** Load and Save as Query with component-level grouping ****")
+test_smarts_load_save("([#8].[#6])")
+test_smarts_load_save("([#8].[#6]).([#8].[#6])")

--- a/api/tests/integration/tests/formats/smarts.py
+++ b/api/tests/integration/tests/formats/smarts.py
@@ -16,6 +16,17 @@ def testSmarts(m):
     print(m.smiles())
 
 
+def test_smarts_load_save(smarts_in):
+    m = indigo.loadSmarts(smarts_in)
+    smarts_out = m.smarts()
+    if smarts_in == smarts_out:
+        print("smarts_in==smarts_out")
+    else:
+        print("smarts_in!=smarts_out")
+        print(" smarts_in=%s", smarts_in)
+        print("smarts_out=%s", smarts_in)
+
+
 molstr = """
   Ketcher 11241617102D 1   1.00000     0.00000     0
 
@@ -81,3 +92,6 @@ testSmarts(m)
 print("**** Load and Save as Query with not list ****")
 m = indigo.loadQueryMolecule(notlist)
 print(m.smarts())
+
+test_smarts_load_save("([#8:1].[#6:2])")
+test_smarts_load_save("([#8:1].[#6:2]).([#8:1].[#6:2])")

--- a/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
+++ b/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
@@ -12,9 +12,16 @@ indigo = Indigo()
 
 smarts_in = "([#8:1].[#6:2])>>([#8:1].[#6:2])"
 rxn1 = indigo.loadReactionSmarts(smarts_in)
-assert rxn1.countReactants() == 1
-assert rxn1.countProducts() == 1
-print("SMARTS component-level grouping load ok")
+if rxn1.countReactants() == 1 and rxn1.countProducts() == 1:
+    print("SMARTS component-level grouping load ok")
+else:
+    print("SMARTS component-level grouping load failed")
+    print("rxn1.countReactants()=%s" % rxn1.countReactants())
+    print("rxn1.countProducts()=%s" % rxn1.countProducts())
 smarts_out = rxn1.smarts()
-assert smarts_in == smarts_out
-print("SMARTS component-level grouping save ok")
+if smarts_in == smarts_out:
+    print("SMARTS component-level grouping save ok")
+else:
+    print("SMARTS component-level grouping save failed")
+    print("smart_in=%s" % smarts_in)
+    print("smart_ou=%s" % smarts_out)

--- a/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
+++ b/api/tests/integration/tests/rsmiles/rsmiles_smarts.py
@@ -10,8 +10,11 @@ from env_indigo import *
 
 indigo = Indigo()
 
-
-rxn1 = indigo.loadReactionSmarts("([#8:1].[#6:2])>>([#8:1].[#6:2])")
+smarts_in = "([#8:1].[#6:2])>>([#8:1].[#6:2])"
+rxn1 = indigo.loadReactionSmarts(smarts_in)
 assert rxn1.countReactants() == 1
 assert rxn1.countProducts() == 1
 print("SMARTS component-level grouping load ok")
+smarts_out = rxn1.smarts()
+assert smarts_in == smarts_out
+print("SMARTS component-level grouping save ok")

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -372,6 +372,8 @@ namespace indigo
         // must belong to different connected components of the target molecule
         Array<int> components;
 
+        std::list<std::unordered_set<int>>& getComponentNeighbors();
+
         void invalidateAtom(int index, int mask) override;
 
         int getAtomMaxExteralConnectivity(int idx);
@@ -397,6 +399,10 @@ namespace indigo
 
         PtrArray<Atom> _atoms;
         PtrArray<Bond> _bonds;
+
+        std::list<std::unordered_set<int>> _component_neighbors;
+        bool _component_neighbors_valid;
+        void _calculateComponentNeighbors();
     };
 
 } // namespace indigo

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -372,7 +372,7 @@ namespace indigo
         // must belong to different connected components of the target molecule
         Array<int> components;
 
-        std::list<std::unordered_set<int>>& getComponentNeighbors();
+        void getComponentNeighbors(std::list<std::unordered_set<int>> &componentNeighbors);
 
         void invalidateAtom(int index, int mask) override;
 
@@ -399,9 +399,6 @@ namespace indigo
 
         PtrArray<Atom> _atoms;
         PtrArray<Bond> _bonds;
-
-        std::list<std::unordered_set<int>> _component_neighbors;
-        void _calculateComponentNeighbors();
     };
 
 } // namespace indigo

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -372,7 +372,7 @@ namespace indigo
         // must belong to different connected components of the target molecule
         Array<int> components;
 
-        void getComponentNeighbors(std::list<std::unordered_set<int>> &componentNeighbors);
+        void getComponentNeighbors(std::list<std::unordered_set<int>>& componentNeighbors);
 
         void invalidateAtom(int index, int mask) override;
 

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -401,7 +401,6 @@ namespace indigo
         PtrArray<Bond> _bonds;
 
         std::list<std::unordered_set<int>> _component_neighbors;
-        bool _component_neighbors_valid;
         void _calculateComponentNeighbors();
     };
 

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2140,3 +2140,30 @@ void QueryMolecule::getQueryAtomLabel(int qa, Array<char>& result)
     if (it != query_atom_labels.end())
         result.readString(it->second.c_str(), true);
 }
+
+void QueryMolecule::_calculateComponentNeighbors()
+{
+    std::unordered_map<int, std::unordered_set<int>> componentAtoms;
+    for (int i = 0; i < components.size(); ++i)
+    {
+        int componentId = components[i];
+        if (componentId > 0)
+        { // vertice[i] belongs to component #Id
+            componentAtoms[componentId].insert(i);
+        }
+    }
+    for (auto elem : componentAtoms)
+    {
+        auto atoms = elem.second;
+        if (atoms.size() > 1)
+            _component_neighbors.emplace_back(atoms);
+    }
+}
+
+std::list<std::unordered_set<int>>& QueryMolecule::getComponentNeighbors()
+{
+    if(!_component_neighbors_valid)
+        _calculateComponentNeighbors();
+
+    return _component_neighbors;
+}

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2162,7 +2162,7 @@ void QueryMolecule::_calculateComponentNeighbors()
 
 std::list<std::unordered_set<int>>& QueryMolecule::getComponentNeighbors()
 {
-    if(!_component_neighbors_valid)
+    if (!_component_neighbors_valid)
         _calculateComponentNeighbors();
 
     return _component_neighbors;

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -26,7 +26,7 @@
 
 using namespace indigo;
 
-QueryMolecule::QueryMolecule() : spatial_constraints(*this)
+QueryMolecule::QueryMolecule() : spatial_constraints(*this), _component_neighbors_valid(false)
 {
 }
 

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2141,7 +2141,7 @@ void QueryMolecule::getQueryAtomLabel(int qa, Array<char>& result)
         result.readString(it->second.c_str(), true);
 }
 
-void QueryMolecule::getComponentNeighbors(std::list<std::unordered_set<int>> &componentNeighbors)
+void QueryMolecule::getComponentNeighbors(std::list<std::unordered_set<int>>& componentNeighbors)
 {
     std::unordered_map<int, std::unordered_set<int>> componentAtoms;
     for (int i = 0; i < components.size(); ++i)

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2141,7 +2141,7 @@ void QueryMolecule::getQueryAtomLabel(int qa, Array<char>& result)
         result.readString(it->second.c_str(), true);
 }
 
-void QueryMolecule::_calculateComponentNeighbors()
+void QueryMolecule::getComponentNeighbors(std::list<std::unordered_set<int>> &componentNeighbors)
 {
     std::unordered_map<int, std::unordered_set<int>> componentAtoms;
     for (int i = 0; i < components.size(); ++i)
@@ -2152,16 +2152,11 @@ void QueryMolecule::_calculateComponentNeighbors()
             componentAtoms[componentId].insert(i);
         }
     }
+    componentNeighbors.clear();
     for (auto elem : componentAtoms)
     {
         auto atoms = elem.second;
         if (atoms.size() > 1)
-            _component_neighbors.emplace_back(atoms);
+            componentNeighbors.emplace_back(atoms);
     }
-}
-
-std::list<std::unordered_set<int>>& QueryMolecule::getComponentNeighbors()
-{
-    _calculateComponentNeighbors();
-    return _component_neighbors;
 }

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -26,7 +26,7 @@
 
 using namespace indigo;
 
-QueryMolecule::QueryMolecule() : spatial_constraints(*this), _component_neighbors_valid(false)
+QueryMolecule::QueryMolecule() : spatial_constraints(*this)
 {
 }
 
@@ -2162,8 +2162,6 @@ void QueryMolecule::_calculateComponentNeighbors()
 
 std::list<std::unordered_set<int>>& QueryMolecule::getComponentNeighbors()
 {
-    if (!_component_neighbors_valid)
-        _calculateComponentNeighbors();
-
+    _calculateComponentNeighbors();
     return _component_neighbors;
 }

--- a/core/indigo-core/molecule/src/smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/smiles_saver.cpp
@@ -75,45 +75,7 @@ void SmilesSaver::saveQueryMolecule(QueryMolecule& mol)
     _bmol = &mol;
     _qmol = &mol;
     _mol = 0;
-    if (smarts_mode)
-    {
-        std::unordered_set<int> component_nums;
-        for (int i = 0; i < _qmol->components.size(); i++)
-        {
-            component_nums.insert(_qmol->components[i]);
-        }
-        if (component_nums.size() > 1)
-        {
-            std::unique_ptr<QueryMolecule> mol = std::make_unique<QueryMolecule>();
-            // decompose _qmol and save each component separately
-            std::list<std::unordered_set<int>>& extNeighbors = _qmol->getComponentNeighbors();
-            int fragment_count = _qmol->countComponents(extNeighbors);
-            for (int i = 0; i < fragment_count; ++i)
-            {
-                Array<int> mapping;
-                auto fragment = std::make_unique<QueryMolecule>();
-                Filter filt(_qmol->getDecomposition().ptr(), Filter::EQ, i);
-                fragment->makeSubmolecule(*_qmol, filt, &mapping, 0);
-                mol->mergeWithMolecule(*fragment, 0);
-                saveQueryMolecule(*fragment);
-            }
-        }
-        else
-        {
-            // _qmol.components contains only one value.
-            // If this value == 0 - no grouping used
-            // otherwise grouping used - SMARTS should be in parentheses
-            if (component_nums.count(0) == 0)
-                _output.writeChar('(');
-            _saveMolecule();
-            if (component_nums.count(0) == 0)
-                _output.writeChar(')');
-        }
-    }
-    else
-    {
-        _saveMolecule();
-    }
+    _saveMolecule();
 }
 
 void SmilesSaver::_saveMolecule()
@@ -223,6 +185,47 @@ void SmilesSaver::_saveMolecule()
     walk.walk();
 
     const Array<DfsWalk::SeqElem>& v_seq = walk.getSequence();
+    Array<int> v_to_comp_group;
+    v_to_comp_group.resize(v_seq.size());
+    v_to_comp_group.fffill();
+
+    if (_qmol != nullptr && smarts_mode)
+    {
+        if (v_seq.size() < 1)
+            return; // No atoms to save
+        std::set<int> components;
+        int cur_component = -1;
+        for (int i = 0; i < v_seq.size(); ++i)
+        {
+            // In v_seq each fragment started with vertex which parent == -1
+            // In SMARTS some fragments could be grouped (component-level grouping)
+            // In QueryMolecule group number stored in "".components" member. GroupId == 0 means no group defined.
+            // Each fragment - connected graph, so all vertexes should belong to one group.
+            // All group fragments should go one by one - in SMARTS its inside "()".
+            if (v_seq[i].parent_vertex < 0) // New Fragment
+            {
+                int new_component = _qmol->components[v_seq[i].idx];
+                // if component defined for new fragment(id>0) and its different from previous and seen before
+                if (new_component > 0 && new_component != cur_component && components.count(new_component))
+                {
+                    // According to the DfsWalk code, the groups components should be neighbors.
+                    // If will be found case when it wrong - add code to rearrange fragments
+                    throw Error("SMARTS fragments need to reaarange.");
+                }
+                components.emplace(new_component);
+                cur_component = new_component;
+            }
+            else
+            {
+                if (cur_component != _qmol->components[v_seq[i].idx])
+                {
+                    // Fragment contains atoms from different components - something went wrong
+                    throw Error("Fragment contains atoms from different components.");
+                }
+            }
+            v_to_comp_group[i] = cur_component;
+        }
+    }
 
     // fill up neighbor lists for the stereocenters calculation
     for (i = 0; i < v_seq.size(); i++)
@@ -563,8 +566,25 @@ void SmilesSaver::_saveMolecule()
         else
         {
             if (!first_component)
+            {
+                // group == 0 means no group set.
+                int prev_group = v_to_comp_group[i - 1];
+                int new_group = v_to_comp_group[i];
+                bool different_groups = new_group != prev_group;
+                if (smarts_mode && prev_group && different_groups) // if component group ended
+                    _output.writeChar(')');
+
                 _output.writeChar('.');
-            first_component = false;
+
+                if (smarts_mode && new_group && different_groups) // if new group started
+                    _output.writeChar('(');
+            }
+            else
+            {
+                if (smarts_mode && v_to_comp_group[i] > 0) // component level grouping set for this fragment
+                    _output.writeChar('(');
+                first_component = false;
+            }
             _written_components++;
         }
         if (write_atom)
@@ -637,6 +657,8 @@ void SmilesSaver::_saveMolecule()
                 _output.writeString("{+n}");
         }
     }
+    if (smarts_mode && v_to_comp_group[i - 1]) // if group set for last fragment - add finish )
+        _output.writeChar(')');
 
     if (write_extra_info && chemaxon && !smarts_mode) // no extended block in SMARTS
     {

--- a/core/indigo-core/molecule/src/smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/smiles_saver.cpp
@@ -80,13 +80,13 @@ void SmilesSaver::saveQueryMolecule(QueryMolecule& mol)
         std::unordered_set<int> component_nums;
         for (int i = 0; i < _qmol->components.size(); i++)
         {
-            component_nums.insert(i);
+            component_nums.insert(_qmol->components[i]);
         }
         if (component_nums.size() > 1)
         {
+            std::unique_ptr<QueryMolecule> mol = std::make_unique<QueryMolecule>();
             // decompose _qmol and save each component separately
-            std::list<std::unordered_set<int>> extNeighbors;
-            // fill extNeighbors
+            std::list<std::unordered_set<int>>& extNeighbors = _qmol->getComponentNeighbors();
             int fragment_count = _qmol->countComponents(extNeighbors);
             for (int i = 0; i < fragment_count; ++i)
             {
@@ -94,9 +94,9 @@ void SmilesSaver::saveQueryMolecule(QueryMolecule& mol)
                 auto fragment = std::make_unique<QueryMolecule>();
                 Filter filt(_qmol->getDecomposition().ptr(), Filter::EQ, i);
                 fragment->makeSubmolecule(*_qmol, filt, &mapping, 0);
+                mol->mergeWithMolecule(*fragment, 0);
                 saveQueryMolecule(*fragment);
             }
-            _saveMolecule();
         }
         else
         {

--- a/core/indigo-core/molecule/src/smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/smiles_saver.cpp
@@ -189,7 +189,7 @@ void SmilesSaver::_saveMolecule()
     v_to_comp_group.resize(v_seq.size());
     v_to_comp_group.fffill();
 
-    if (_qmol != nullptr && smarts_mode)
+    if (_qmol != nullptr && smarts_mode && _qmol->components.size() >= v_seq.size())
     {
         if (v_seq.size() < 1)
             return; // No atoms to save
@@ -657,7 +657,7 @@ void SmilesSaver::_saveMolecule()
                 _output.writeString("{+n}");
         }
     }
-    if (smarts_mode && v_to_comp_group[i - 1]) // if group set for last fragment - add finish )
+    if (smarts_mode && v_to_comp_group[i - 1] > 0) // if group set for last fragment - add finish )
         _output.writeChar(')');
 
     if (write_extra_info && chemaxon && !smarts_mode) // no extended block in SMARTS

--- a/core/indigo-core/reaction/src/rsmiles_loader.cpp
+++ b/core/indigo-core/reaction/src/rsmiles_loader.cpp
@@ -128,7 +128,7 @@ void RSmilesLoader::_loadReaction()
     {
         rcnt = std::make_unique<QueryMolecule>();
         r_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*rcnt));
-        rcnt_extNeibs = static_cast<QueryMolecule&>(*rcnt).getComponentNeighbors();
+        static_cast<QueryMolecule&>(*rcnt).getComponentNeighbors(rcnt_extNeibs);
     }
     rcnt_aam.copy(rcnt->reaction_atom_mapping);
 
@@ -162,7 +162,7 @@ void RSmilesLoader::_loadReaction()
     {
         ctlt = std::make_unique<QueryMolecule>();
         c_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*ctlt));
-        ctlt_extNeibs = static_cast<QueryMolecule&>(*ctlt).getComponentNeighbors();
+        static_cast<QueryMolecule&>(*ctlt).getComponentNeighbors(ctlt_extNeibs);
     }
     ctlt_aam.copy(ctlt->reaction_atom_mapping);
 
@@ -202,7 +202,7 @@ void RSmilesLoader::_loadReaction()
     {
         prod = std::make_unique<QueryMolecule>();
         p_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*prod));
-        prod_extNeibs = static_cast<QueryMolecule&>(*prod).getComponentNeighbors();
+        static_cast<QueryMolecule&>(*prod).getComponentNeighbors(prod_extNeibs);
     }
     prod_aam.copy(prod->reaction_atom_mapping);
 

--- a/core/indigo-core/reaction/src/rsmiles_loader.cpp
+++ b/core/indigo-core/reaction/src/rsmiles_loader.cpp
@@ -75,25 +75,6 @@ void RSmilesLoader::loadQueryReaction(QueryReaction& rxn)
     _loadReaction();
 }
 
-static void _createComponenetsExternalNeighbors(QueryMolecule& qmol, std::list<std::unordered_set<int>>& externNeib)
-{
-    std::unordered_map<int, std::unordered_set<int>> componentAtoms;
-    for (int i = 0; i < qmol.components.size(); ++i)
-    {
-        int componentId = qmol.components[i];
-        if (componentId > 0)
-        { // vertice[i] belongs to component #Id
-            componentAtoms[componentId].insert(i);
-        }
-    }
-    for (auto elem : componentAtoms)
-    {
-        auto atoms = elem.second;
-        if (atoms.size() > 1)
-            externNeib.emplace_back(atoms);
-    }
-}
-
 void RSmilesLoader::_loadReaction()
 {
     _brxn->clear();
@@ -147,7 +128,7 @@ void RSmilesLoader::_loadReaction()
     {
         rcnt = std::make_unique<QueryMolecule>();
         r_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*rcnt));
-        _createComponenetsExternalNeighbors(static_cast<QueryMolecule&>(*rcnt), rcnt_extNeibs);
+        rcnt_extNeibs = static_cast<QueryMolecule&>(*rcnt).getComponentNeighbors();
     }
     rcnt_aam.copy(rcnt->reaction_atom_mapping);
 
@@ -181,7 +162,7 @@ void RSmilesLoader::_loadReaction()
     {
         ctlt = std::make_unique<QueryMolecule>();
         c_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*ctlt));
-        _createComponenetsExternalNeighbors(static_cast<QueryMolecule&>(*ctlt), ctlt_extNeibs);
+        ctlt_extNeibs = static_cast<QueryMolecule&>(*ctlt).getComponentNeighbors();
     }
     ctlt_aam.copy(ctlt->reaction_atom_mapping);
 
@@ -221,7 +202,7 @@ void RSmilesLoader::_loadReaction()
     {
         prod = std::make_unique<QueryMolecule>();
         p_loader.loadQueryMolecule(static_cast<QueryMolecule&>(*prod));
-        _createComponenetsExternalNeighbors(static_cast<QueryMolecule&>(*prod), prod_extNeibs);
+        prod_extNeibs = static_cast<QueryMolecule&>(*prod).getComponentNeighbors();
     }
     prod_aam.copy(prod->reaction_atom_mapping);
 

--- a/core/indigo-core/reaction/src/rsmiles_saver.cpp
+++ b/core/indigo-core/reaction/src/rsmiles_saver.cpp
@@ -146,7 +146,7 @@ void RSmilesSaver::_saveReaction()
         _writeMolecule(i);
     }
 
-    if (chemaxon)
+    if (chemaxon && !smarts_mode)
     {
         _comma = false;
         _writeFragmentsInfo();

--- a/core/indigo-core/tests/tests/formats.cpp
+++ b/core/indigo-core/tests/tests/formats.cpp
@@ -323,3 +323,23 @@ M  END
     saver.saveMolecule(t_mol);
     ASSERT_EQ(t_mol.sgroups.getSGroupCount(), 0);
 }
+
+TEST_F(IndigoCoreFormatsTest, smarts_load_save)
+{
+    QueryMolecule q_mol;
+
+    //std::string smarts_in{"([#8:1].[#6:2])"};
+    std::string smarts_in{"([#8:1].[#6:2]).([#8:1].[#6:2])"};
+    BufferScanner scanner(smarts_in.c_str());
+    SmilesLoader loader(scanner);
+    loader.smarts_mode = true;
+    loader.loadQueryMolecule(q_mol);
+    Array<char> out;
+    ArrayOutput std_out(out);
+    SmilesSaver saver(std_out);
+    saver.smarts_mode = true;
+    saver.saveQueryMolecule(q_mol);
+    std::string smarts_out{out.ptr(), static_cast<std::size_t>(out.size())};
+    printf("smart_in=%s\nsmart_out=%s\n", smarts_in, smarts_out);
+}
+

--- a/core/indigo-core/tests/tests/formats.cpp
+++ b/core/indigo-core/tests/tests/formats.cpp
@@ -328,7 +328,6 @@ TEST_F(IndigoCoreFormatsTest, smarts_load_save)
 {
     QueryMolecule q_mol;
 
-    //std::string smarts_in{"([#8:1].[#6:2])"};
     std::string smarts_in{"([#8].[#6]).([#6].[#8])"};
     BufferScanner scanner(smarts_in.c_str());
     SmilesLoader loader(scanner);
@@ -342,4 +341,3 @@ TEST_F(IndigoCoreFormatsTest, smarts_load_save)
     std::string smarts_out{out.ptr(), static_cast<std::size_t>(out.size())};
     ASSERT_EQ(smarts_in, smarts_out);
 }
-

--- a/core/indigo-core/tests/tests/formats.cpp
+++ b/core/indigo-core/tests/tests/formats.cpp
@@ -329,7 +329,7 @@ TEST_F(IndigoCoreFormatsTest, smarts_load_save)
     QueryMolecule q_mol;
 
     //std::string smarts_in{"([#8:1].[#6:2])"};
-    std::string smarts_in{"([#8:1].[#6:2]).([#8:1].[#6:2])"};
+    std::string smarts_in{"([#8].[#6]).([#6].[#8])"};
     BufferScanner scanner(smarts_in.c_str());
     SmilesLoader loader(scanner);
     loader.smarts_mode = true;
@@ -340,6 +340,6 @@ TEST_F(IndigoCoreFormatsTest, smarts_load_save)
     saver.smarts_mode = true;
     saver.saveQueryMolecule(q_mol);
     std::string smarts_out{out.ptr(), static_cast<std::size_t>(out.size())};
-    printf("smart_in=%s\nsmart_out=%s\n", smarts_in, smarts_out);
+    ASSERT_EQ(smarts_in, smarts_out);
 }
 

--- a/core/indigo-core/tests/tests/reaction.cpp
+++ b/core/indigo-core/tests/tests/reaction.cpp
@@ -20,6 +20,7 @@
 
 #include <base_cpp/output.h>
 #include <reaction/reaction.h>
+#include <reaction/rsmiles_saver.h>
 
 #include "common.h"
 
@@ -99,4 +100,12 @@ TEST_F(IndigoCoreReactionTest, smarts_reaction)
     loadQueryReaction(smarts_in.c_str(), qr);
     ASSERT_EQ(qr.reactantsCount(), 1);
     ASSERT_EQ(qr.productsCount(), 1);
+    Array<char> out;
+    ArrayOutput std_out(out);
+    RSmilesSaver saver(std_out);
+    saver.smarts_mode = true;
+    saver.saveQueryReaction(qr);
+    out.push(0);
+    std::string smarts_out{out.ptr()};
+    ASSERT_EQ(smarts_in, smarts_out);
 }

--- a/core/indigo-core/tests/tests/reaction.cpp
+++ b/core/indigo-core/tests/tests/reaction.cpp
@@ -66,7 +66,7 @@ TEST_F(IndigoCoreReactionTest, aliases_complex)
     QueryReaction reaction;
     loadQueryReaction("[#6:1]=[#6:2][#6:3].[#6:4]=[#6:5][#6:6]>>[#6:3][#6:2]=[#6:5][#6:6] |$;;R1;;;R2;R1;;;R2$|", reaction);
     reaction.clearAAM();
-    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6] |$;;R1;;;R2;R1;;;R2$|", saveReactionSmiles(reaction, true).c_str());
+    ASSERT_STREQ("[#6]=[#6]-[#6].[#6]=[#6]-[#6]>>[#6]-[#6]=[#6]-[#6]", saveReactionSmiles(reaction, true).c_str());
     ASSERT_STREQ("$RXN\n\n -INDIGO- 0100000000\n\n  2  1\n$MOL\n\n  -INDIGO-01000000002D\n\n  3  2  0  0  0  0  0  0  0  0999 V2000\n    0.0000    0.0000    "
                  "0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.0000    0.0000   "
                  " 0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  2  0  0  0  0\n  2  3  1  0  0  0  0\nA    3\nR1\nM  END\n$MOL\n\n  "


### PR DESCRIPTION
Add '()' save support. Add UTs.