### PR TITLE
 #1281 Support SMARTS "or unspecified" bond property

### DIFF
--- a/api/tests/integration/ref/formats/smarts.py.out
+++ b/api/tests/integration/ref/formats/smarts.py.out
@@ -35,3 +35,6 @@ CC[C+5]CCCCC
 [#9]\[#6]=[#6]/[#6]=[#6]\[#6] is ok. smarts_in==smarts_out
 [#9]\[#6]=[#6]/[#6]=[#6]\[#6] is ok. json_in==json_out
 [#9]\[#6]=[#6]/[#6]=[#6]\[#6] is ok. expected string found in json
+[#9]\?[#6]=[#6]/?[#6]=[#6]\?[#6] is ok. smarts_in==smarts_out
+[#9]\?[#6]=[#6]/?[#6]=[#6]\?[#6] is ok. json_in==json_out
+[#9]\?[#6]=[#6]/?[#6]=[#6]\?[#6] is ok. expected string found in json

--- a/api/tests/integration/tests/formats/smarts.py
+++ b/api/tests/integration/tests/formats/smarts.py
@@ -152,3 +152,7 @@ expected_str = '"bonds":[{"type":1,"atoms":[0,1],"stereo":6},{"type":2,"atoms":[
 test_smarts_load_save_through_ket(
     "[#9]\[#6]=[#6]/[#6]=[#6]\[#6]", expected_str
 )
+expected_str = '"bonds":[{"type":1,"customQuery":"\\\?","atoms":[0,1]},{"type":2,"atoms":[1,2]},{"type":1,"customQuery":"/?","atoms":[2,3]},{"type":2,"atoms":[3,4]},{"type":1,"customQuery":"\\\?","atoms":[4,5]}]'
+test_smarts_load_save_through_ket(
+    "[#9]\?[#6]=[#6]/?[#6]=[#6]\?[#6]", expected_str
+)

--- a/core/indigo-core/molecule/base_molecule.h
+++ b/core/indigo-core/molecule/base_molecule.h
@@ -79,7 +79,9 @@ namespace indigo
     {
         BOND_UP = 1,
         BOND_DOWN = 2,
-        BOND_EITHER = 3
+        BOND_EITHER = 3,
+        BOND_UP_OR_UNSPECIFIED = 4,
+        BOND_DOWN_OR_UNSPECIFIED = 5,
     };
 
     enum

--- a/core/indigo-core/molecule/src/molecule_json_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_saver.cpp
@@ -439,12 +439,13 @@ void MoleculeJsonSaver::saveBonds(BaseMolecule& mol, JsonWriter& writer)
             {
                 QueryMolecule::Bond& qbond = _pqmol->getBond(i);
                 int bond_order = QueryMolecule::getQueryBondType(qbond, direction, negative);
-                if (bond_order < 0 || negative)
+                if (bond_order < 0 || negative || direction == BOND_UP_OR_UNSPECIFIED || direction == BOND_DOWN_OR_UNSPECIFIED)
                 {
                     writer.Uint(BOND_SINGLE);
                     std::string customQuery = QueryMolecule::getSmartsBondStr(&qbond);
                     writer.Key("customQuery");
                     writer.String(customQuery.c_str());
+                    direction = BOND_ZERO; // clean up to not override stereo
                 }
                 else
                 {
@@ -457,6 +458,9 @@ void MoleculeJsonSaver::saveBonds(BaseMolecule& mol, JsonWriter& writer)
                         break;
                     case BOND_DOWN:
                         direction = BIOVIA_STEREO_DOWN;
+                        break;
+                    default:
+                        direction = BOND_ZERO; // clean up to not override stereo
                         break;
                     }
                 }

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -377,6 +377,10 @@ void QueryMolecule::writeSmartsBond(Output& output, Bond* bond, bool has_or_pare
                 output.writeChar('/');
             else if (bond->direction == BOND_DOWN)
                 output.writeChar('\\');
+            else if (bond->direction == BOND_UP_OR_UNSPECIFIED)
+                output.writeString("/?");
+            else if (bond->direction == BOND_DOWN_OR_UNSPECIFIED)
+                output.writeString("\\?");
             else
                 output.writeChar('-');
         }

--- a/core/indigo-core/molecule/src/smiles_loader.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader.cpp
@@ -2583,7 +2583,17 @@ void SmilesLoader::_readBondSub(Array<char>& bond_str, _BondDesc& bond, std::uni
         {
             scanner.skip(1);
             if (smarts_mode)
-                direction = BOND_UP;
+            {
+                if (scanner.lookNext() == '?')
+                {
+                    direction = BOND_UP_OR_UNSPECIFIED;
+                    scanner.skip(1);
+                }
+                else
+                {
+                    direction = BOND_UP;
+                }
+            }
             order = BOND_SINGLE;
             if (bond.dir == 2)
                 throw Error("Specificiation of both cis- and trans- bond restriction is not supported yet.");
@@ -2593,7 +2603,17 @@ void SmilesLoader::_readBondSub(Array<char>& bond_str, _BondDesc& bond, std::uni
         {
             scanner.skip(1);
             if (smarts_mode)
-                direction = BOND_DOWN;
+            {
+                if (scanner.lookNext() == '?')
+                {
+                    direction = BOND_DOWN_OR_UNSPECIFIED;
+                    scanner.skip(1);
+                }
+                else
+                {
+                    direction = BOND_DOWN;
+                }
+            }
             order = BOND_SINGLE;
             if (bond.dir == 1)
                 throw Error("Specificiation of both cis- and trans- bond restriction is not supported yet.");


### PR DESCRIPTION
Add support for SMARTS "/?" "\?" (up/down or unspecified)
Add UT