### PR TITLE
 #1372 Wildcard symbol ('any') with logical operators at custom query for bond is missing at SMARTS

### DIFF
--- a/api/tests/integration/ref/formats/smarts.py.out
+++ b/api/tests/integration/ref/formats/smarts.py.out
@@ -96,3 +96,7 @@ Smarts [C]!-[C] loaded as smarts - OK.
 Smarts [C]-,=[C] loaded as smarts - OK.
 Smarts [C]-;=[C] loaded as smarts - OK.
 Smarts [C]-&=[C] loaded as smarts - OK.
+*******  Any wildcard '~' in bond custom query *******
+[#7]~,-[#6] is ok. smarts_in==smarts_out
+[#7]~,-[#6] is ok. json_in==json_out
+[#7]~,-[#6] is ok. expected string found in json

--- a/api/tests/integration/tests/formats/smarts.py
+++ b/api/tests/integration/tests/formats/smarts.py
@@ -244,3 +244,7 @@ for smarts in smarts_list:
         print("Smarts %s loaded as smarts - OK." % smarts)
     else:
         print("Smarts %s loaded as %s - FAILED" % (smarts, format))
+print("*******  Any wildcard '~' in bond custom query *******")
+smarts = "[#7]~,-[#6]"
+expected = '"bonds":[{"customQuery":"~,-","atoms":[0,1]}]}}'
+test_smarts_load_save_through_ket(smarts, expected)

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -102,6 +102,7 @@ namespace indigo
 
             BOND_ORDER,
             BOND_TOPOLOGY,
+            BOND_ANY,
 
             HIGHLIGHTING
         };
@@ -248,6 +249,7 @@ namespace indigo
         {
         public:
             Bond();
+            Bond(int type_);
             Bond(int type_, int value_);
             Bond(int type_, int value_, int direction_);
             ~Bond() override;

--- a/core/indigo-core/molecule/src/molecule_substructure_matcher.cpp
+++ b/core/indigo-core/molecule/src/molecule_substructure_matcher.cpp
@@ -541,6 +541,8 @@ bool MoleculeSubstructureMatcher::matchQueryBond(QueryMolecule::Bond* query, Bas
     case QueryMolecule::OP_NOT:
         return !matchQueryBond(query->child(0), target, sub_idx, super_idx, am, flags ^ MATCH_DISABLED_AS_TRUE);
 
+    case QueryMolecule::BOND_ANY:
+        return true;
     case QueryMolecule::BOND_ORDER: {
         if (flags & MATCH_BOND_TYPE)
         {

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -399,6 +399,10 @@ void QueryMolecule::writeSmartsBond(Output& output, Bond* bond, bool has_or_pare
             output.writeString("!@");
         break;
     }
+    case BOND_ANY: {
+        output.writeChar('~');
+        break;
+    }
     default:
         throw Error("Unexpected bond type: %d", bond->type);
     }
@@ -743,6 +747,9 @@ void QueryMolecule::_getBondDescription(Bond* bond, Output& out)
     case BOND_TOPOLOGY:
         out.printf("%s", bond->value == TOPOLOGY_RING ? "ring" : "chain");
         return;
+    case BOND_ANY:
+        out.writeChar('~');
+        return;
     default:
         out.printf("<constraint of type %d>", bond->type);
     }
@@ -928,6 +935,10 @@ QueryMolecule::Atom::~Atom()
 }
 
 QueryMolecule::Bond::Bond() : Node(OP_NONE), value(0), direction(0)
+{
+}
+
+QueryMolecule::Bond::Bond(int type_) : Node(type_), value(0), direction(0)
 {
 }
 

--- a/core/indigo-core/molecule/src/smiles_loader.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader.cpp
@@ -2636,6 +2636,13 @@ void SmilesLoader::_readBondSub(Array<char>& bond_str, _BondDesc& bond, std::uni
         else if (order == _ANY_BOND)
         {
             bond.type = order;
+            if (qbond.get() != 0)
+            {
+                if (subqbond.get() == 0)
+                    subqbond = std::make_unique<QueryMolecule::Bond>(QueryMolecule::BOND_ANY);
+                else
+                    subqbond.reset(QueryMolecule::Bond::und(subqbond.release(), new QueryMolecule::Bond(QueryMolecule::BOND_ANY)));
+            }
         }
 
         if (topology > 0)


### PR DESCRIPTION
Fix code, add UT.