### PR TITLE
 Fix pylint error "too many arguments"

### DIFF
--- a/.github/workflows/indigo-ci.yaml
+++ b/.github/workflows/indigo-ci.yaml
@@ -676,7 +676,7 @@ jobs:
           python setup.py bdist_wheel
           cp dist/*.whl ${GITHUB_WORKSPACE}/dist/
       - name: Run pylint
-        run: pylint bingo_elastic
+        run: pylint --max-args 10 bingo_elastic
         working-directory: bingo/bingo-elastic/python
       - name: Run tests
         run: pytest tests


### PR DESCRIPTION
Use "--max-args 10" pylint option to prevent "too many arguments" error