### PR TITLE
 #1287 New S-Group type Query component level grouping

### DIFF
--- a/core/indigo-core/molecule/src/molecule_json_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_loader.cpp
@@ -865,6 +865,8 @@ void MoleculeJsonLoader::parseSGroups(const rapidjson::Value& sgroups, BaseMolec
                     _pqmol->components[atom_idx] = components_count;
                 }
             }
+            else
+                throw Error("queryProperties is allowed only for queries");
             continue;
         }
         int sg_type = SGroup::getType(sg_type_str.c_str());


### PR DESCRIPTION
Raise exception when ket with queryComponent loadad as Molecule. 
Such ket files should be loaded as QueryMolecule.
Also fix autoload and convert in Ketcher.