### PR TITLE
 #1522 A lot of warning when compile indigo-core-unit-tests

### DIFF
--- a/api/c/bingo-nosql/src/mmf/mmf_allocator.cpp
+++ b/api/c/bingo-nosql/src/mmf/mmf_allocator.cpp
@@ -118,7 +118,7 @@ void MMFAllocator::_addFile(size_t alloc_size)
     {
         if (alloc_size <= file_size)
         {
-            int dgr = log(file_size / allocator_data->_min_file_size);
+            int dgr = static_cast<int>(log(file_size / allocator_data->_min_file_size));
             bitSetBit(&allocator_data->_existing_files, dgr, 1);
 
             break;

--- a/api/c/indigo/src/option_manager.h
+++ b/api/c/indigo/src/option_manager.h
@@ -19,6 +19,11 @@
 #ifndef __otion_manager_h__
 #define __otion_manager_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/os_sync_wrapper.h"
 #include "base_cpp/red_black.h"
 
@@ -185,5 +190,9 @@ protected:
 private:
     IndigoOptionManager(const IndigoOptionManager&);
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif //__otion_manager_h__

--- a/api/cpp/tests/basic/basic.cpp
+++ b/api/cpp/tests/basic/basic.cpp
@@ -64,11 +64,11 @@ TEST(Basic, MolecularWeight)
     auto session = IndigoSession::create();
     {
         const auto plainAtom = session->loadMolecule("[C]");
-        ASSERT_FLOAT_EQ(plainAtom.molecularWeight(), 12.0107);
+        ASSERT_FLOAT_EQ(plainAtom.molecularWeight(), 12.0107f);
     }
     {
         const auto correctIsotope = session->loadMolecule("[13C]");
-        ASSERT_FLOAT_EQ(correctIsotope.molecularWeight(), 13.003355);
+        ASSERT_FLOAT_EQ(correctIsotope.molecularWeight(), 13.003355f);
     }
     {
         const auto incorrectIsotope = session->loadMolecule("[60C]");

--- a/core/indigo-core/CMakeLists.txt
+++ b/core/indigo-core/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.6)
 
 project(indigo-core LANGUAGES C CXX)
 
+if (MSVC)
+    string(APPEND CMAKE_C_FLAGS " -W3 -WX")
+    string(APPEND CMAKE_CXX_FLAGS " -W3 -WX")
+endif ()
+
 file(GLOB_RECURSE ${PROJECT_NAME}_SOURCES CONFIUGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/common/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/common/*.cpp

--- a/core/indigo-core/CMakeLists.txt
+++ b/core/indigo-core/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.6)
 project(indigo-core LANGUAGES C CXX)
 
 if (MSVC)
-    string(APPEND CMAKE_C_FLAGS " -W3 -WX")
-    string(APPEND CMAKE_CXX_FLAGS " -W3 -WX")
+    string(APPEND CMAKE_C_FLAGS " -WX")
+    string(APPEND CMAKE_CXX_FLAGS " -WX")
 endif ()
 
 file(GLOB_RECURSE ${PROJECT_NAME}_SOURCES CONFIUGURE_DEPENDS

--- a/core/indigo-core/CMakeLists.txt
+++ b/core/indigo-core/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.6)
 project(indigo-core LANGUAGES C CXX)
 
 if (MSVC)
-    string(APPEND CMAKE_C_FLAGS " -WX")
-    string(APPEND CMAKE_CXX_FLAGS " -WX")
+    string(APPEND CMAKE_C_FLAGS " -W3 -WX")
+    string(APPEND CMAKE_CXX_FLAGS " -W3  -WX")
 endif ()
 
 file(GLOB_RECURSE ${PROJECT_NAME}_SOURCES CONFIUGURE_DEPENDS

--- a/core/indigo-core/common/base_cpp/array.h
+++ b/core/indigo-core/common/base_cpp/array.h
@@ -580,11 +580,4 @@ namespace indigo
 
 } // namespace indigo
 
-// operators defined here for use with ObjArray<> and ObjPool<>
-template <typename T>
-void* operator new(size_t size, T* allocated_area)
-{
-    return allocated_area;
-}
-
 #endif

--- a/core/indigo-core/common/base_cpp/cancellation_handler.cpp
+++ b/core/indigo-core/common/base_cpp/cancellation_handler.cpp
@@ -38,7 +38,7 @@ bool TimeoutCancellationHandler::isCancelled()
     if (_mseconds > 0)
     {
         qword dif_time = nanoClock() - _currentTime;
-        if (static_cast<size_t>(nanoHowManySeconds(dif_time)) * 1000 > _mseconds)
+        if (static_cast<long>(nanoHowManySeconds(dif_time)) * 1000 > _mseconds)
         {
             StringOutput mes_out(_message);
             mes_out.printf("The operation timed out: %d ms", _mseconds);

--- a/core/indigo-core/common/base_cpp/cancellation_handler.h
+++ b/core/indigo-core/common/base_cpp/cancellation_handler.h
@@ -18,6 +18,11 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <memory>
 #include <string>
 
@@ -80,3 +85,7 @@ namespace indigo
         ~AutoCancellationHandler();
     };
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/common/base_cpp/chunk_storage.cpp
+++ b/core/indigo-core/common/base_cpp/chunk_storage.cpp
@@ -55,7 +55,7 @@ void ChunkStorage::add(const Array<char>& data)
 
 void ChunkStorage::add(const char* str)
 {
-    add((const byte*)str, strlen(str) + 1);
+    add(reinterpret_cast<const byte*>(str), static_cast<int>(strlen(str) + 1));
 }
 
 byte* ChunkStorage::get(int i)

--- a/core/indigo-core/common/base_cpp/exception.h
+++ b/core/indigo-core/common/base_cpp/exception.h
@@ -19,6 +19,11 @@
 #ifndef __exception_h__
 #define __exception_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4275)
+#endif
+
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
@@ -99,5 +104,9 @@ public                                                                          
 #define IMPL_TIMEOUT_EXCEPTION(Namespace, prefix) IMPL_EXCEPTION(Namespace, TimeoutException, prefix " timeout")
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // __exception_h__

--- a/core/indigo-core/common/base_cpp/os_sync_wrapper.h
+++ b/core/indigo-core/common/base_cpp/os_sync_wrapper.h
@@ -19,6 +19,11 @@
 #ifndef __os_sync_wrapper_h__
 #define __os_sync_wrapper_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <condition_variable>
 #include <mutex>
 
@@ -70,5 +75,9 @@ namespace indigo
         void* volatile _localParam;
     };
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // __os_sync_wrapper_h__

--- a/core/indigo-core/common/base_cpp/profiling.h
+++ b/core/indigo-core/common/base_cpp/profiling.h
@@ -18,6 +18,11 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <atomic>
 #include <safe_ptr.h>
 
@@ -148,3 +153,7 @@ namespace indigo
         qword _start_time, _dt;
     };
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/common/base_cpp/properties_map.h
+++ b/core/indigo-core/common/base_cpp/properties_map.h
@@ -19,6 +19,11 @@
 #ifndef __properties_map_h__
 #define __properties_map_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/array.h"
 #include "base_cpp/auto_iter.h"
 #include "base_cpp/exception.h"
@@ -93,5 +98,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // __auto_iter_h__

--- a/core/indigo-core/common/base_cpp/scanner.cpp
+++ b/core/indigo-core/common/base_cpp/scanner.cpp
@@ -533,7 +533,7 @@ void Scanner::readAll(std::string& str)
         throw Error("Cannot read more than %d into memory", max_int);
     }
     str.resize(size);
-    read(str.size(), &str[0]);
+    read(static_cast<int>(str.size()), &str[0]);
 }
 
 void Scanner::readAll(Array<char>& arr)
@@ -737,7 +737,7 @@ void BufferScanner::_init(const char* buffer, int size)
     {
         std::string encoded(buffer, size);
         auto decoded = base64::decode(encoded.c_str(), encoded.size());
-        _base64_buffer.copy((char*)decoded.data(), decoded.size());
+        _base64_buffer.copy(reinterpret_cast<const char*>(decoded.data()), static_cast<int>(decoded.size()));
         _buffer = _base64_buffer.ptr();
         _size = _base64_buffer.size();
     }

--- a/core/indigo-core/common/base_cpp/scanner.cpp
+++ b/core/indigo-core/common/base_cpp/scanner.cpp
@@ -449,12 +449,12 @@ void Scanner::readCharsFix(int n, char* chars_out)
 
 int Scanner::readCharsFlexible(int n, char* chars_out)
 {
-    size_t i = 0;
+    int i = 0;
     while ((i < n) && !isEOF())
     {
         chars_out[i++] = readChar();
     }
-    return (int)i;
+    return i;
 }
 
 word Scanner::readBinaryWord()
@@ -532,7 +532,7 @@ void Scanner::readAll(std::string& str)
     {
         throw Error("Cannot read more than %d into memory", max_int);
     }
-    str.resize(size);
+    str.resize(static_cast<size_t>(size));
     read(static_cast<int>(str.size()), &str[0]);
 }
 

--- a/core/indigo-core/common/base_cpp/scanner.h
+++ b/core/indigo-core/common/base_cpp/scanner.h
@@ -19,6 +19,11 @@
 #ifndef __scanner_h__
 #define __scanner_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/array.h"
 #include "base_cpp/io_base.h"
 #include "base_cpp/obj_array.h"
@@ -157,5 +162,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/common/base_cpp/smart_output.cpp
+++ b/core/indigo-core/common/base_cpp/smart_output.cpp
@@ -94,7 +94,7 @@ void SmartTableOutput::flush()
 void SmartTableOutput::setLineFormat(const char* line_format)
 {
     Array<char>& format = _line_formats.push();
-    format.copy(line_format, strlen(line_format));
+    format.copy(line_format, static_cast<int>(strlen(line_format)));
     _line_format_index.top() = _line_formats.size() - 1;
 }
 

--- a/core/indigo-core/common/base_cpp/string_pool.cpp
+++ b/core/indigo-core/common/base_cpp/string_pool.cpp
@@ -45,7 +45,7 @@ int StringPool::_add(const char* str, int size)
         throw Error("Internal error: size == -1 && str == 0");
 
     if (size == -1)
-        size = strlen(str);
+        size = static_cast<int>(strlen(str));
     _storage.at(idx).resize(size + 1);
     if (str != 0 && size != 0)
         memcpy(at(idx), str, size);
@@ -55,7 +55,7 @@ int StringPool::_add(const char* str, int size)
 
 void StringPool::set(int idx, const char* str)
 {
-    int size = strlen(str);
+    int size = static_cast<int>(strlen(str));
     _storage.at(idx).resize(size + 1);
     if (str != 0 && size != 0)
         memcpy(at(idx), str, size);

--- a/core/indigo-core/common/base_cpp/tree.h
+++ b/core/indigo-core/common/base_cpp/tree.h
@@ -28,31 +28,31 @@ namespace indigo
     class Tree : public NonCopyable
     {
     public:
-        explicit Tree(int label)
+        explicit Tree(int nlabel)
         {
-            this->label = label;
+            this->label = nlabel;
         }
 
         Tree() : Tree(-1)
         {
         }
 
-        void insert(int label, int parent)
+        void insert(int nlabel, int parent)
         {
             Tree* present = _find(parent);
             if (present != nullptr)
             {
-                present->_insert(label);
+                present->_insert(nlabel);
             }
             else
             {
-                _insert(parent)._insert(label);
+                _insert(parent)._insert(nlabel);
             }
         }
 
-        void insert(int label)
+        void insert(int nlabel)
         {
-            insert(label, -1);
+            insert(nlabel, -1);
         }
 
         ObjArray<Tree>& children()
@@ -67,31 +67,31 @@ namespace indigo
 
         int label;
 
-        inline Tree* find(int label)
+        inline Tree* find(int nlabel)
         {
-            return _find(label);
+            return _find(nlabel);
         }
 
     protected:
-        Tree& _insert(int label)
+        Tree& _insert(int nlabel)
         {
-            return _children.push(label);
+            return _children.push(nlabel);
         }
 
-        Tree* _find(int label)
+        Tree* _find(int nlabel)
         {
-            if (this->label == label)
+            if (this->label == nlabel)
             {
                 return this;
             }
             for (auto i = 0; i < _children.size(); i++)
             {
                 Tree& child = _children[i];
-                if (child.label == label)
+                if (child.label == nlabel)
                 {
                     return &child;
                 }
-                Tree* deeper = child._find(label);
+                Tree* deeper = child._find(nlabel);
                 if (deeper != nullptr)
                 {
                     return deeper;

--- a/core/indigo-core/common/math/random.cpp
+++ b/core/indigo-core/common/math/random.cpp
@@ -35,7 +35,7 @@ unsigned int Random::next(int mod)
     if (mod > 0)
         return next() % mod;
     if (mod < 0)
-        return -(next() % -mod);
+        return next() % -mod;
     return 0;
 }
 
@@ -50,7 +50,7 @@ unsigned int Random::nextLarge(int mod)
     if ((1LL << 32) - x > mod)
         return x % mod;
 
-    int max = (1LL << 32) - (1LL << 32) % mod;
+    int max = static_cast<int>((1LL << 32) - (1LL << 32) % mod);
     if (x < max)
         return x % mod;
     return nextLarge(mod);

--- a/core/indigo-core/graph/graph_perfect_matching.h
+++ b/core/indigo-core/graph/graph_perfect_matching.h
@@ -72,12 +72,12 @@ namespace indigo
         void setPath(int* path, int length);
         void clearPath(void);
 
-        virtual bool checkVertex(int v_idx)
+        virtual bool checkVertex(int /*v_idx*/)
         {
             return true;
         }
         // e_idx - edge index in graph (not mapping)
-        virtual bool checkEdge(int e_idx)
+        virtual bool checkEdge(int /*e_idx*/)
         {
             return true;
         }

--- a/core/indigo-core/layout/molecule_cleaner_2d.h
+++ b/core/indigo-core/layout/molecule_cleaner_2d.h
@@ -19,6 +19,11 @@
 #ifndef __molecule_cleaner_2d__
 #define __molecule_cleaner_2d__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/array.h"
 #include "base_cpp/non_copyable.h"
 #include "base_cpp/obj_array.h"
@@ -109,5 +114,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // __molecule_cleaner_2d__

--- a/core/indigo-core/layout/molecule_layout_macrocycles.h
+++ b/core/indigo-core/layout/molecule_layout_macrocycles.h
@@ -36,7 +36,7 @@ namespace indigo
     static const int WEIGHT_FACTOR = 12;
     static const int SIX = 6;
 
-    static int get_weight(int weight, int rotate)
+    inline int get_weight(int weight, int rotate)
     {
         if (abs(weight) <= WEIGHT_FACTOR)
             return 0;

--- a/core/indigo-core/layout/src/molecule_cleaner_2d.cpp
+++ b/core/indigo-core/layout/src/molecule_cleaner_2d.cpp
@@ -470,7 +470,7 @@ void MoleculeCleaner2d::_uniteBondsOnLine()
     for (int i = 0; i < valid_list.size(); i++)
         valid_index[valid_list[i]] = i;
 
-    QS_DEF(ObjArray<Array<int>>, new_in);
+    QS_DEF(ObjArray<Array<bool>>, new_in);
     new_in.clear();
 
     for (int i = 0; i < new_component_count; i++)

--- a/core/indigo-core/layout/src/molecule_cleaner_2d.cpp
+++ b/core/indigo-core/layout/src/molecule_cleaner_2d.cpp
@@ -1133,8 +1133,8 @@ bool MoleculeCleaner2d::_isZero()
     bool is_zero = true;
     for (int v = _mol.vertexBegin(); v != _mol.vertexEnd(); v = _mol.vertexNext(v))
     {
-        is_zero = is_zero & _mol.getAtomXyz(v).x == 0;
-        is_zero = is_zero & _mol.getAtomXyz(v).y == 0;
+        is_zero = is_zero && _mol.getAtomXyz(v).x == 0;
+        is_zero = is_zero && _mol.getAtomXyz(v).y == 0;
     }
     return is_zero;
 }

--- a/core/indigo-core/layout/src/molecule_layout_graph_assign_smart.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_graph_assign_smart.cpp
@@ -61,7 +61,7 @@ static int _vertex_cmp(int& n1, int& n2, void* context)
     return v1.morgan_code - v2.morgan_code;
 }
 
-void MoleculeLayoutGraphSmart::_assignAbsoluteCoordinates(float bond_length)
+void MoleculeLayoutGraphSmart::_assignAbsoluteCoordinates(float /* bond_length */)
 {
     BiconnectedDecomposer bc_decom(*this);
     QS_DEF(Array<int>, bc_tree);
@@ -95,7 +95,7 @@ void MoleculeLayoutGraphSmart::_assignAbsoluteCoordinates(float bond_length)
 
     _findFirstVertexIdx(n_comp, fixed_components, bc_components, all_trivial);
 
-    int i, j = -1;
+    int i = -1;
 
     // ( 1] atoms assigned absolute coordinates and adjacent to atoms not;
     //   assigned coordinates are put on a list;
@@ -326,7 +326,7 @@ void MoleculeLayoutGraphSmart::_assignRelativeCoordinates(int& fixed_component, 
         QS_DEF(Array<int>, unused_count);
         unused_count.clear_resize(cycles.end());
         unused_count.zerofill();
-        for (int i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
+        for (i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
         {
             for (int j = 0; j < cycles[i].vertexCount(); j++)
             {
@@ -334,13 +334,13 @@ void MoleculeLayoutGraphSmart::_assignRelativeCoordinates(int& fixed_component, 
                     unused_count[i]++;
             }
         }
-        for (int i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
+        for (i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
             unused_count[i] *= cycles[i].vertexCount();
-        for (int i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
+        for (i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
             cycles[i].calcMorganCode(supergraph);
 
         int min_i = cycles.begin();
-        for (int i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
+        for (i = cycles.begin(); i != cycles.end(); i = cycles.next(i))
         {
             if (unused_count[i] < unused_count[min_i] || (unused_count[i] == unused_count[min_i] && cycles[i].morganCode() > cycles[min_i].morganCode()))
                 min_i = i;
@@ -353,7 +353,7 @@ void MoleculeLayoutGraphSmart::_assignRelativeCoordinates(int& fixed_component, 
             int separating_component = _search_separated_component(cycles[min_i], interval_list);
             if (separating_component >= 0)
             {
-                for (int i = 0; i < interval_list.size(); i++)
+                for (i = 0; i < interval_list.size(); i++)
                 {
                     int start = interval_list[i].left;
                     int finish = interval_list[i].right;
@@ -715,7 +715,7 @@ void MoleculeLayoutGraphSmart::_assignEveryCycle(const Cycle& cycle)
 
             if (i == segment_count - 1)
             {
-                int x = 5;
+                // int x = 5;
             }
 
             _list_of_vertex.clear_resize(0);
@@ -909,7 +909,7 @@ void MoleculeLayoutGraphSmart::_assignEveryCycle(const Cycle& cycle)
     for (int i = 0; i < size; i++)
         need_to_insert[i] = _layout_vertices[cycle.getVertex(i)].type != ELEMENT_NOT_DRAWN;
 
-    int start = 0;
+    // int start = 0;
 
     bool componentIsWholeCycle = false;
 
@@ -1536,7 +1536,7 @@ void MoleculeLayoutGraphSmart::_segment_smoothing_prepearing(const Cycle& cycle,
         segment_graph.push().makeLayoutSubgraph(*this, segments_filter[i]);
     }
 
-    int segment_count = segment_graph.size();
+    // int segment_count = segment_graph.size();
 
     int current_number = 0;
     for (int i = 0; i < cycle_size; i++)
@@ -1665,20 +1665,20 @@ SmoothingCycle::SmoothingCycle(Array<Vec2f>& p, Array<float>& t_a, ObjArray<Mole
         edge_length[i] = _2FLOAT(s[i].getLength());
 }
 
-void SmoothingCycle::_do_smoothing(int iter_count)
+void SmoothingCycle::_do_smoothing(int /* iter_count */)
 {
     QS_DEF(Array<local_pair_ii>, touching_segments);
     touching_segments.clear();
 
     float coef = 1.0f;
-    float multiplyer = std::max(0.5f, std::min(0.999f, _2FLOAT(1. - 10.0 / iter_count)));
+    // float multiplyer = std::max(0.5f, std::min(0.999f, _2FLOAT(1. - 10.0 / iter_count)));
     for (int i = 0; i < 100; i++, coef *= 0.9f)
     {
         _gradient_step(coef, touching_segments, 0);
     }
 }
 
-void SmoothingCycle::_gradient_step(float coef, Array<local_pair_ii>& touching_segments, bool flag)
+void SmoothingCycle::_gradient_step(float coef, Array<local_pair_ii>& /* touching_segments */, bool /* flag */)
 {
     QS_DEF(Array<Vec2f>, change);
     change.clear_resize(cycle_length);
@@ -1728,7 +1728,7 @@ void SmoothingCycle::_gradient_step(float coef, Array<local_pair_ii>& touching_s
         point[i] -= change[i] * coef;
 }
 
-Vec2f SmoothingCycle::_get_len_derivative(Vec2f current_vector, float target_dist, bool flag)
+Vec2f SmoothingCycle::_get_len_derivative(Vec2f current_vector, float target_dist, bool /* flag */)
 {
     float dist = current_vector.length();
     // dist = std::max(dist, 0.01f);
@@ -1744,15 +1744,15 @@ Vec2f SmoothingCycle::_get_len_derivative(Vec2f current_vector, float target_dis
     return current_vector * -coef;
 }
 
-Vec2f SmoothingCycle::_get_len_derivative_simple(Vec2f current_vector, float target_dist)
+Vec2f SmoothingCycle::_get_len_derivative_simple(Vec2f current_vector, float /* target_dist */)
 {
-    float dist = current_vector.length();
+    // float dist = current_vector.length();
     // dist = std::max(dist, 0.01f);
     float coef = -1; // dist - target_dist;
     return current_vector * -coef;
 }
 
-Vec2f SmoothingCycle::_get_angle_derivative(Vec2f left_point, Vec2f right_point, float target_angle, bool flag)
+Vec2f SmoothingCycle::_get_angle_derivative(Vec2f left_point, Vec2f right_point, float target_angle, bool /* flag */)
 {
     float len1_sq = left_point.lengthSqr();
     float len2_sq = right_point.lengthSqr();

--- a/core/indigo-core/layout/src/molecule_layout_graph_border.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_graph_border.cpp
@@ -541,7 +541,7 @@ void MoleculeLayoutGraphSmart::_getSurroundCycle(Cycle& cycle, Vec2f p) const
     QS_DEF(Array<int>, vertices);
     QS_DEF(Array<int>, edges);
     QS_DEF(Array<Vec2f>, pos);
-    int i, n = 0;
+    int n = 0;
     const float eps = 1e-5f;
 
     Random rand(SOME_MAGIC_INT_FOR_RANDOM_3);

--- a/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
@@ -1041,7 +1041,7 @@ float MoleculeLayoutMacrocyclesLattice::rating(CycleLayout& cl)
             pp.push_back((cl.point[i] * _2FLOAT(cl.edge_length[i] - t) + cl.point[(i + 1) % cl.vertex_count] * _2FLOAT(t)) / _2FLOAT(cl.edge_length[i]));
         }
 
-    int size = pp.size();
+    size_t size = pp.size();
     for (int i = 0; i < size; i++)
         for (int j = 0; j < size; j++)
             if (i != j && (i + 1) % size != j && i != (j + 1) % size)

--- a/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
@@ -328,7 +328,7 @@ void AnswerField::_restore_path(answer_point* path, answer_point finish)
             {
                 path[len].p ^= 1;
 
-                int rot = path[len + 1].rot;
+                // int rot = path[len + 1].rot;
 
                 int add = get_weight(_vertex_weight[len], path[len + 1].p);
 
@@ -502,7 +502,8 @@ IMPL_ERROR(AnswerField, "answer_field");
 
 CP_DEF(AnswerField);
 
-AnswerField::AnswerField(int len, int target_x, int target_y, float target_rotation, int* vertex_weight_link, int* vertex_stereo_link, int* edge_stereo_link)
+AnswerField::AnswerField(int len, int target_x, int target_y, float /* target_rotation */, int* vertex_weight_link, int* vertex_stereo_link,
+                         int* edge_stereo_link)
     : CP_INIT, TL_CP_GET(_vertex_weight), // tree size
       TL_CP_GET(_vertex_stereo),          // there is an angle in the vertex
       TL_CP_GET(_edge_stereo),            // trans-cis configuration
@@ -721,7 +722,7 @@ void AnswerField::fill()
                         int xchenge = getDx(next_rot);
                         int ychenge = getDy(next_rot);
 
-                        unsigned short add = get_weight(_vertex_weight[l], newp);
+                        unsigned short add = static_cast<unsigned short>(get_weight(_vertex_weight[l], newp));
                         //               unsigned short add = max(0, _vertex_weight[l] * (newp ? -1 : 1));
 
                         // add += (p && chenge_rotation > 0) || (!p && chenge_rotation < 0);
@@ -813,12 +814,12 @@ void MoleculeLayoutMacrocyclesLattice::CycleLayout::init(int* up_point)
     rotate[vertex_count] = rotate[0];
 
     point.clear_resize(vertex_count + 1);
-    int length = external_vertex_number[vertex_count];
-    float r = _2FLOAT(_2DOUBLE(length) / 2. / M_PI);
+    int vlength = external_vertex_number[vertex_count];
+    float r = _2FLOAT(_2DOUBLE(vlength) / 2. / M_PI);
     for (int i = 0; i <= vertex_count; i++)
     {
         point[i] = Vec2f(r + _2FLOAT(up_point[external_vertex_number[i]]), 0.f);
-        point[i].rotate(_2FLOAT(2. * M_PI * external_vertex_number[i] / length));
+        point[i].rotate(_2FLOAT(2. * M_PI * external_vertex_number[i] / vlength));
     }
 }
 
@@ -875,10 +876,10 @@ float MoleculeLayoutMacrocyclesLattice::preliminary_layout(CycleLayout& cl)
                 for (int mask = 0; mask < mask_count; mask++)
                     if (can[i][j][mask])
                     {
-                        for (int up = 0; up <= 1; up++)
+                        for (int iup = 0; iup <= 1; iup++)
                         {
                             int previ = i ? i - 1 : length - 1;
-                            if (_edge_stereo[previ] == is_cis[curr_mask = ((mask << 1) + up)] || _edge_stereo[previ] == 0)
+                            if (_edge_stereo[previ] == is_cis[curr_mask = ((mask << 1) + iup)] || _edge_stereo[previ] == 0)
                             {
                                 int rot = j;
                                 if (is_pos_rotate[curr_mask & 7])
@@ -1042,8 +1043,8 @@ float MoleculeLayoutMacrocyclesLattice::rating(CycleLayout& cl)
         }
 
     size_t size = pp.size();
-    for (int i = 0; i < size; i++)
-        for (int j = 0; j < size; j++)
+    for (auto i = 0; i < size; i++)
+        for (auto j = 0; j < size; j++)
             if (i != j && (i + 1) % size != j && i != (j + 1) % size)
             {
                 int nexti = (i + 1) % size;
@@ -1096,8 +1097,8 @@ void MoleculeLayoutMacrocyclesLattice::CycleLayout::soft_move_vertex(int vertex_
     float count = _2FLOAT(vertex_count);
     Vec2f shift_vector = move_vector;
     Vec2f add_vector = move_vector * _2FLOAT(-1.0 / vertex_count);
-    float mult = 1.f;
-    float add_mult = _2FLOAT(-1.0 / vertex_count);
+    // float mult = 1.f;
+    // float add_mult = _2FLOAT(-1.0 / vertex_count);
     do
     {
         point[i++] += move_vector * (count / vertex_count);
@@ -1131,7 +1132,7 @@ void MoleculeLayoutMacrocyclesLattice::CycleLayout::stright_move_chein(int verte
         point[i] += vector;
 }
 
-void MoleculeLayoutMacrocyclesLattice::closingStep(CycleLayout& cl, int index, int base_vertex, bool fix_angle, bool fix_next, float multiplyer)
+void MoleculeLayoutMacrocyclesLattice::closingStep(CycleLayout& cl, int /* index */, int base_vertex, bool fix_angle, bool fix_next, float multiplyer)
 {
 
     int prev_vertex = base_vertex - 1;
@@ -1143,7 +1144,7 @@ void MoleculeLayoutMacrocyclesLattice::closingStep(CycleLayout& cl, int index, i
         if (prev_vertex == -1)
             prev_vertex = cl.vertex_count - 1;
     }
-    int move_vertex = fix_next ? next_vertex : prev_vertex;
+    // int move_vertex = fix_next ? next_vertex : prev_vertex;
 
     Vec2f move_vector(0, 0);
 
@@ -1281,8 +1282,8 @@ void MoleculeLayoutMacrocyclesLattice::closing(CycleLayout& cl)
         if (lenSqr < 0.25)
         {
             float angle = _2FLOAT(-M_PI * cl.vertex_count);
-            for (int i = 0; i < cl.vertex_count; i++)
-                angle += cl.point[i].calc_angle_pos(cl.point[(i + 1) % cl.vertex_count], cl.point[(i + cl.vertex_count - 1) % cl.vertex_count]);
+            for (int j = 0; j < cl.vertex_count; j++)
+                angle += cl.point[j].calc_angle_pos(cl.point[(j + 1) % cl.vertex_count], cl.point[(j + cl.vertex_count - 1) % cl.vertex_count]);
             if (angle < 0)
             {
                 cl.point[cl.vertex_count].copy(cl.point[0]);
@@ -1406,7 +1407,7 @@ void MoleculeLayoutMacrocyclesLattice::smoothingStep(CycleLayout& cl, int vertex
     // printf("%5.5f %5.5f %5.5f %5.5f\n", len1, len2, len3, r3);
     Vec2f newPoint;
     const float eps = 1e-4f;
-    const float eps2 = eps * eps;
+    // const float eps2 = eps * eps;
     if (len1 < eps || len2 < eps || len3 < eps)
     {
         cl.point[vertex_number] = (p1 + p2) / 2.0;
@@ -1434,9 +1435,9 @@ void MoleculeLayoutMacrocyclesLattice::smoothingStep(CycleLayout& cl, int vertex
                 Vec2f pp = cl.point[j] * (1 - s) + cl.point[(j + 1) % cl.vertex_count] * s;
                 float distSqr = Vec2f::distSqr(cl.point[vertex_number], pp);
                 float dist = sqrt(distSqr);
-                float coef = (good_distance - dist) / dist;
+                float fcoef = (good_distance - dist) / dist;
                 // printf("%5.5f \n", dist);
-                newPoint += (cl.point[vertex_number] - pp) * coef;
+                newPoint += (cl.point[vertex_number] - pp) * fcoef;
             }
 
         newPoint *= coef;
@@ -1477,8 +1478,8 @@ Vec2f MoleculeLayoutMacrocyclesLattice::CycleLayout::getWantedVector(int vertex_
 
     // printf("%5.5f %5.5f %5.5f %5.5f\n", len1, len2, len3, r3);
     Vec2f newPoint;
-    const float eps = 1e-4f;
-    const float eps2 = eps * eps;
+    // const float eps = 1e-4f;
+    // const float eps2 = eps * eps;
     // if (len1 < eps || len2 < eps || len3 < eps) return ;
 
     float coef1 = (r1 / len1 - 1);

--- a/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_macrocycle_lattice.cpp
@@ -1043,12 +1043,12 @@ float MoleculeLayoutMacrocyclesLattice::rating(CycleLayout& cl)
         }
 
     size_t size = pp.size();
-    for (auto i = 0; i < size; i++)
-        for (auto j = 0; j < size; j++)
+    for (size_t i = 0; i < size; i++)
+        for (size_t j = 0; j < size; j++)
             if (i != j && (i + 1) % size != j && i != (j + 1) % size)
             {
-                int nexti = (i + 1) % size;
-                int nextj = (j + 1) % size;
+                size_t nexti = (i + 1) % size;
+                size_t nextj = (j + 1) % size;
                 float dist = Vec2f::distSegmentSegment(pp[i], pp[nexti], pp[j], pp[nextj]);
 
                 if (fabs(dist) < eps)

--- a/core/indigo-core/layout/src/molecule_layout_macrocycles.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_macrocycles.cpp
@@ -219,7 +219,7 @@ int improvement(int ind, int molSize, int* rotateAngle, int* edgeLenght, int* ve
         float coef3 = (r3 / len3 - 1);
         if (rotateAngle[worstVertex] != 0)
         {
-            float angle = acos(Vec2f::cross(p1 - p[worstVertex], p2 - p[worstVertex]) / (Vec2f::dist(p1, p[worstVertex]) * Vec2f::dist(p2, p[worstVertex])));
+            // float angle = acos(Vec2f::cross(p1 - p[worstVertex], p2 - p[worstVertex]) / (Vec2f::dist(p1, p[worstVertex]) * Vec2f::dist(p2, p[worstVertex])));
             // if (angle < 2 * M_PI / 3) coef3 /= 10;
         }
 
@@ -318,8 +318,8 @@ void soft_move_vertex(Vec2f* p, int vertex_count, int vertex_number, Vec2f move_
     float count = _2FLOAT(vertex_count);
     Vec2f shift_vector = move_vector;
     Vec2f add_vector = move_vector * (-1.0f / vertex_count);
-    float mult = 1.f;
-    float add_mult = -1.0f / vertex_count;
+    // float mult = 1.f;
+    // float add_mult = -1.0f / vertex_count;
     do
     {
         p[i++] += move_vector * (count / vertex_count);
@@ -355,8 +355,8 @@ void stright_move_chein(Vec2f* p, int vertex_count, int vertex_number, Vec2f vec
         p[i] += vector;
 }
 
-void MoleculeLayoutMacrocycles::improvement2(int index, int vertex_count, int cycle_size, int* rotate_angle, int* edge_lenght, int* vertex_number, Vec2f* p,
-                                             int base_vertex, bool fix_angle, bool fix_next, float multiplyer)
+void MoleculeLayoutMacrocycles::improvement2(int /* index */, int vertex_count, int /* cycle_size */, int* rotate_angle, int* edge_lenght, int* vertex_number,
+                                             Vec2f* p, int base_vertex, bool fix_angle, bool fix_next, float multiplyer)
 {
     profTimerStart(tt, "improvement2");
 
@@ -688,7 +688,7 @@ void rotate(float* ar, int ar_length, int shift)
     memcpy(ar, temp.ptr(), ar_length * sizeof(float));
 }
 
-float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
+float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool /* profi */)
 {
     {
         profTimerStart(tt, "answerField");
@@ -705,7 +705,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
     // fifth : y-coordinate
     // value : minimum number of vertexes sticked out + count of CIS-configurations
 
-    int infinity = 60000;
+    unsigned short infinity = 60000;
 
     int shift = -1;
     int max_value = -infinity;
@@ -764,7 +764,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
 
     minRotates[0][init_rot][1][init_x][init_y] = 0;
     minRotates[1][init_rot][1][init_x + 1][init_y] = 0;
-    int max_dist = length;
+    // int max_dist = length;
 
     {
         profTimerStart(tt, "main.for");
@@ -837,7 +837,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
                                     {
                                         if (ar1[y] > ar2[y] + add)
                                         {
-                                            ar1[y] = ar2[y] + add;
+                                            ar1[y] = static_cast<unsigned short>(ar2[y] + add);
                                         }
                                     }
                                 }
@@ -872,7 +872,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
                                     {
                                         if (ar1[y] > ar2[y] + add)
                                         {
-                                            ar1[y] = ar2[y] + add;
+                                            ar1[y] = static_cast<unsigned short>(ar2[y] + add);
                                         }
                                     }
                                 }
@@ -907,9 +907,9 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
             type = _t;
         }
 
-        bool operator<(const point& p) const
+        bool operator<(const point& pt) const
         {
-            return diff - p.diff;
+            return diff - pt.diff;
         }
     };
 
@@ -937,7 +937,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
                         if (curr_dif <= critical_diff_grid)
                         {
                             diff_set.insert(curr_dif);
-                            if (diff_set.size() > var_count)
+                            if (static_cast<long>(diff_set.size()) > var_count)
                                 diff_set.erase(*diff_set.rbegin());
                             critical_diff_grid = *diff_set.rbegin();
                         }
@@ -980,7 +980,7 @@ float MoleculeLayoutMacrocycles::depictionMacrocycleGreed(bool profi)
                         if (curr_dif <= critical_diff_circle)
                         {
                             diff_set.insert(curr_dif);
-                            if (diff_set.size() > var_count)
+                            if (static_cast<long>(diff_set.size()) > var_count)
                                 diff_set.erase(*diff_set.rbegin());
                             critical_diff_circle = *diff_set.rbegin();
                         }
@@ -1294,7 +1294,7 @@ float MoleculeLayoutMacrocycles::depictionCircle()
     {
         int index_start = 0;
         int index_end = 0;
-        int start = 0;
+        // int start = 0;
         for (int i = 0; i < length; i++)
             if (!only_up[i] && only_up[(i + length - 1) % length])
             {

--- a/core/indigo-core/layout/src/molecule_layout_macrocycles.cpp
+++ b/core/indigo-core/layout/src/molecule_layout_macrocycles.cpp
@@ -598,7 +598,7 @@ float MoleculeLayoutMacrocycles::badness(int ind, int molSize, int* rotateAngle,
             pp.push_back((p[i] * _2FLOAT(edgeLenght[i] - t) + p[(i + 1) % ind] * _2FLOAT(t)) / _2FLOAT(edgeLenght[i]));
         }
 
-    int size = pp.size();
+    int size = static_cast<int>(pp.size());
     for (int i = 0; i < size; i++)
         for (int j = 0; j < size; j++)
             if (i != j && (i + 1) % size != j && i != (j + 1) % size)

--- a/core/indigo-core/molecule/CDXCommons.h
+++ b/core/indigo-core/molecule/CDXCommons.h
@@ -33,7 +33,8 @@ namespace indigo
 
     struct CDXColor
     {
-        CDXColor(float red, float green, float blue) : r(red * kColorMult), g(green * kColorMult), b(blue * kColorMult)
+        CDXColor(float red, float green, float blue)
+            : r(static_cast<int>(red * kColorMult)), g(static_cast<int>(green * kColorMult)), b(static_cast<int>(blue * kColorMult))
         {
         }
         uint16_t r;

--- a/core/indigo-core/molecule/CDXCommons.h
+++ b/core/indigo-core/molecule/CDXCommons.h
@@ -6,6 +6,11 @@
 #include <unordered_map>
 #include <utility>
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
 namespace indigo
 {
 
@@ -34,7 +39,7 @@ namespace indigo
     struct CDXColor
     {
         CDXColor(float red, float green, float blue)
-            : r(static_cast<int>(red * kColorMult)), g(static_cast<int>(green * kColorMult)), b(static_cast<int>(blue * kColorMult))
+            : r(static_cast<uint16_t>(red * kColorMult)), g(static_cast<uint16_t>(green * kColorMult)), b(static_cast<uint16_t>(blue * kColorMult))
         {
         }
         uint16_t r;
@@ -51,7 +56,7 @@ namespace indigo
 
     struct CDXTextStyle
     {
-        CDXTextStyle() : offset(0), font_index(-1), font_face(0), font_size(0), font_color(0){};
+        CDXTextStyle() : offset(0), font_index(static_cast<uint16_t>(-1)), font_face(0), font_size(0), font_color(0){};
         uint16_t offset;
         uint16_t font_index;
         uint16_t font_face;
@@ -1245,5 +1250,9 @@ namespace indigo
     const std::vector<std::string> KStyleProperties = {"font", "face", "size", "color"};
 
 }
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
 
 #endif // _H_CDXCommons

--- a/core/indigo-core/molecule/base_molecule.h
+++ b/core/indigo-core/molecule/base_molecule.h
@@ -180,7 +180,7 @@ namespace indigo
         virtual int getAtomSubstCount(int idx) = 0;
         virtual int getAtomRingBondsCount(int idx) = 0; // >= 0 -- ring bonds count, -1 -- not sure
         virtual int getAtomConnectivity(int idx) = 0;
-        virtual void setExplicitValence(int idx, int valence){};
+        virtual void setExplicitValence(int /*idx*/, int /*valence*/){};
 
         int getAtomRadical_NoThrow(int idx, int fallback);
         int getAtomValence_NoThrow(int idx, int fallback);
@@ -210,7 +210,7 @@ namespace indigo
 
         int transformSCSRtoFullCTAB();
         int transformFullCTABtoSCSR(ObjArray<TGroup>& templates);
-        int transformHELMtoSGroups(Array<char>& helm_class, Array<char>& name, Array<char>& code, Array<char>& natreplace, StringPool& r_names);
+        int transformHELMtoSGroups(Array<char>& helm_class, Array<char>& helm_name, Array<char>& code, Array<char>& natreplace, StringPool& r_names);
         void transformSuperatomsToTemplates(int template_id);
         bool expandNucleotide(int atom_idx);
 

--- a/core/indigo-core/molecule/canonical_smiles_saver.h
+++ b/core/indigo-core/molecule/canonical_smiles_saver.h
@@ -19,6 +19,11 @@
 #ifndef __canonical_smiles_saver__
 #define __canonical_smiles_saver__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <map>
 
 #include "base_cpp/exception.h"
@@ -48,5 +53,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/elements.h
+++ b/core/indigo-core/molecule/elements.h
@@ -189,6 +189,7 @@ namespace indigo
         static int fromChar(char c);
         static int fromTwoChars(char c1, char c2);
         static int fromTwoChars2(char c1, char c2);
+        static int fromTwoChars2(char c1, int c2);
 
         static int radicalElectrons(int radical);
         static int radicalOrbitals(int radical);

--- a/core/indigo-core/molecule/ket_commons.h
+++ b/core/indigo-core/molecule/ket_commons.h
@@ -139,7 +139,7 @@ namespace indigo
     {
         int id = extract_id(atp_id_str, "R");
         if (id < 0)
-            throw std::exception("convertAPFromHELM: prefix not found.");
+            throw std::invalid_argument("convertAPFromHELM: prefix 'R' not found in 'atp_id_str'.");
         char ap_symbol = static_cast<char>(id) + '@'; // convert number to ASCII letter
         std::string res(1, ap_symbol);
         switch (ap_symbol)

--- a/core/indigo-core/molecule/ket_commons.h
+++ b/core/indigo-core/molecule/ket_commons.h
@@ -137,7 +137,10 @@ namespace indigo
 
     inline std::string convertAPFromHELM(const std::string& atp_id_str)
     {
-        char ap_symbol = extract_id(atp_id_str, "R") + '@'; // convert number to ASCII letter
+        int id = extract_id(atp_id_str, "R");
+        if (id < 0)
+            throw std::exception("convertAPFromHELM: prefix not found.");
+        char ap_symbol = static_cast<char>(id) + '@'; // convert number to ASCII letter
         std::string res(1, ap_symbol);
         switch (ap_symbol)
         {

--- a/core/indigo-core/molecule/molecule_arom.h
+++ b/core/indigo-core/molecule/molecule_arom.h
@@ -80,7 +80,7 @@ namespace indigo
         virtual bool _checkVertex(int v_idx);
         virtual bool _isCycleAromatic(const int* cycle, int cycle_len) = 0;
         virtual void _handleAromaticCycle(const int* cycle, int cycle_len);
-        virtual bool _acceptOutgoingDoubleBond(int atom, int bond)
+        virtual bool _acceptOutgoingDoubleBond(int /*atom*/, int /*bond*/)
         {
             return false;
         }

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -40,6 +40,11 @@ typedef int INT32;
 typedef unsigned int UINT32;
 #include "CDXCommons.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#endif
+
 namespace tinyxml2
 {
     class XMLHandle;
@@ -434,7 +439,7 @@ namespace indigo
             return result;
         }
 
-        std::string parseCDXUINT16(uint16_t val, uint16_t tag)
+        std::string parseCDXUINT16(uint16_t val, uint16_t /*tag*/)
         {
             return std::to_string(val);
         }
@@ -945,5 +950,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -292,7 +292,7 @@ namespace indigo
                 auto ptr32 = (int32_t*)ptr;
                 std::stringstream ss;
                 ss << std::setprecision(2) << std::fixed;
-                for (auto i = 0; i < value_size / sizeof(int32_t); ++i)
+                for (uint16_t i = 0; i < value_size / sizeof(int32_t); ++i)
                 {
                     if (i)
                         ss << " ";
@@ -308,7 +308,7 @@ namespace indigo
                 auto ptr32 = (int32_t*)ptr;
                 std::stringstream ss;
                 ss << std::setprecision(2) << std::fixed;
-                for (auto i = 0; i < value_size / sizeof(int32_t); ++i)
+                for (uint16_t i = 0; i < value_size / sizeof(int32_t); ++i)
                 {
                     if (i)
                         ss << " ";
@@ -358,7 +358,7 @@ namespace indigo
             break;
             case ECDXType::CDXObjectIDArray: {
                 auto ptr32 = (uint32_t*)ptr;
-                for (auto i = 0; i < value_size / sizeof(uint32_t); ++i)
+                for (uint16_t i = 0; i < value_size / sizeof(uint32_t); ++i)
                 {
                     if (i)
                         result += " ";

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -623,8 +623,7 @@ namespace indigo
 
         CDXProperty findBinaryProperty(int16_t tag)
         {
-            auto prop = firstBinaryProperty();
-            for (prop; prop.hasContent(); prop = prop.getNextProp())
+            for (auto prop = firstBinaryProperty(); prop.hasContent(); prop = prop.getNextProp())
             {
                 if (prop.tag() == tag)
                     return prop;
@@ -662,7 +661,7 @@ namespace indigo
                 {
                     ptr = (uint8_t*)ptr16;
                     auto sz = skipObject(ptr) - ptr;
-                    return CDXElement(ptr, sz);
+                    return CDXElement(ptr, static_cast<int>(sz));
                 }
             }
             return CDXElement();
@@ -697,7 +696,7 @@ namespace indigo
             {
                 ptr = (uint8_t*)ptr16;
                 auto sz = skipObject(ptr) - ptr;
-                return CDXElement(ptr, sz);
+                return CDXElement(ptr, static_cast<int>(sz));
             }
             return CDXElement();
         }
@@ -810,7 +809,7 @@ namespace indigo
         CDXReader(Scanner& scanner);
         virtual CDXElement rootElement()
         {
-            return CDXElement(_buffer.data(), _buffer.size());
+            return CDXElement(_buffer.data(), static_cast<int>(_buffer.size()));
         }
 
         virtual void process()

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -926,7 +926,7 @@ namespace indigo
 
         Molecule* _pmol;
         QueryMolecule* _pqmol;
-        std::unordered_map<int, std::size_t> _id_to_atom_idx;
+        std::unordered_map<int, int> _id_to_atom_idx;
         std::unordered_map<int, std::size_t> _id_to_node_index;
         std::unordered_map<int, std::size_t> _id_to_bond_index;
         std::vector<int> _fragment_nodes;

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -912,7 +912,7 @@ namespace indigo
         void _parseArrow(CDXElement elem);
         void _parseAltGroup(CDXElement elem);
 
-        void _addAtomsAndBonds(BaseMolecule& mol, const std::vector<int>& atoms, const std::vector<CdxmlBond>& bonds);
+        void _addAtomsAndBonds(BaseMolecule& mol, const std::vector<int>& atoms, const std::vector<CdxmlBond>& new_bonds);
         void _addBracket(BaseMolecule& mol, const CdxmlBracket& bracket);
         void _handleSGroup(SGroup& sgroup, const std::unordered_set<int>& atoms, BaseMolecule& bmol);
         void _processEnhancedStereo(BaseMolecule& mol);

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -292,7 +292,7 @@ namespace indigo
                 auto ptr32 = (int32_t*)ptr;
                 std::stringstream ss;
                 ss << std::setprecision(2) << std::fixed;
-                for (int i = 0; i < value_size / sizeof(int32_t); ++i)
+                for (auto i = 0; i < value_size / sizeof(int32_t); ++i)
                 {
                     if (i)
                         ss << " ";
@@ -308,7 +308,7 @@ namespace indigo
                 auto ptr32 = (int32_t*)ptr;
                 std::stringstream ss;
                 ss << std::setprecision(2) << std::fixed;
-                for (int i = 0; i < value_size / sizeof(int32_t); ++i)
+                for (auto i = 0; i < value_size / sizeof(int32_t); ++i)
                 {
                     if (i)
                         ss << " ";
@@ -358,7 +358,7 @@ namespace indigo
             break;
             case ECDXType::CDXObjectIDArray: {
                 auto ptr32 = (uint32_t*)ptr;
-                for (int i = 0; i < value_size / sizeof(uint32_t); ++i)
+                for (auto i = 0; i < value_size / sizeof(uint32_t); ++i)
                 {
                     if (i)
                         result += " ";

--- a/core/indigo-core/molecule/molecule_cdxml_saver.h
+++ b/core/indigo-core/molecule/molecule_cdxml_saver.h
@@ -19,6 +19,11 @@
 #ifndef __molecule_cdxml_saver_h__
 #define __molecule_cdxml_saver_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <memory>
 
 #include "base_cpp/properties_map.h"
@@ -154,5 +159,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/molecule_cip_calculator.h
+++ b/core/indigo-core/molecule/molecule_cip_calculator.h
@@ -18,6 +18,11 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <array>
 #include <string>
 #include <unordered_map>
@@ -97,3 +102,7 @@ namespace indigo
         static void cipSort(Array<int>& ligands, CIPContext* context);
     };
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/molecule_dearom.h
+++ b/core/indigo-core/molecule/molecule_dearom.h
@@ -76,7 +76,7 @@ namespace indigo
         {
             return _dearomParams;
         }
-        void setDearomatizationParams(int params)
+        void setDearomatizationParams(byte params)
         {
             _dearomParams = params;
         }

--- a/core/indigo-core/molecule/molecule_json_saver.h
+++ b/core/indigo-core/molecule/molecule_json_saver.h
@@ -19,6 +19,11 @@
 #ifndef __molecule_json_saver_h__
 #define __molecule_json_saver_h__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <sstream>
 
 #include <rapidjson/prettywriter.h>
@@ -235,5 +240,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/molecule_morgan_fingerprint_builder.h
+++ b/core/indigo-core/molecule/molecule_morgan_fingerprint_builder.h
@@ -19,6 +19,11 @@
 #ifndef PROJECT_MOLECULE_MORGAN_FINGERPRINT_H
 #define PROJECT_MOLECULE_MORGAN_FINGERPRINT_H
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include <set>
 #include <vector>
 
@@ -109,5 +114,9 @@ namespace indigo
     };
 
 }; // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // PROJECT_MOLECULE_MORGAN_FINGERPRINT_H

--- a/core/indigo-core/molecule/molfile_saver.h
+++ b/core/indigo-core/molecule/molfile_saver.h
@@ -19,6 +19,11 @@
 #ifndef __molfile_saver__
 #define __molfile_saver__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/array.h"
 #include "base_cpp/tlscont.h"
 #include "molecule/base_molecule.h"
@@ -112,5 +117,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/monomers_lib.h
+++ b/core/indigo-core/molecule/monomers_lib.h
@@ -1,6 +1,11 @@
 #ifndef __monomers_lib__
 #define __monomers_lib__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/exception.h"
 #include "molecule/molecule.h"
 #include <map>
@@ -89,5 +94,9 @@ namespace indigo
         std::unordered_map<std::string, std::shared_ptr<BaseMolecule>> _aminoacids_lib;
     };
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/molecule/src/canonical_smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/canonical_smiles_saver.cpp
@@ -117,7 +117,7 @@ void CanonicalSmilesSaver::saveMolecule(Molecule& mol_)
     _actual_atom_atom_mapping.clear_resize(mol.vertexCount());
     _actual_atom_atom_mapping.zerofill();
 
-    for (int i = 0; i < order.size(); ++i)
+    for (i = 0; i < order.size(); ++i)
     {
         int aam = mol.reaction_atom_mapping[order[i]];
         if (aam)

--- a/core/indigo-core/molecule/src/cmf_loader.cpp
+++ b/core/indigo-core/molecule/src/cmf_loader.cpp
@@ -108,7 +108,7 @@ bool CmfLoader::_readAtom(int& code, _AtomDesc& atom, int atom_idx)
             int c;
             if (!_getNextCode(c))
                 throw Error("pseudo-atom label is incomplete");
-            label[i] = c;
+            label[i] = static_cast<char>(c);
         }
 
         label[len] = 0;
@@ -700,12 +700,12 @@ void CmfLoader::loadMolecule(Molecule& mol)
     {
         // Compute inv_atom_mapping_to_restore
         inv_atom_mapping_to_restore.clear_resize(atom_mapping_to_restore.size());
-        for (int i = 0; i < atom_mapping_to_restore.size(); i++)
+        for (i = 0; i < atom_mapping_to_restore.size(); i++)
             inv_atom_mapping_to_restore[atom_mapping_to_restore[i]] = i;
 
         // Compute inv_bond_mapping_to_restore
         inv_bond_mapping_to_restore.clear_resize(bond_mapping_to_restore.size());
-        for (int i = 0; i < bond_mapping_to_restore.size(); i++)
+        for (i = 0; i < bond_mapping_to_restore.size(); i++)
             inv_bond_mapping_to_restore[bond_mapping_to_restore[i]] = i;
 
         QS_DEF(Molecule, tmp);
@@ -956,7 +956,7 @@ void CmfLoader::loadXyz(Scanner& scanner)
     }
 
     // Read sgroup coordinates data
-    for (int i = 0; i < _sgroup_order.size(); i++)
+    for (i = 0; i < _sgroup_order.size(); i++)
         _readSGroupXYZ(scanner, _sgroup_order[i], *_mol, range);
 
     _mol->have_xyz = true;

--- a/core/indigo-core/molecule/src/cmf_saver.cpp
+++ b/core/indigo-core/molecule/src/cmf_saver.cpp
@@ -167,7 +167,7 @@ void CmfSaver::saveMolecule(Molecule& mol)
                     else
                         throw Error("internal");
 
-                    _encode(dir);
+                    _encode(static_cast<byte>(dir));
                 }
             }
 
@@ -268,7 +268,7 @@ void CmfSaver::_encodeUIntArraySkipNegative(const Array<int>& data)
     }
 }
 
-void CmfSaver::_encodeBaseSGroup(Molecule& mol, SGroup& sgroup, const Mapping& mapping)
+void CmfSaver::_encodeBaseSGroup(Molecule& /* mol */, SGroup& sgroup, const Mapping& mapping)
 {
     _encodeUIntArray(sgroup.atoms, *mapping.atom_mapping);
     _encodeUIntArray(sgroup.bonds, *mapping.bond_mapping);
@@ -353,7 +353,7 @@ void CmfSaver::_encodeExtSection(Molecule& mol, const Mapping& mapping)
             _encodeBaseSGroup(mol, sa, mapping);
             _encodeString(sa.subscript);
             _encodeString(sa.sa_class);
-            byte packed = ((int)sa.contracted & 0x01) | (sa.bond_connections.size() << 1);
+            byte packed = static_cast<byte>(((int)sa.contracted & 0x01) | (sa.bond_connections.size() << 1));
             _output->writeByte(packed);
             if (sa.bond_connections.size() > 0)
             {
@@ -481,7 +481,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
         else
         {
             _encode(CMF_RSITE);
-            _encode(bits);
+            _encode(static_cast<byte>(bits));
         }
     }
     else
@@ -491,7 +491,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
         if (number <= 0 || number >= ELEM_MAX)
             throw Error("unexpected atom label");
 
-        _encode(number);
+        _encode(static_cast<byte>(number));
     }
 
     int charge = mol.getAtomCharge(idx);
@@ -506,10 +506,10 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
             int charge3 = charge + 128;
             if (charge3 < 0 || charge >= 256)
                 throw Error("unexpected atom charge: %d", charge);
-            _encode(charge3);
+            _encode(static_cast<byte>(charge3));
         }
         else
-            _encode(charge2 + CMF_CHARGES);
+            _encode(static_cast<byte>(charge2 + CMF_CHARGES));
     }
 
     int isotope = mol.getAtomIsotope(idx);
@@ -536,7 +536,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
                 throw Error("unexpected %s isotope: %d", Element::toString(number), isotope);
             }
             _encode(CMF_ISOTOPE_OTHER);
-            _encode(deviation);
+            _encode(static_cast<byte>(deviation));
         }
     }
 
@@ -601,7 +601,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
             // CMF_STEREO_*_0 -> CMF_STEREO_*_1
             code += CMF_MAX_STEREOGROUPS * 2 + 1;
 
-        _encode(code);
+        _encode(static_cast<byte>(code));
     }
 
     if (mol.allene_stereo.isCenter(idx))
@@ -630,7 +630,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
             if (impl_h < 0 || impl_h > CMF_MAX_IMPLICIT_H)
                 throw Error("implicit hydrogen count %d out of range", impl_h);
 
-            _encode(CMF_IMPLICIT_H + impl_h);
+            _encode(static_cast<byte>(CMF_IMPLICIT_H + impl_h));
         }
         catch (Element::Error)
         {
@@ -650,7 +650,7 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
                     _output->writePackedUInt(valence);
                 }
                 else
-                    _encode(CMF_VALENCE + valence);
+                    _encode(static_cast<byte>(CMF_VALENCE + valence));
             }
             catch (Element::Error)
             {
@@ -668,17 +668,17 @@ void CmfSaver::_encodeAtom(Molecule& mol, int idx, const int* mapping)
             if (aidx == idx)
             {
                 _encode(CMF_ATTACHPT);
-                _encode(i);
+                _encode(static_cast<byte>(i));
             }
     }
 
     if (atom_flags != 0)
     {
-        int i, flags = atom_flags[idx];
+        int flags = atom_flags[idx];
 
         for (i = 0; i < CMF_NUM_OF_ATOM_FLAGS; i++)
             if (flags & (1 << i))
-                _encode(CMF_ATOM_FLAGS + i);
+                _encode(static_cast<byte>(CMF_ATOM_FLAGS + i));
     }
 
     if (save_highlighting)
@@ -753,7 +753,7 @@ void CmfSaver::_encodeBond(Molecule& mol, int idx, const int* mapping)
 
         for (i = 0; i < CMF_NUM_OF_BOND_FLAGS; i++)
             if (flags & (1 << i))
-                _encode(CMF_BOND_FLAGS + i);
+                _encode(static_cast<byte>(CMF_BOND_FLAGS + i));
     }
 
     if (save_highlighting)
@@ -768,7 +768,7 @@ void CmfSaver::_encodeCycleNumer(int n)
         _encode(CMF_CYCLES_PLUS);
         n -= CMF_NUM_OF_CYCLES;
     }
-    _encode(CMF_CYCLES + n);
+    _encode(static_cast<byte>(CMF_CYCLES + n));
 }
 
 void CmfSaver::_encode(byte symbol)

--- a/core/indigo-core/molecule/src/cml_loader.cpp
+++ b/core/indigo-core/molecule/src/cml_loader.cpp
@@ -919,15 +919,15 @@ void CmlLoader::_loadMoleculeElement(XMLHandle& handle)
             else
                 throw Error("unknown bond type: %d", order);
 
-            const char* topology = elem->Attribute("topology");
-            if (topology != 0)
+            const char* bond_topology = elem->Attribute("topology");
+            if (bond_topology != 0)
             {
-                if (strncmp(topology, "ring", 4) == 0)
+                if (strncmp(bond_topology, "ring", 4) == 0)
                     bond.reset(QueryMolecule::Bond::und(bond.release(), new QueryMolecule::Bond(QueryMolecule::BOND_TOPOLOGY, TOPOLOGY_RING)));
-                else if (strncmp(topology, "chain", 5) == 0)
+                else if (strncmp(bond_topology, "chain", 5) == 0)
                     bond.reset(QueryMolecule::Bond::und(bond.release(), new QueryMolecule::Bond(QueryMolecule::BOND_TOPOLOGY, TOPOLOGY_CHAIN)));
                 else
-                    throw Error("unknown topology: %s", topology);
+                    throw Error("unknown topology: %s", bond_topology);
             }
 
             idx = _qmol->addBond(beg, end, bond.release());
@@ -1059,14 +1059,14 @@ void CmlLoader::_loadMoleculeElement(XMLHandle& handle)
         if (refs4 != 0)
         {
             BufferScanner strscan(refs4);
-            QS_DEF(Array<char>, id);
+            QS_DEF(Array<char>, a_id);
             int pyramid[4];
 
             for (int k = 0; k < 4; k++)
             {
                 strscan.skipSpace();
-                strscan.readWord(id, 0);
-                pyramid[k] = getAtomIdx(id.ptr());
+                strscan.readWord(a_id, 0);
+                pyramid[k] = getAtomIdx(a_id.ptr());
                 if (pyramid[k] == idx)
                     pyramid[k] = -1;
             }
@@ -1303,8 +1303,8 @@ void CmlLoader::_loadSGroupElement(XMLElement* elem, std::unordered_map<std::str
                 }
 
                 int point_idx = 0;
-                Vec2f* pbrackets;
-                XMLElement* pPoint;
+                Vec2f* pbrackets = nullptr;
+                XMLElement* pPoint = nullptr;
                 for (pPoint = brackets->FirstChildElement(); pPoint; pPoint = pPoint->NextSiblingElement())
                 {
                     if (strncmp(pPoint->Value(), "MPoint", 6) != 0)
@@ -1459,8 +1459,8 @@ void CmlLoader::_loadSGroupElement(XMLElement* elem, std::unordered_map<std::str
                 }
 
                 int point_idx = 0;
-                Vec2f* pbrackets;
-                XMLElement* pPoint;
+                Vec2f* pbrackets = nullptr;
+                XMLElement* pPoint = nullptr;
                 for (pPoint = brackets->FirstChildElement(); pPoint; pPoint = pPoint->NextSiblingElement())
                 {
                     if (strncmp(pPoint->Value(), "MPoint", 6) != 0)
@@ -1537,8 +1537,8 @@ void CmlLoader::_loadSGroupElement(XMLElement* elem, std::unordered_map<std::str
                 }
 
                 int point_idx = 0;
-                Vec2f* pbrackets;
-                XMLElement* pPoint;
+                Vec2f* pbrackets = nullptr;
+                XMLElement* pPoint = nullptr;
                 for (pPoint = brackets->FirstChildElement(); pPoint; pPoint = pPoint->NextSiblingElement())
                 {
                     if (strncmp(pPoint->Value(), "MPoint", 6) != 0)
@@ -1646,8 +1646,8 @@ void CmlLoader::_loadSGroupElement(XMLElement* elem, std::unordered_map<std::str
                 }
 
                 int point_idx = 0;
-                Vec2f* pbrackets;
-                XMLElement* pPoint;
+                Vec2f* pbrackets = nullptr;
+                XMLElement* pPoint = nullptr;
                 for (pPoint = brackets->FirstChildElement(); pPoint; pPoint = pPoint->NextSiblingElement())
                 {
                     if (strncmp(pPoint->Value(), "MPoint", 6) != 0)
@@ -1731,8 +1731,8 @@ void CmlLoader::_loadSGroupElement(XMLElement* elem, std::unordered_map<std::str
                 }
 
                 int point_idx = 0;
-                Vec2f* pbrackets;
-                XMLElement* pPoint;
+                Vec2f* pbrackets = nullptr;
+                XMLElement* pPoint = nullptr;
                 for (pPoint = brackets->FirstChildElement(); pPoint; pPoint = pPoint->NextSiblingElement())
                 {
                     if (strncmp(pPoint->Value(), "MPoint", 6) != 0)
@@ -1832,8 +1832,8 @@ void CmlLoader::_loadRgroupElement(XMLHandle& handle)
         const char* rgroup_then = elem->Attribute("thenR");
         if (rgroup_then != 0)
         {
-            BufferScanner strscan(rgroup_then);
-            rgroup.if_then = strscan.readInt1();
+            BufferScanner rstrscan(rgroup_then);
+            rgroup.if_then = rstrscan.readInt1();
         }
 
         rgroup.rest_h = 0;

--- a/core/indigo-core/molecule/src/cml_saver.cpp
+++ b/core/indigo-core/molecule/src/cml_saver.cpp
@@ -232,21 +232,21 @@ void CmlSaver::_addMoleculeElement(XMLElement* elem, BaseMolecule& mol, bool que
 
                 _mol->getAllowedRGroups(i, rg_refs);
 
-                QS_DEF(Array<char>, buf);
-                ArrayOutput out(buf);
+                QS_DEF(Array<char>, rbuf);
+                ArrayOutput rout(rbuf);
 
                 if (rg_refs.size() == 1)
                 {
-                    out.printf("%d", rg_refs[0]);
-                    buf.push(0);
-                    atom->SetAttribute("rgroupRef", buf.ptr());
+                    rout.printf("%d", rg_refs[0]);
+                    rbuf.push(0);
+                    atom->SetAttribute("rgroupRef", rbuf.ptr());
                 }
             }
 
             if (qmol != 0)
             {
-                QS_DEF(Array<char>, buf);
-                ArrayOutput out(buf);
+                QS_DEF(Array<char>, qbuf);
+                ArrayOutput qout(qbuf);
 
                 QS_DEF(Array<int>, list);
 
@@ -257,62 +257,62 @@ void CmlSaver::_addMoleculeElement(XMLElement* elem, BaseMolecule& mol, bool que
                     {
                         int k;
 
-                        out.writeString("L");
+                        qout.writeString("L");
 
                         for (k = 0; k < list.size(); k++)
                         {
                             if (query_atom_type == QueryMolecule::QUERY_ATOM_NOTLIST)
-                                out.writeString("!");
+                                qout.writeString("!");
                             else
-                                out.writeString(",");
+                                qout.writeString(",");
 
-                            out.writeString(Element::toString(list[k]));
+                            qout.writeString(Element::toString(list[k]));
                         }
-                        out.writeString(": ");
+                        qout.writeString(": ");
                     }
                     else if (query_atom_type == QueryMolecule::QUERY_ATOM_A)
-                        out.writeString("A");
+                        qout.writeString("A");
                     else if (query_atom_type == QueryMolecule::QUERY_ATOM_Q)
-                        out.writeString("Q");
+                        qout.writeString("Q");
                 }
 
                 int rbc;
                 if (_getRingBondCountFlagValue(*qmol, i, rbc))
                 {
                     if (rbc > 0)
-                        out.printf("rb%d;", rbc);
+                        qout.printf("rb%d;", rbc);
                     else if (rbc == -2)
-                        out.printf("rb*;");
+                        qout.printf("rb*;");
                     else if (rbc == -1)
-                        out.printf("rb0;");
+                        qout.printf("rb0;");
                 }
 
                 int subst;
                 if (_getSubstitutionCountFlagValue(*qmol, i, subst))
                 {
                     if (subst > 0)
-                        out.printf("s%d;", subst);
+                        qout.printf("s%d;", subst);
                     else if (subst == -2)
-                        out.printf("s*;");
+                        qout.printf("s*;");
                     else if (subst == -1)
-                        out.printf("s0;");
+                        qout.printf("s0;");
                 }
 
                 int unsat;
                 if (qmol->getAtom(i).sureValue(QueryMolecule::ATOM_UNSATURATION, unsat))
-                    out.printf("u1;");
+                    qout.printf("u1;");
 
                 int hcount = MoleculeSavers::getHCount(mol, i, atom_number, charge);
 
                 if (hcount > 0)
-                    out.printf("H%d", hcount);
+                    qout.printf("H%d", hcount);
                 else if (hcount == 0)
-                    out.printf("H0");
+                    qout.printf("H0");
 
-                if (buf.size() > 0)
+                if (qbuf.size() > 0)
                 {
-                    buf.push(0);
-                    atom->SetAttribute("mrvQueryProps", buf.ptr());
+                    qbuf.push(0);
+                    atom->SetAttribute("mrvQueryProps", qbuf.ptr());
                 }
             }
 
@@ -373,15 +373,15 @@ void CmlSaver::_addMoleculeElement(XMLElement* elem, BaseMolecule& mol, bool que
                 XMLElement* atomparity = _doc->NewElement("atomParity");
                 atom->LinkEndChild(atomparity);
 
-                QS_DEF(Array<char>, buf);
-                ArrayOutput out(buf);
+                QS_DEF(Array<char>, sbuf);
+                ArrayOutput sout(sbuf);
                 const int* pyramid = _mol->stereocenters.getPyramid(i);
                 if (pyramid[3] == -1)
-                    out.printf("a%d a%d a%d a%d", pyramid[0], pyramid[1], pyramid[2], i);
+                    sout.printf("a%d a%d a%d a%d", pyramid[0], pyramid[1], pyramid[2], i);
                 else
-                    out.printf("a%d a%d a%d a%d", pyramid[0], pyramid[1], pyramid[2], pyramid[3]);
-                buf.push(0);
-                atomparity->SetAttribute("atomRefs4", buf.ptr());
+                    sout.printf("a%d a%d a%d a%d", pyramid[0], pyramid[1], pyramid[2], pyramid[3]);
+                sbuf.push(0);
+                atomparity->SetAttribute("atomRefs4", sbuf.ptr());
 
                 atomparity->LinkEndChild(_doc->NewText("1"));
             }
@@ -506,13 +506,13 @@ void CmlSaver::_addMoleculeElement(XMLElement* elem, BaseMolecule& mol, bool que
                 XMLElement* bondstereo = _doc->NewElement("bondStereo");
                 bond->LinkEndChild(bondstereo);
 
-                QS_DEF(Array<char>, buf);
-                ArrayOutput out(buf);
+                QS_DEF(Array<char>, pbuf);
+                ArrayOutput pout(pbuf);
 
                 const int* subst = _mol->cis_trans.getSubstituents(i);
-                out.printf("a%d a%d a%d a%d", subst[0], edge.beg, edge.end, subst[2]);
-                buf.push(0);
-                bondstereo->SetAttribute("atomRefs4", buf.ptr());
+                pout.printf("a%d a%d a%d a%d", subst[0], edge.beg, edge.end, subst[2]);
+                pbuf.push(0);
+                bondstereo->SetAttribute("atomRefs4", pbuf.ptr());
                 bondstereo->LinkEndChild(_doc->NewText((parity == MoleculeCisTrans::CIS) ? "C" : "T"));
             }
             else if (_mol->cis_trans.isIgnored(i))
@@ -555,16 +555,16 @@ void CmlSaver::_addSgroupElement(XMLElement* molecule, BaseMolecule& mol, SGroup
 
     if (sgroup.atoms.size() > 0)
     {
-        QS_DEF(Array<char>, buf);
-        ArrayOutput out(buf);
+        QS_DEF(Array<char>, sbuf);
+        ArrayOutput sout(sbuf);
 
         for (int j = 0; j < sgroup.atoms.size(); j++)
-            out.printf("a%d ", sgroup.atoms[j]);
+            sout.printf("a%d ", sgroup.atoms[j]);
 
-        buf.pop();
-        buf.push(0);
+        sbuf.pop();
+        sbuf.push(0);
 
-        sg->SetAttribute("atomRefs", buf.ptr());
+        sg->SetAttribute("atomRefs", sbuf.ptr());
     }
 
     if (sgroup.brackets.size() > 0)
@@ -742,16 +742,16 @@ void CmlSaver::_addSgroupElement(XMLElement* molecule, BaseMolecule& mol, SGroup
 
         if (mul.parent_atoms.size() > 0)
         {
-            QS_DEF(Array<char>, buf);
-            ArrayOutput out(buf);
+            QS_DEF(Array<char>, pbuf);
+            ArrayOutput pout(pbuf);
 
             for (int j = 0; j < mul.parent_atoms.size(); j++)
-                out.printf("a%d ", mul.parent_atoms[j]);
+                pout.printf("a%d ", mul.parent_atoms[j]);
 
-            buf.pop();
-            buf.push(0);
+            pbuf.pop();
+            pbuf.push(0);
 
-            sg->SetAttribute("patoms", buf.ptr());
+            sg->SetAttribute("patoms", pbuf.ptr());
         }
 
         MoleculeSGroups* sgroups = &mol.sgroups;

--- a/core/indigo-core/molecule/src/crippen.cpp
+++ b/core/indigo-core/molecule/src/crippen.cpp
@@ -380,8 +380,8 @@ namespace
             for (const auto& rawLine : pkaDecisionTree)
             {
                 const auto& line = CSVReader::readCSVRow(rawLine);
-                const size_t id = stoull(line[0]);
-                const size_t parentId = stoull(line[1]);
+                const long long id = stoull(line[0]);
+                const long long parentId = stoull(line[1]);
                 const bool isLeaf = !static_cast<bool>(stoi(line[2]));
                 const string& smarts = line[4];
                 const bool yes = static_cast<bool>(stoi(line[5]));

--- a/core/indigo-core/molecule/src/crippen.cpp
+++ b/core/indigo-core/molecule/src/crippen.cpp
@@ -380,8 +380,8 @@ namespace
             for (const auto& rawLine : pkaDecisionTree)
             {
                 const auto& line = CSVReader::readCSVRow(rawLine);
-                const long long id = stoull(line[0]);
-                const long long parentId = stoull(line[1]);
+                const size_t id = static_cast<size_t>(stoull(line[0]));
+                const size_t parentId = static_cast<size_t>(stoull(line[1]));
                 const bool isLeaf = !static_cast<bool>(stoi(line[2]));
                 const string& smarts = line[4];
                 const bool yes = static_cast<bool>(stoi(line[5]));

--- a/core/indigo-core/molecule/src/elements.cpp
+++ b/core/indigo-core/molecule/src/elements.cpp
@@ -236,6 +236,13 @@ int Element::fromTwoChars2(char c1, char c2)
     return fromString2(str);
 }
 
+int Element::fromTwoChars2(char c1, int c2)
+{
+    if (c2 < 0)
+        return -1;
+    return fromTwoChars2(c1, static_cast<char>(c2));
+}
+
 bool Element::isHalogen(int element)
 {
     return element == ELEM_F || element == ELEM_Cl || element == ELEM_Br || element == ELEM_I || element == ELEM_At;

--- a/core/indigo-core/molecule/src/elements.cpp
+++ b/core/indigo-core/molecule/src/elements.cpp
@@ -1310,7 +1310,7 @@ int Element::getNumOuterElectrons(int element)
         4 // Ce
     };
     // clang-format on
-    if (element > outerElements.size())
+    if (element > static_cast<int>(outerElements.size()))
     {
         throw Error("outerElements are currently filled only for elements up to lantanoids");
     }

--- a/core/indigo-core/molecule/src/elements.cpp
+++ b/core/indigo-core/molecule/src/elements.cpp
@@ -1078,7 +1078,7 @@ void Element::_initDefaultIsotopes()
     std::vector<double> most_abundant_isotope_fraction;
     most_abundant_isotope_fraction.resize(_element_parameters.size());
 
-    for (int i = ELEM_MIN; i < _element_parameters.size(); i++)
+    for (unsigned int i = ELEM_MIN; i < _element_parameters.size(); i++)
     {
         _element_parameters.at(i).default_isotope = IsotopeKey::NATURAL;
         _element_parameters.at(i).most_abundant_isotope = IsotopeKey::NATURAL;
@@ -1139,7 +1139,7 @@ void Element::_initDefaultIsotopes()
         }
     }
 
-    for (int i = ELEM_MIN; i < _element_parameters.size(); i++)
+    for (unsigned int i = ELEM_MIN; i < _element_parameters.size(); i++)
     {
         ElementParameters& element = _element_parameters.at(i);
 
@@ -1154,7 +1154,7 @@ void Element::_initDefaultIsotopes()
     }
 
     // Post-condition
-    for (int i = ELEM_MIN; i < _element_parameters.size(); i++)
+    for (unsigned int i = ELEM_MIN; i < _element_parameters.size(); i++)
         if (_element_parameters.at(i).default_isotope == IsotopeKey::NATURAL)
             // usually you can't catch this as it's being thrown before main()
             throw Error("default isotope is not set on element #%d", i);

--- a/core/indigo-core/molecule/src/haworth_projection_finder.cpp
+++ b/core/indigo-core/molecule/src/haworth_projection_finder.cpp
@@ -308,7 +308,7 @@ void HaworthProjectionFinder::_markRingBonds(const Array<int>& vertices, const A
     }
 }
 
-void HaworthProjectionFinder::_addRingStereocenters(const Array<int>& vertices, const Array<int>& edges)
+void HaworthProjectionFinder::_addRingStereocenters(const Array<int>& vertices, const Array<int>& /* edges */)
 {
     // Find left vertex
     int j_left = -1;
@@ -365,8 +365,7 @@ void HaworthProjectionFinder::_addRingStereocenters(const Array<int>& vertices, 
                 break;
             }
 
-            float yn = _mol.getAtomXyz(vn).y;
-            if (yn > yc)
+            if (_mol.getAtomXyz(vn).y > yc)
                 vi_top = vn;
             else
                 vi_bottom = vn;

--- a/core/indigo-core/molecule/src/inchi_parser.cpp
+++ b/core/indigo-core/molecule/src/inchi_parser.cpp
@@ -31,7 +31,7 @@ InChICodeParser::InChICodeParser(const char* inchi_code) : _mobileCount(0)
     size_t pos = str.find("/h");
     // assert(pos != npos)
     int num = 0, from = -1;
-    bool isValid;
+    bool isValid = false;
     int type = STATIC;
     for (pos += 2; pos < str.size() && str[pos] != '/'; ++pos)
     {

--- a/core/indigo-core/molecule/src/inchi_wrapper.cpp
+++ b/core/indigo-core/molecule/src/inchi_wrapper.cpp
@@ -623,7 +623,7 @@ void InchiWrapper::saveMoleculeIntoInchi(Molecule& mol, Array<char>& inchi)
             arom_options.unique_dearomatization = true;
             dearom->dearomatize(arom_options);
         }
-        catch (NonUniqueDearomatizationException& ex)
+        catch (NonUniqueDearomatizationException&)
         {
             // Do not allow non-unique dearomatizations
             throw;

--- a/core/indigo-core/molecule/src/inchi_wrapper.cpp
+++ b/core/indigo-core/molecule/src/inchi_wrapper.cpp
@@ -542,9 +542,9 @@ void InchiWrapper::generateInchiInput(Molecule& mol, inchi_Input& input, Array<i
         else if (type == MoleculeStereocenters::ATOM_OR)
             setOptions("/SRel");
 
-        for (int i = 0; i < 4; i++)
-            if (pyramid[i] != -1)
-                pyramid[i] = mapping[pyramid[i]];
+        for (int k = 0; k < 4; k++)
+            if (pyramid[k] != -1)
+                pyramid[k] = mapping[pyramid[k]];
 
         inchi_Stereo0D& st = stereo.push();
 

--- a/core/indigo-core/molecule/src/max_common_submolecule.cpp
+++ b/core/indigo-core/molecule/src/max_common_submolecule.cpp
@@ -45,7 +45,7 @@ bool MaxCommonSubmolecule::matchBonds(Graph& g1, Graph& g2, int i, int j, void* 
     return MoleculeExactMatcher::matchBonds(mol1, mol2, i, j, flags);
 }
 
-bool MaxCommonSubmolecule::matchAtoms(Graph& g1, Graph& g2, const int* core_sub, int i, int j, void* userdata)
+bool MaxCommonSubmolecule::matchAtoms(Graph& g1, Graph& g2, const int* /* core_sub */, int i, int j, void* userdata)
 {
     BaseMolecule& mol1 = (BaseMolecule&)g1;
     BaseMolecule& mol2 = (BaseMolecule&)g2;

--- a/core/indigo-core/molecule/src/molecule.cpp
+++ b/core/indigo-core/molecule/src/molecule.cpp
@@ -27,7 +27,6 @@
 
 #ifdef _MSC_VER
 #pragma warning(push, 4)
-#pragma warning(error : 4100 4101 4189 4244 4456 4458 4715)
 #endif
 
 using namespace indigo;

--- a/core/indigo-core/molecule/src/molecule.cpp
+++ b/core/indigo-core/molecule/src/molecule.cpp
@@ -25,6 +25,11 @@
 #include "molecule/molecule_dearom.h"
 #include "molecule/molecule_standardize.h"
 
+#ifdef _MSC_VER
+#pragma warning(push, 4)
+#pragma warning(error : 4100 4101 4189 4244 4456 4458 4715)
+#endif
+
 using namespace indigo;
 
 Molecule::Molecule()
@@ -69,7 +74,7 @@ void Molecule::_flipBond(int atom_parent, int atom_from, int atom_to)
     updateEditRevision();
 }
 
-void Molecule::_mergeWithSubmolecule(BaseMolecule& bmol, const Array<int>& vertices, const Array<int>* edges, const Array<int>& mapping, int skip_flags)
+void Molecule::_mergeWithSubmolecule(BaseMolecule& bmol, const Array<int>& vertices, const Array<int>* edges, const Array<int>& mapping, int /*skip_flags*/)
 {
     Molecule& mol = bmol.asMolecule();
     _ignore_bad_valence = mol.getIgnoreBadValenceFlag();
@@ -535,7 +540,7 @@ int Molecule::totalHydrogensCount()
     return total_h;
 }
 
-int Molecule::matchAtomsCmp(Graph& g1, Graph& g2, int idx1, int idx2, void* userdata)
+int Molecule::matchAtomsCmp(Graph& g1, Graph& g2, int idx1, int idx2, void* /*userdata*/)
 {
     Molecule& m1 = ((BaseMolecule&)g1).asMolecule();
     Molecule& m2 = ((BaseMolecule&)g2).asMolecule();
@@ -845,7 +850,7 @@ int Molecule::_getImplicitHForConnectivity(int idx, int conn, bool use_cache)
         }
         else
         {
-            int radical = -1;
+            radical = -1;
 
             if (_radicals.size() > idx)
                 radical = _radicals[idx];
@@ -1689,7 +1694,7 @@ bool Molecule::ionize(float ph, float ph_toll, const IonizeOptions& options)
     return MoleculeIonizer::ionize(*this, ph, ph_toll, options);
 }
 
-bool Molecule::isPossibleFischerProjection(const char* options)
+bool Molecule::isPossibleFischerProjection(const char* /*options*/)
 {
     if (!BaseMolecule::hasCoord(*this) || BaseMolecule::hasZCoord(*this))
         return false;
@@ -1760,3 +1765,7 @@ bool Molecule::isPiBonded(const int atom_index) const
     }
     return false;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/src/molecule_allene_stereo.cpp
+++ b/core/indigo-core/molecule/src/molecule_allene_stereo.cpp
@@ -709,7 +709,7 @@ void MoleculeAlleneStereo::removeAtoms(BaseMolecule& baseMolecule, const Array<i
         }
     }
 
-    for (int i = 0; i < centers_to_remove.size(); i++)
+    for (i = 0; i < centers_to_remove.size(); i++)
     {
         int idx = centers_to_remove[i];
         if (_centers.find(idx))

--- a/core/indigo-core/molecule/src/molecule_arom.cpp
+++ b/core/indigo-core/molecule/src/molecule_arom.cpp
@@ -49,8 +49,8 @@ AromatizerBase::AromatizerBase(BaseMolecule& molecule)
         SGroup& sgroup = molecule.sgroups.getSGroup(i);
         if (sgroup.sgroup_type == SGroup::SG_TYPE_SUP)
         {
-            for (int i = 0; i < sgroup.atoms.size(); i++)
-                _inside_superatoms.find_or_insert(sgroup.atoms[i]);
+            for (int j = 0; j < sgroup.atoms.size(); j++)
+                _inside_superatoms.find_or_insert(sgroup.atoms[j]);
         }
     }
 }

--- a/core/indigo-core/molecule/src/molecule_arom.cpp
+++ b/core/indigo-core/molecule/src/molecule_arom.cpp
@@ -174,13 +174,13 @@ bool AromatizerBase::handleUnsureCycles()
     return is_all_aromatic;
 }
 
-bool AromatizerBase::_cb_check_vertex(Graph& graph, int v_idx, void* context)
+bool AromatizerBase::_cb_check_vertex(Graph& /*graph*/, int v_idx, void* context)
 {
     AromatizerBase* arom = (AromatizerBase*)context;
     return arom->_checkVertex(v_idx);
 }
 
-bool AromatizerBase::_cb_handle_cycle(Graph& graph, const Array<int>& vertices, const Array<int>& edges, void* context)
+bool AromatizerBase::_cb_handle_cycle(Graph& /*graph*/, const Array<int>& vertices, const Array<int>& /*edges*/, void* context)
 {
     AromatizerBase* arom = (AromatizerBase*)context;
     arom->_handleCycle(vertices);
@@ -268,12 +268,12 @@ void AromatizerBase::removeAromaticCycle(int id, const int* cycle, int cycle_len
     }
 }
 
-bool AromatizerBase::_checkVertex(int v_idx)
+bool AromatizerBase::_checkVertex(int /*v_idx*/)
 {
     return true;
 }
 
-void AromatizerBase::_handleAromaticCycle(const int* cycle, int cycle_len)
+void AromatizerBase::_handleAromaticCycle(const int* /*cycle*/, int /*cycle_len*/)
 {
 }
 

--- a/core/indigo-core/molecule/src/molecule_arom.cpp
+++ b/core/indigo-core/molecule/src/molecule_arom.cpp
@@ -641,7 +641,7 @@ QueryMoleculeAromatizer::PiValue QueryMoleculeAromatizer::_getPiLabel(int v_idx)
         }
     }
 
-    if (_options.aromatize_skip_superatoms && _inside_superatoms.size() && _inside_superatoms.find(v_idx) != _inside_superatoms.end())
+    if (_options.aromatize_skip_superatoms && _inside_superatoms.size() && _inside_superatoms.find(v_idx))
         return PiValue(-1, -1);
 
     if (query.isRSite(v_idx))

--- a/core/indigo-core/molecule/src/molecule_auto_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_auto_loader.cpp
@@ -131,8 +131,7 @@ bool MoleculeAutoLoader::tryMDLCT(Scanner& scanner, Array<char>& outbuf)
                 scanner.seek(pos, SEEK_SET);
                 return false;
             }
-            int c = scanner.readChar();
-            curline.push(c);
+            curline.push(scanner.readChar());
         }
 
         curline.push(0);
@@ -448,11 +447,11 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
                     throw Error("InChI input doesn't support query molecules");
                 }
 
-                Array<char> inchi;
-                _scanner->readWord(inchi, " ");
+                Array<char> inchi_data;
+                _scanner->readWord(inchi_data, " ");
 
                 InchiWrapper loader;
-                loader.loadMoleculeFromInchi(inchi.ptr(), (Molecule&)mol);
+                loader.loadMoleculeFromInchi(inchi_data.ptr(), (Molecule&)mol);
                 return;
             }
         }

--- a/core/indigo-core/molecule/src/molecule_auto_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_auto_loader.cpp
@@ -219,7 +219,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
         base64_str.erase(std::remove_if(base64_str.begin(), base64_str.end(), [](char c) { return c == '\n' || c == '\r'; }), base64_str.end());
         if (validate_base64(base64_str))
         {
-            base64_data.copy(base64_str.data(), base64_str.size());
+            base64_data.copy(base64_str.data(), static_cast<int>(base64_str.size()));
             base64_scanner = std::make_unique<BufferScanner>(base64_data, true);
             local_scanner = base64_scanner.get();
         }
@@ -393,10 +393,10 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
             const std::string kDNA = "DNA:";
 
             long long start_pos = _scanner->tell();
-            if (_scanner->length() > kRNA.size())
+            if (_scanner->length() > static_cast<long long>(kRNA.size()))
             {
                 std::vector<char> tag(kPeptide.size() + 1, 0);
-                _scanner->readCharsFix(kRNA.size(), tag.data());
+                _scanner->readCharsFix(static_cast<int>(kRNA.size()), tag.data());
                 SequenceLoader sl(*_scanner);
                 if (kRNA == tag.data())
                 {
@@ -411,9 +411,9 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
                 else
                 {
                     _scanner->seek(start_pos, SEEK_SET);
-                    if (_scanner->length() > kPeptide.size())
+                    if (_scanner->length() > static_cast<long long>(kPeptide.size()))
                     {
-                        _scanner->readCharsFix(kPeptide.size(), tag.data());
+                        _scanner->readCharsFix(static_cast<int>(kPeptide.size()), tag.data());
                         if (kPeptide == tag.data())
                         {
                             sl.loadSequence(mol, SequenceLoader::SeqType::PEPTIDESeq);
@@ -480,7 +480,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
                 {
                     loader.loadQueryMolecule(static_cast<QueryMolecule&>(mol));
                 }
-                catch (Exception& e)
+                catch (Exception&)
                 {
                     _scanner->seek(start, SEEK_SET);
                     loader.loadSMARTS(static_cast<QueryMolecule&>(mol));
@@ -507,7 +507,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol)
             parser.parseMolecule(name.ptr(), static_cast<Molecule&>(mol));
             return;
         }
-        catch (Exception& e)
+        catch (Exception&)
         {
         }
 

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -160,7 +160,7 @@ void MoleculeCdxmlLoader::_parseCollections(BaseMolecule& mol)
     std::vector<int> atoms;
     for (auto& node : nodes)
     {
-        int node_idx = _id_to_node_index.at(node.id);
+        int node_idx = static_cast<int>(_id_to_node_index.at(node.id));
         switch (node.type)
         {
         case kCDXNodeType_NamedAlternativeGroup:
@@ -328,7 +328,7 @@ void MoleculeCdxmlLoader::_parseCDXMLPage(CDXElement elem)
 
 void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings, bool inside_fragment_node)
 {
-    int fragment_start_idx = -1;
+    size_t fragment_start_idx = -1;
 
     auto node_lambda = [this](CDXElement elem) {
         CdxmlNode node;
@@ -336,11 +336,11 @@ void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings,
         _addNode(node);
         if (node.has_fragment)
         {
-            int inner_idx_start = nodes.size();
+            auto inner_idx_start = nodes.size();
             this->_parseCDXMLElements(elem.firstChildElement(), false, true);
-            int inner_idx_end = nodes.size();
+            auto inner_idx_end = nodes.size();
             CdxmlNode& fragment_node = nodes[inner_idx_start - 1];
-            for (int i = inner_idx_start; i < inner_idx_end; ++i)
+            for (auto i = inner_idx_start; i < inner_idx_end; ++i)
             {
                 auto it = std::upper_bound(fragment_node.inner_nodes.cbegin(), fragment_node.inner_nodes.cend(), fragment_node.id,
                                            [](int a, int b) { return a > b; });
@@ -374,7 +374,7 @@ void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings,
         {
             CdxmlBracket bracket;
             bracket.is_superatom = true;
-            for (int node_idx = fragment_start_idx; node_idx < this->nodes.size(); ++node_idx)
+            for (auto node_idx = fragment_start_idx; node_idx < this->nodes.size(); ++node_idx)
             {
                 auto& node = this->nodes[node_idx];
                 if (node.type == kCDXNodeType_Element || node.type == kCDXNodeType_ElementList)
@@ -431,11 +431,11 @@ void MoleculeCdxmlLoader::_updateConnection(const CdxmlNode& node, int atom_idx)
 void MoleculeCdxmlLoader::_addAtomsAndBonds(BaseMolecule& mol, const std::vector<int>& atoms, const std::vector<CdxmlBond>& bonds)
 {
     _id_to_atom_idx.clear();
-    mol.reaction_atom_mapping.clear_resize(atoms.size());
+    mol.reaction_atom_mapping.clear_resize(static_cast<int>(atoms.size()));
     mol.reaction_atom_mapping.zerofill();
-    mol.reaction_atom_inversion.clear_resize(atoms.size());
+    mol.reaction_atom_inversion.clear_resize(static_cast<int>(atoms.size()));
     mol.reaction_atom_inversion.zerofill();
-    mol.reaction_atom_exact_change.clear_resize(atoms.size());
+    mol.reaction_atom_exact_change.clear_resize(static_cast<int>(atoms.size()));
     mol.reaction_atom_exact_change.zerofill();
 
     int atom_idx;
@@ -739,7 +739,7 @@ void MoleculeCdxmlLoader::_handleSGroup(SGroup& sgroup, const std::unordered_set
 
 void MoleculeCdxmlLoader::_parseFragmentAttributes(CDXProperty prop)
 {
-    for (prop; prop.hasContent(); prop = prop.next())
+    for (; prop.hasContent(); prop = prop.next())
     {
         // it means that we are inside of NodeType=Fragment
         // let's check it
@@ -767,7 +767,7 @@ void MoleculeCdxmlLoader::_parseFragmentAttributes(CDXProperty prop)
 
 void MoleculeCdxmlLoader::applyDispatcher(CDXProperty prop, const std::unordered_map<std::string, std::function<void(const std::string&)>>& dispatcher)
 {
-    for (prop; prop.hasContent(); prop = prop.next())
+    for (; prop.hasContent(); prop = prop.next())
     {
         auto it = dispatcher.find(prop.name());
         if (it != dispatcher.end())

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -328,7 +328,7 @@ void MoleculeCdxmlLoader::_parseCDXMLPage(CDXElement elem)
 
 void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings, bool inside_fragment_node)
 {
-    size_t fragment_start_idx = -1;
+    int fragment_start_idx = -1;
 
     auto node_lambda = [this](CDXElement elem) {
         CdxmlNode node;
@@ -356,7 +356,7 @@ void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings,
     };
 
     auto fragment_lambda = [this, &fragment_start_idx](CDXElement elem) {
-        fragment_start_idx = nodes.size();
+        fragment_start_idx = static_cast<int>(nodes.size());
         this->_parseFragmentAttributes(elem.firstProperty());
         this->_parseCDXMLElements(elem.firstChildElement());
     };

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -862,7 +862,7 @@ void MoleculeCdxmlLoader::_parseNode(CdxmlNode& node, CDXElement elem)
                     node.type = kCDXNodeType_NamedAlternativeGroup;
                     node.element = ELEM_RSITE;
                 }
-                catch (const std::exception& ex)
+                catch (const std::exception&)
                 {
                     // not a R-Group
                 }
@@ -1243,9 +1243,9 @@ void MoleculeCdxmlLoader::_parseText(CDXElement elem, std::vector<std::pair<Vec3
             {
                 writer.StartObject();
                 writer.Key("offset");
-                writer.Int(ts.offset);
+                writer.Int(static_cast<int>(ts.offset));
                 writer.Key("length");
-                writer.Int(ts.size);
+                writer.Int(static_cast<int>(ts.size));
                 writer.Key("style");
                 writer.String(style_str.c_str());
                 writer.EndObject();

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -65,7 +65,7 @@ CDXProperty CDXProperty::getNextProp()
         auto ptr16 = (uint16_t*)_data;
         if (*ptr16 == kCDXProp_Text && _style_index >= 0 && _style_prop >= 0)
         {
-            if (++_style_prop < KStyleProperties.size())
+            if (++_style_prop < static_cast<int>(KStyleProperties.size()))
                 return CDXProperty(_data, _data_limit, _size, 0, _style_index, _style_prop);
             else
                 return CDXProperty();
@@ -376,7 +376,7 @@ void MoleculeCdxmlLoader::_parseCDXMLElements(CDXElement elem, bool no_siblings,
         {
             CdxmlBracket bracket;
             bracket.is_superatom = true;
-            for (auto node_idx = fragment_start_idx; node_idx < this->nodes.size(); ++node_idx)
+            for (size_t node_idx = fragment_start_idx; node_idx < this->nodes.size(); ++node_idx)
             {
                 auto& node = this->nodes[node_idx];
                 if (node.type == kCDXNodeType_Element || node.type == kCDXNodeType_ElementList)
@@ -752,7 +752,7 @@ void MoleculeCdxmlLoader::_parseFragmentAttributes(CDXProperty prop)
                 auto vec_str = split(prop.value(), ' ');
                 if (fn.connections.size() == vec_str.size())
                 {
-                    for (int i = 0; i < vec_str.size(); ++i)
+                    for (size_t i = 0; i < vec_str.size(); ++i)
                     {
                         auto pid = std::stoi(vec_str[i]);
                         fn.connections[i].point_id = pid;

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -428,7 +428,7 @@ void MoleculeCdxmlLoader::_updateConnection(const CdxmlNode& node, int atom_idx)
     }
 }
 
-void MoleculeCdxmlLoader::_addAtomsAndBonds(BaseMolecule& mol, const std::vector<int>& atoms, const std::vector<CdxmlBond>& bonds)
+void MoleculeCdxmlLoader::_addAtomsAndBonds(BaseMolecule& mol, const std::vector<int>& atoms, const std::vector<CdxmlBond>& new_bonds)
 {
     _id_to_atom_idx.clear();
     mol.reaction_atom_mapping.clear_resize(static_cast<int>(atoms.size()));
@@ -438,7 +438,6 @@ void MoleculeCdxmlLoader::_addAtomsAndBonds(BaseMolecule& mol, const std::vector
     mol.reaction_atom_exact_change.clear_resize(static_cast<int>(atoms.size()));
     mol.reaction_atom_exact_change.zerofill();
 
-    int atom_idx;
     for (auto atom_idx : atoms)
     {
         auto& atom = nodes[atom_idx];
@@ -481,7 +480,7 @@ void MoleculeCdxmlLoader::_addAtomsAndBonds(BaseMolecule& mol, const std::vector
         }
     }
 
-    for (const auto& bond : bonds)
+    for (const auto& bond : new_bonds)
     {
         int bond_idx;
         if (_pmol)

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -37,6 +37,7 @@ bool is_fragment(int node_type)
     return node_type == kCDXNodeType_Nickname || node_type == kCDXNodeType_Fragment;
 }
 
+/*/
 static float readFloat(const char* point_str)
 {
     float res = 0;
@@ -47,6 +48,7 @@ static float readFloat(const char* point_str)
     }
     return res;
 }
+//*/
 
 IMPL_ERROR(MoleculeCdxmlLoader, "CDXML loader");
 IMPL_ERROR(CDXMLReader, "CDXML reader");
@@ -869,9 +871,9 @@ void MoleculeCdxmlLoader::_parseNode(CdxmlNode& node, CDXElement elem)
             }
             if (node.element == ELEM_C) // overridable
             {
-                auto elem = Element::fromString2(label.c_str());
-                if (elem > 0)
-                    node.element = elem;
+                auto element = Element::fromString2(label.c_str());
+                if (element > 0)
+                    node.element = element;
                 else if (node.label.empty())
                 {
                     node.label = label;

--- a/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
@@ -16,6 +16,11 @@
  * limitations under the License.
  ***************************************************************************/
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4315) // TODO: Fix CDXFont allign issue
+#endif
+
 #include "molecule/molecule_cdxml_saver.h"
 #include "base_cpp/locale_guard.h"
 #include "base_cpp/output.h"
@@ -48,13 +53,13 @@ void MoleculeCdxmlSaver::writeBinaryTextValue(const tinyxml2::XMLElement* pTextE
             {
                 std::string attr_name = pAttr->Name();
                 if (attr_name == "font")
-                    ts.font_index = pAttr->IntValue();
+                    ts.font_index = static_cast<uint16_t>(pAttr->IntValue());
                 else if (attr_name == "size")
                     ts.font_size = static_cast<uint16_t>(pAttr->FloatValue() * kCDXMLSizeMultiplier);
                 else if (attr_name == "color")
-                    ts.font_color = pAttr->IntValue();
+                    ts.font_color = static_cast<uint16_t>(pAttr->IntValue());
                 else if (attr_name == "face")
-                    ts.font_face = pAttr->IntValue();
+                    ts.font_face = static_cast<uint16_t>(pAttr->IntValue());
             }
             ts.offset = static_cast<uint16_t>(text.size());
             styled_strings.push_back(ts);
@@ -91,7 +96,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
     case ECDXType::CDXString: {
         std::string val = pAttr->Value();
         uint16_t styles = 0;
-        _output.writeBinaryUInt16(static_cast<int>(val.size() + sizeof(styles)));
+        _output.writeBinaryUInt16(static_cast<uint16_t>(val.size() + sizeof(styles)));
         _output.writeBinaryUInt16(styles);
         _output.write(val.data(), static_cast<int>(val.size()));
     }
@@ -112,7 +117,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
             val = kLabelAlignmentStrToInt.at(pAttr->Value());
             break;
         case kCDXProp_Atom_Radical:
-            val = kRadicalStrToId.at(pAttr->Value());
+            val = static_cast<int8_t>(kRadicalStrToId.at(pAttr->Value()));
             break;
         case kCDXProp_Bond_CIPStereochemistry:
             val = kCIPBondStereochemistryIndexToChar.at(pAttr->Value()[0]);
@@ -121,16 +126,16 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
             val = kCIPStereochemistryCharToIndex.at(pAttr->Value()[0]);
             break;
         case kCDXProp_Arrow_Type:
-            val = kCDXProp_Arrow_TypeStrToID.at(pAttr->Value());
+            val = static_cast<int8_t>(kCDXProp_Arrow_TypeStrToID.at(pAttr->Value()));
             break;
         case kCDXProp_Atom_Geometry:
-            val = KGeometryTypeNameToInt.at(pAttr->Value());
+            val = static_cast<int8_t>(KGeometryTypeNameToInt.at(pAttr->Value()));
             break;
         case kCDXProp_Atom_EnhancedStereoType:
-            val = (int)kCDXEnhancedStereoStrToID.at(pAttr->Value());
+            val = static_cast<int8_t>(kCDXEnhancedStereoStrToID.at(pAttr->Value()));
             break;
         default:
-            val = pAttr->IntValue();
+            val = static_cast<int8_t>(pAttr->IntValue());
             break;
         }
         _output.writeBinaryUInt16(sizeof(val));
@@ -140,14 +145,14 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
 
     case ECDXType::CDXINT16:
     case ECDXType::CDXUINT16: {
-        int16_t val = pAttr->IntValue();
+        int16_t val = static_cast<int16_t>(pAttr->IntValue());
         switch (tag)
         {
         case kCDXProp_Node_Type:
-            val = KNodeTypeNameToInt.at(pAttr->Value());
+            val = static_cast<int16_t>(KNodeTypeNameToInt.at(pAttr->Value()));
             break;
         case kCDXProp_Graphic_Type:
-            val = kCDXPropGraphicTypeStrToID.at(pAttr->Value());
+            val = static_cast<int16_t>(kCDXPropGraphicTypeStrToID.at(pAttr->Value()));
             break;
         case kCDXProp_Rectangle_Type: {
             auto vecs = split(pAttr->Value(), ' ');
@@ -159,17 +164,17 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
             val *= kBondSpacingMultiplier;
             break;
         case kCDXProp_Line_Type:
-            val = kLineTypeStrToInt.at(pAttr->Value());
+            val = static_cast<int16_t>(kLineTypeStrToInt.at(pAttr->Value()));
             break;
         case kCDXProp_Arrow_Type:
-            val = kCDXProp_Arrow_TypeStrToID.at(pAttr->Value());
+            val = static_cast<int16_t>(kCDXProp_Arrow_TypeStrToID.at(pAttr->Value()));
             break;
         case kCDXProp_Arrow_ArrowHead_Head:
         case kCDXProp_Arrow_ArrowHead_Tail:
             val = kCDXProp_Arrow_ArrowHeadStrToInt.at(pAttr->Value());
             break;
         case kCDXProp_Bond_Display:
-            val = kCDXProp_Bond_DisplayStrToID.at(pAttr->Value());
+            val = static_cast<int16_t>(kCDXProp_Bond_DisplayStrToID.at(pAttr->Value()));
             break;
         }
 
@@ -240,7 +245,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
             std::stringstream converter;
             converter << std::hex << hex_str;
             converter >> val;
-            bytes_vector.push_back(val);
+            bytes_vector.push_back(static_cast<uint8_t>(val));
         }
         _output.writeBinaryUInt16(static_cast<uint16_t>(bytes_vector.size()));
         _output.write(bytes_vector.data(), static_cast<int>(bytes_vector.size()));
@@ -380,7 +385,7 @@ void MoleculeCdxmlSaver::beginDocument(Bounds* bounds)
     _current = _root;
 }
 
-void MoleculeCdxmlSaver::beginPage(Bounds* bounds)
+void MoleculeCdxmlSaver::beginPage(Bounds* /* bounds */)
 {
     _page = _doc->NewElement("page");
     _root->LinkEndChild(_page);
@@ -817,17 +822,16 @@ void MoleculeCdxmlSaver::addNodeToFragment(BaseMolecule& mol, XMLElement* fragme
         s->LinkEndChild(txt);
         if (hcount > 1)
         {
-            XMLElement* s = _doc->NewElement("s");
-            t->LinkEndChild(s);
-            s->SetAttribute("font", 3);
-            s->SetAttribute("size", 10);
-            s->SetAttribute("face", 32);
+            XMLElement* ss = _doc->NewElement("s");
+            t->LinkEndChild(ss);
+            ss->SetAttribute("font", 3);
+            ss->SetAttribute("size", 10);
+            ss->SetAttribute("face", 32);
 
             out.clear();
             out.printf("%d", hcount);
             buf.push(0);
-            XMLText* txt = _doc->NewText(buf.ptr());
-            s->LinkEndChild(txt);
+            ss->LinkEndChild(_doc->NewText(buf.ptr()));
         }
     }
     else if (atom_number < 0 && mol.isQueryMolecule())
@@ -1088,7 +1092,7 @@ void MoleculeCdxmlSaver::saveMoleculeFragment(BaseMolecule& mol, const Vec2f& of
 
 void MoleculeCdxmlSaver::saveRGroup(PtrPool<BaseMolecule>& fragments, const Vec2f& offset, int rgnum)
 {
-    XMLElement* parent = _current;
+    // XMLElement* parent = _current;
     XMLElement* fragment = _doc->NewElement("altgroup");
     _current->LinkEndChild(fragment);
     _current = fragment;
@@ -1375,14 +1379,15 @@ void MoleculeCdxmlSaver::addMetaObject(const MetaObject& obj, int id)
     break;
     case KETTextObject::CID: {
         const KETTextObject& ko = static_cast<const KETTextObject&>(obj);
-        double text_offset_y = 0;
+        // double text_offset_y = 0;
         int font_size = static_cast<int>(KETDefaultFontSize);
         CDXMLFontStyle font_face(0);
         for (auto& text_item : ko._block)
         {
-            size_t first_index = -1;
-            size_t second_index = -1;
-            double text_offset_x = 0;
+            bool is_first_index = true;
+            size_t first_index = 0;
+            size_t second_index = 0;
+            // double text_offset_x = 0;
             FONT_STYLE_SET current_styles;
             Vec2f text_origin(ko._pos.x, ko._pos.y);
             std::string pos_str = std::to_string(_bond_length * text_origin.x) + " " + std::to_string(-_bond_length * text_origin.y);
@@ -1394,10 +1399,11 @@ void MoleculeCdxmlSaver::addMetaObject(const MetaObject& obj, int id)
             t->SetAttribute("InterpretChemically", "no");
             for (auto& kvp : text_item.styles)
             {
-                if (first_index == -1)
+                if (is_first_index)
                 {
                     first_index = kvp.first;
                     current_styles = kvp.second;
+                    is_first_index = false;
                     continue;
                 }
                 second_index = kvp.first;
@@ -1630,6 +1636,7 @@ void MoleculeCdxmlSaver::writeIrregularElement(tinyxml2::XMLElement* pElement, i
     {
     case kCDXProp_FontTable: {
         std::vector<CDXFont> font_table;
+
         uint16_t total_size = sizeof(uint16_t) * 2; // platform type + fonts counter
         for (auto pElem = pElement->FirstChildElement(); pElem; pElem = pElem->NextSiblingElement())
         {
@@ -1640,10 +1647,10 @@ void MoleculeCdxmlSaver::writeIrregularElement(tinyxml2::XMLElement* pElement, i
                 {
                     std::string attr_name = pAttr->Name();
                     if (attr_name == "id")
-                        font.font_id = pAttr->IntValue();
+                        font.font_id = static_cast<uint16_t>(pAttr->IntValue());
                     else if (attr_name == "charset")
                     {
-                        font.char_set = kCharsetStrToInt.at(pAttr->Value());
+                        font.char_set = static_cast<uint16_t>(kCharsetStrToInt.at(pAttr->Value()));
                     }
                     else if (attr_name == "name")
                         font.name = pAttr->Value();
@@ -1732,17 +1739,17 @@ void MoleculeCdxmlSaver::writeBinaryElement(tinyxml2::XMLElement* element)
 {
     std::string objname = element->Value();
     int id = 0, tag = 0;
-    bool is_object = false;
+    // bool is_object = false;
     if (objname != "CDXML")
     {
         auto it = KCDXNameToObjID.find(objname);
         if (it != KCDXNameToObjID.end())
         {
             tag = it->second;
-            _output.writeBinaryUInt16(tag);
+            _output.writeBinaryUInt16(static_cast<uint16_t>(tag));
             if (tag < kCDXTag_Object)
             {
-                writeIrregularElement(element, tag);
+                writeIrregularElement(element, static_cast<uint16_t>(tag));
                 return;
             }
         }
@@ -1877,3 +1884,7 @@ void MoleculeCdxmlSaver::saveMolecule(BaseMolecule& mol)
     endPage();
     endDocument();
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
@@ -56,7 +56,7 @@ void MoleculeCdxmlSaver::writeBinaryTextValue(const tinyxml2::XMLElement* pTextE
                 else if (attr_name == "face")
                     ts.font_face = pAttr->IntValue();
             }
-            ts.offset = text.size();
+            ts.offset = static_cast<uint16_t>(text.size());
             styled_strings.push_back(ts);
             auto ptext = pStyleElem->GetText();
             if (ptext)
@@ -67,8 +67,8 @@ void MoleculeCdxmlSaver::writeBinaryTextValue(const tinyxml2::XMLElement* pTextE
     _output.writeBinaryUInt16(kCDXProp_Text);
     if (text.size())
     {
-        _output.writeBinaryUInt16(styled_strings.size() * sizeof(CDXTextStyle) + sizeof(uint16_t) + text.size());
-        _output.writeBinaryUInt16(styled_strings.size());
+        _output.writeBinaryUInt16(static_cast<uint16_t>(styled_strings.size() * sizeof(CDXTextStyle) + sizeof(uint16_t) + text.size()));
+        _output.writeBinaryUInt16(static_cast<uint16_t>(styled_strings.size()));
         for (const auto& ss : styled_strings)
         {
             _output.writeBinaryUInt16(ss.offset);
@@ -77,7 +77,7 @@ void MoleculeCdxmlSaver::writeBinaryTextValue(const tinyxml2::XMLElement* pTextE
             _output.writeBinaryUInt16(ss.font_size);
             _output.writeBinaryUInt16(ss.font_color);
         }
-        _output.write(text.c_str(), text.size());
+        _output.write(text.c_str(), static_cast<int>(text.size()));
     }
     else
         _output.writeBinaryUInt16(0);
@@ -91,9 +91,9 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
     case ECDXType::CDXString: {
         std::string val = pAttr->Value();
         uint16_t styles = 0;
-        _output.writeBinaryUInt16(val.size() + sizeof(styles));
+        _output.writeBinaryUInt16(static_cast<int>(val.size() + sizeof(styles)));
         _output.writeBinaryUInt16(styles);
-        _output.write((const void*)val.data(), val.size());
+        _output.write(val.data(), static_cast<int>(val.size()));
     }
     break;
 
@@ -199,7 +199,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
                 std::swap(vec_strs[i], vec_strs[i + 1]);
         }
 
-        _output.writeBinaryUInt16(sizeof(int32_t) * vec_strs.size());
+        _output.writeBinaryUInt16(static_cast<uint16_t>(sizeof(int32_t) * vec_strs.size()));
 
         for (const auto& v : vec_strs)
         {
@@ -242,15 +242,15 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
             converter >> val;
             bytes_vector.push_back(val);
         }
-        _output.writeBinaryUInt16(bytes_vector.size());
-        _output.write(bytes_vector.data(), bytes_vector.size());
+        _output.writeBinaryUInt16(static_cast<uint16_t>(bytes_vector.size()));
+        _output.write(bytes_vector.data(), static_cast<int>(bytes_vector.size()));
     }
     break;
 
     case ECDXType::CDXObjectIDArray: {
         std::string values = pAttr->Value();
         auto vals = split(values, ' ');
-        _output.writeBinaryUInt16(vals.size() * sizeof(int32_t));
+        _output.writeBinaryUInt16(static_cast<uint16_t>(vals.size() * sizeof(int32_t)));
         for (const auto& val : vals)
             _output.writeBinaryInt(std::stoi(val));
     }
@@ -492,7 +492,7 @@ void MoleculeCdxmlSaver::addDefaultColorTable()
 int MoleculeCdxmlSaver::_getAttachmentPoint(BaseMolecule& mol, int atom_idx)
 {
     int val = 0;
-    if (mol.attachmentPointCount())
+    if (mol.attachmentPointCount() != 0)
     {
         for (int idx = 1; idx <= mol.attachmentPointCount(); idx++)
         {
@@ -1380,8 +1380,8 @@ void MoleculeCdxmlSaver::addMetaObject(const MetaObject& obj, int id)
         CDXMLFontStyle font_face(0);
         for (auto& text_item : ko._block)
         {
-            int first_index = -1;
-            int second_index = -1;
+            size_t first_index = -1;
+            size_t second_index = -1;
             double text_offset_x = 0;
             FONT_STYLE_SET current_styles;
             Vec2f text_origin(ko._pos.x, ko._pos.y);
@@ -1649,20 +1649,20 @@ void MoleculeCdxmlSaver::writeIrregularElement(tinyxml2::XMLElement* pElement, i
                         font.name = pAttr->Value();
                 }
                 font_table.push_back(font);
-                total_size += sizeof(uint16_t) * 3 + font.name.size(); // font id + charset + name length + name
+                total_size += static_cast<uint16_t>(sizeof(uint16_t) * 3 + font.name.size()); // font id + charset + name length + name
             }
         }
 
         _output.writeBinaryUInt16(total_size);
         _output.writeBinaryUInt16(0); // platform type
-        _output.writeBinaryUInt16(font_table.size());
+        _output.writeBinaryUInt16(static_cast<uint16_t>(font_table.size()));
 
         for (const auto& ft : font_table)
         {
             _output.writeBinaryUInt16(ft.font_id);
             _output.writeBinaryUInt16(ft.char_set);
-            _output.writeBinaryUInt16(ft.name.size());
-            _output.write(ft.name.c_str(), ft.name.size());
+            _output.writeBinaryUInt16(static_cast<uint16_t>(ft.name.size()));
+            _output.write(ft.name.c_str(), static_cast<int>(ft.name.size()));
         }
     }
     break;
@@ -1689,8 +1689,8 @@ void MoleculeCdxmlSaver::writeIrregularElement(tinyxml2::XMLElement* pElement, i
             }
             color_table.emplace_back(r, g, b);
         }
-        _output.writeBinaryUInt16(color_table.size() * sizeof(CDXColor) + sizeof(uint16_t));
-        _output.writeBinaryUInt16(color_table.size());
+        _output.writeBinaryUInt16(static_cast<uint16_t>(color_table.size() * sizeof(CDXColor) + sizeof(uint16_t)));
+        _output.writeBinaryUInt16(static_cast<uint16_t>(color_table.size()));
         for (const auto& rgb : color_table)
         {
             _output.write(&rgb, sizeof(rgb));

--- a/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
@@ -200,7 +200,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
         auto vec_strs = split(values, ' ');
         if (vec_strs.size() % 2 == 0)
         {
-            for (int i = 0; i < vec_strs.size(); i += 2)
+            for (size_t i = 0; i < vec_strs.size(); i += 2)
                 std::swap(vec_strs[i], vec_strs[i + 1]);
         }
 
@@ -238,7 +238,7 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
     case ECDXType::CDXUnformatted: {
         std::string values = pAttr->Value();
         std::vector<uint8_t> bytes_vector;
-        for (int i = 0; i < values.size(); i += 2)
+        for (size_t i = 0; i < values.size(); i += 2)
         {
             uint32_t val;
             std::string hex_str = values.substr(i, 2);
@@ -1050,7 +1050,7 @@ void MoleculeCdxmlSaver::addFragmentNodes(BaseMolecule& mol, tinyxml2::XMLElemen
         if (connection_order.size() > 1)
         {
             std::string order;
-            for (int i = 0; i < connection_order.size(); ++i)
+            for (size_t i = 0; i < connection_order.size(); ++i)
             {
                 if (i)
                     order += " ";
@@ -1062,7 +1062,7 @@ void MoleculeCdxmlSaver::addFragmentNodes(BaseMolecule& mol, tinyxml2::XMLElemen
         if (bond_ordering.size() > 1)
         {
             std::string order;
-            for (int i = 0; i < bond_ordering.size(); ++i)
+            for (size_t i = 0; i < bond_ordering.size(); ++i)
             {
                 if (i)
                     order += " ";

--- a/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_saver.cpp
@@ -50,7 +50,7 @@ void MoleculeCdxmlSaver::writeBinaryTextValue(const tinyxml2::XMLElement* pTextE
                 if (attr_name == "font")
                     ts.font_index = pAttr->IntValue();
                 else if (attr_name == "size")
-                    ts.font_size = pAttr->FloatValue() * kCDXMLSizeMultiplier;
+                    ts.font_size = static_cast<uint16_t>(pAttr->FloatValue() * kCDXMLSizeMultiplier);
                 else if (attr_name == "color")
                     ts.font_color = pAttr->IntValue();
                 else if (attr_name == "face")
@@ -203,14 +203,14 @@ void MoleculeCdxmlSaver::writeBinaryValue(const XMLAttribute* pAttr, int16_t tag
 
         for (const auto& v : vec_strs)
         {
-            int32_t coord = std::stof(v) * (1 << 16);
+            int32_t coord = static_cast<int32_t>(std::stof(v) * (1 << 16));
             _output.writeBinaryInt(coord);
         }
     }
     break;
 
     case ECDXType::CDXCoordinate: {
-        int32_t coord = pAttr->FloatValue() * (1 << 16);
+        int32_t coord = static_cast<int32_t>(pAttr->FloatValue() * (1 << 16));
         _output.writeBinaryUInt16(sizeof(coord));
         _output.writeBinaryInt(coord);
     }
@@ -1376,7 +1376,7 @@ void MoleculeCdxmlSaver::addMetaObject(const MetaObject& obj, int id)
     case KETTextObject::CID: {
         const KETTextObject& ko = static_cast<const KETTextObject&>(obj);
         double text_offset_y = 0;
-        int font_size = KETDefaultFontSize;
+        int font_size = static_cast<int>(KETDefaultFontSize);
         CDXMLFontStyle font_face(0);
         for (auto& text_item : ko._block)
         {
@@ -1426,7 +1426,7 @@ void MoleculeCdxmlSaver::addMetaObject(const MetaObject& obj, int id)
                         font_face.is_subscript = text_style.second;
                         break;
                     default:
-                        font_size = text_style.second ? text_style.first : KETDefaultFontSize;
+                        font_size = text_style.second ? text_style.first : static_cast<int>(KETDefaultFontSize);
                         break;
                     }
                 }

--- a/core/indigo-core/molecule/src/molecule_chain_fingerprints.cpp
+++ b/core/indigo-core/molecule/src/molecule_chain_fingerprints.cpp
@@ -61,7 +61,7 @@ void MoleculeChainFingerprintBuilder::process()
     gse.processChains();
 }
 
-void MoleculeChainFingerprintBuilder::_handleChain(Graph& graph, int size, const int* vertices, const int* edges, void* context)
+void MoleculeChainFingerprintBuilder::_handleChain(Graph& /* graph */, int size, const int* vertices, const int* edges, void* context)
 {
     MoleculeChainFingerprintBuilder* self = (MoleculeChainFingerprintBuilder*)context;
     QS_DEF(Array<char>, str);
@@ -112,7 +112,7 @@ void MoleculeChainFingerprintBuilder::_handleChain(Graph& graph, int size, const
 
     seed = std::min(seed1, seed2);
 
-    for (int i = 0; i < self->_parameters.bits_per_chain; i++)
+    for (i = 0; i < self->_parameters.bits_per_chain; i++)
     {
         seed = seed * 0x8088405 + 1;
 

--- a/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
+++ b/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
@@ -154,7 +154,7 @@ bool MoleculeCIPCalculator::addCIPStereoDescriptors(BaseMolecule& mol)
     mol._cip_atoms.clear();
     mol._cip_bonds.clear();
 
-    for (auto atom_idx = 0; atom_idx < atom_cip_desc.size(); ++atom_idx)
+    for (atom_idx = 0; atom_idx < atom_cip_desc.size(); ++atom_idx)
     {
         if (atom_cip_desc[atom_idx] > CIPDesc::UNKNOWN)
             mol._cip_atoms.insert(atom_idx, atom_cip_desc[atom_idx]);
@@ -861,7 +861,7 @@ bool MoleculeCIPCalculator::_checkLigandsEquivalence(Array<int>& ligands, Array<
     return neq != 0;
 }
 
-bool MoleculeCIPCalculator::_isPseudoAssymCenter(BaseMolecule& mol, int idx, Array<CIPDesc>& atom_cip_desc, Array<int>& ligands,
+bool MoleculeCIPCalculator::_isPseudoAssymCenter(BaseMolecule& /* mol */, int /* idx */, Array<CIPDesc>& atom_cip_desc, Array<int>& ligands,
                                                  Array<EquivLigand>& equiv_ligands)
 {
     int neq = 0;

--- a/core/indigo-core/molecule/src/molecule_cis_trans.cpp
+++ b/core/indigo-core/molecule/src/molecule_cis_trans.cpp
@@ -825,10 +825,10 @@ void MoleculeCisTrans::flipBond(BaseMolecule& baseMolecule, int atom_parent, int
 
         _Bond& bond = _bonds[edge];
 
-        for (int i = 0; i < 4; i++)
-            if (bond.substituents[i] == atom_from)
+        for (int j = 0; j < 4; j++)
+            if (bond.substituents[j] == atom_from)
             {
-                bond.substituents[i] = atom_to;
+                bond.substituents[j] = atom_to;
                 break;
             }
     }
@@ -842,10 +842,10 @@ void MoleculeCisTrans::flipBond(BaseMolecule& baseMolecule, int atom_parent, int
 
         _Bond& bond = _bonds[edge];
 
-        for (int i = 0; i < 4; i++)
-            if (bond.substituents[i] == atom_parent)
+        for (int j = 0; j < 4; j++)
+            if (bond.substituents[j] == atom_parent)
             {
-                bond.substituents[i] = atom_to;
+                bond.substituents[j] = atom_to;
                 break;
             }
     }

--- a/core/indigo-core/molecule/src/molecule_dearom.cpp
+++ b/core/indigo-core/molecule/src/molecule_dearom.cpp
@@ -88,7 +88,7 @@ void Dearomatizer::enumerateDearomatizations(DearomatizationsStorage& dearomatiz
     QueryMolecule qsubmolecule;
 
     dearomatizations.setGroupsCount(_connectivityGroups);
-    dearomatizations.setDearomatizationParams(_dearomatizationParams);
+    dearomatizations.setDearomatizationParams(static_cast<byte>(_dearomatizationParams));
 
     _aromaticGroups.constructGroups(dearomatizations, true);
 
@@ -120,7 +120,7 @@ void Dearomatizer::enumerateDearomatizations(DearomatizationsStorage& dearomatiz
     }
 }
 
-void Dearomatizer::_fixHeteratom(int atom_idx, bool toFix)
+void Dearomatizer::_fixHeteratom(int atom_idx, bool /* toFix */)
 {
 
     if (!_verticesFixed.get(atom_idx))
@@ -160,7 +160,7 @@ void Dearomatizer::_enumerateMatching(void)
 {
     // Find strong edge in alternating circle
     const Edge* edge = 0;
-    int e_idx;
+    int e_idx = -1;
     bool found = false;
     for (int i = 0; i < _aromaticGroupData.bonds.size(); i++)
     {
@@ -491,7 +491,7 @@ int DearomatizationsStorage::getGroupHeteroAtomsCount(int group) const
 void DearomatizationsStorage::saveBinary(Output& output) const
 {
     output.writeByte(_dearomParams);
-    output.writePackedShort(_aromaticGroups.size());
+    output.writePackedShort(static_cast<short>(_aromaticGroups.size()));
     if (_dearomParams != Dearomatizer::PARAMS_SAVE_JUST_HETERATOMS)
     {
         for (int i = 0; i < _aromaticGroups.size(); i++)
@@ -502,9 +502,9 @@ void DearomatizationsStorage::saveBinary(Output& output) const
                                  _aromaticGroups[i - 1].dearomBondsState.count * bitGetSize(_aromaticGroups[i - 1].aromBondsIndices.count);
             if (i != 0 && _aromaticGroups[i].dearomBondsState.offset != expectedOffset)
                 throw Error("DearomatizationsStorage::saveBinary: invalid data order #1");
-            output.writePackedShort(_aromaticGroups[i].dearomBondsState.count);
+            output.writePackedShort(static_cast<short>(_aromaticGroups[i].dearomBondsState.count));
         }
-        output.writePackedShort(_dearomBondsStateArray.size());
+        output.writePackedShort(static_cast<short>(_dearomBondsStateArray.size()));
         if (_dearomBondsStateArray.size() != 0)
             output.write(_dearomBondsStateArray.ptr(), _dearomBondsStateArray.size() * sizeof(byte));
     }
@@ -518,10 +518,10 @@ void DearomatizationsStorage::saveBinary(Output& output) const
                                  _aromaticGroups[i - 1].heteroAtomsState.count * bitGetSize(_aromaticGroups[i - 1].heteroAtomsIndices.count);
             if (i != 0 && _aromaticGroups[i].heteroAtomsState.offset != expectedOffset)
                 throw Error("DearomatizationsStorage::saveBinary: invalid data order #2");
-            output.writePackedShort(_aromaticGroups[i].heteroAtomsState.count);
+            output.writePackedShort(static_cast<short>(_aromaticGroups[i].heteroAtomsState.count));
         }
 
-        output.writePackedShort(_heteroAtomsStateArray.size());
+        output.writePackedShort(static_cast<short>(_heteroAtomsStateArray.size()));
         if (_heteroAtomsStateArray.size() != 0)
             output.write(_heteroAtomsStateArray.ptr(), _heteroAtomsStateArray.size() * sizeof(byte));
     }
@@ -593,8 +593,8 @@ DearomatizationsGroups::DearomatizationsGroups(BaseMolecule& molecule, bool skip
             SGroup& sgroup = molecule.sgroups.getSGroup(i);
             if (sgroup.sgroup_type == SGroup::SG_TYPE_SUP)
             {
-                for (int i = 0; i < sgroup.atoms.size(); i++)
-                    _inside_superatoms.find_or_insert(sgroup.atoms[i]);
+                for (int j = 0; j < sgroup.atoms.size(); j++)
+                    _inside_superatoms.find_or_insert(sgroup.atoms[j]);
             }
         }
 }
@@ -641,9 +641,9 @@ void DearomatizationsGroups::getGroupData(int group, int flags, Dearomatizations
 
             int max_conn = Element::getMaximumConnectivity(label, charge, radical, false);
 
-            int group = Element::group(_molecule.getAtomNumber(v_idx));
+            int atom_group = Element::group(_molecule.getAtomNumber(v_idx));
 
-            int vac = _molecule.getVacantPiOrbitals(group, charge, radical, max_conn, &lonepairs);
+            int vac = _molecule.getVacantPiOrbitals(atom_group, charge, radical, max_conn, &lonepairs);
 
             if (_vertexIsAcceptDoubleEdge[v_idx] && _vertexIsAcceptSingleEdge[v_idx] && (vac > 0 || lonepairs > 0))
                 data->heteroAtoms.push(v_idx);

--- a/core/indigo-core/molecule/src/molecule_electrons_localizer.cpp
+++ b/core/indigo-core/molecule/src/molecule_electrons_localizer.cpp
@@ -331,7 +331,7 @@ bool MoleculeElectronsLocalizer::_findValidSolution(int cardinality)
 
     // Check if localization is valid
     int invalid_atom = -1;
-    int ret_code;
+    int ret_code = -1;
     for (int v = _skeleton.vertexBegin(); v != _skeleton.vertexEnd(); v = _skeleton.vertexNext(v))
     {
         if ((ret_code = _isLocalizationValid(v)) != OK)

--- a/core/indigo-core/molecule/src/molecule_exact_matcher.cpp
+++ b/core/indigo-core/molecule/src/molecule_exact_matcher.cpp
@@ -127,7 +127,7 @@ void MoleculeExactMatcher::_collectConnectedComponentsInfo()
     _query_decomposer->decompose(&query_vertices_filter);
 }
 
-bool MoleculeExactMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool MoleculeExactMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* /*core_sub*/, int sub_idx, int super_idx, void* userdata)
 {
     BaseMolecule& query = (BaseMolecule&)subgraph;
     BaseMolecule& target = (BaseMolecule&)supergraph;

--- a/core/indigo-core/molecule/src/molecule_exact_substructure_matcher.cpp
+++ b/core/indigo-core/molecule/src/molecule_exact_substructure_matcher.cpp
@@ -157,7 +157,7 @@ void MoleculeExactSubstructureMatcher::_collectConnectedComponentsInfo()
     _query_decomposer->decompose(&query_vertices_filter);
 }
 
-bool MoleculeExactSubstructureMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool MoleculeExactSubstructureMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* /* core_sub */, int sub_idx, int super_idx, void* userdata)
 {
     Molecule& query = (Molecule&)subgraph;
     Molecule& target = (Molecule&)supergraph;

--- a/core/indigo-core/molecule/src/molecule_fingerprint.cpp
+++ b/core/indigo-core/molecule/src/molecule_fingerprint.cpp
@@ -723,7 +723,7 @@ void MoleculeFingerprintBuilder::_makeFingerprint_calcChem(BaseMolecule& mol)
     {
         mol.asMolecule().invalidateHCounters();
     }
-    catch (indigo::Exception& e)
+    catch (indigo::Exception&)
     {
         // Since `mol` is (probably) `QueryMolecule`,
         // connectivity doesn't matter anyway
@@ -741,7 +741,7 @@ void MoleculeFingerprintBuilder::_makeFingerprint_calcChem(BaseMolecule& mol)
             if (!res)
                 continue; // skippable atom
         }
-        catch (indigo::Exception& e)
+        catch (indigo::Exception&)
         {
             continue;
         }
@@ -770,7 +770,7 @@ void MoleculeFingerprintBuilder::_makeFingerprint_calcChem(BaseMolecule& mol)
             if (!res1 || !res2)
                 continue; // skippable atoms
         }
-        catch (indigo::Exception& e)
+        catch (indigo::Exception&)
         {
             continue;
         }

--- a/core/indigo-core/molecule/src/molecule_fingerprint.cpp
+++ b/core/indigo-core/molecule/src/molecule_fingerprint.cpp
@@ -166,9 +166,9 @@ void MoleculeFingerprintBuilder::process()
 /*
  * Accepted types: 'sim', 'sub', 'sub-res', 'sub-tau', 'full'
  */
-void MoleculeFingerprintBuilder::parseFingerprintType(const char* type, bool query)
+void MoleculeFingerprintBuilder::parseFingerprintType(const char* type, bool bquery)
 {
-    this->query = query;
+    this->query = bquery;
 
     if (type == 0 || *type == 0 || strcasecmp(type, "sim") == 0)
     {
@@ -208,7 +208,7 @@ void MoleculeFingerprintBuilder::parseFingerprintType(const char* type, bool que
     }
     else if (strcasecmp(type, "full") == 0)
     {
-        if (query)
+        if (bquery)
             throw Error("there can not be 'full' fingerprint of a query molecule");
         // full (non-query) fingerprint, do not skip anything
     }
@@ -357,8 +357,8 @@ int MoleculeFingerprintBuilder::_maximalSubgraphCriteriaValue(Graph& graph, cons
     return ret;
 }
 
-dword MoleculeFingerprintBuilder::_canonicalizeFragment(BaseMolecule& mol, const Array<int>& vertices, const Array<int>& edges, bool use_atoms, bool use_bonds,
-                                                        int* different_vertex_count)
+dword MoleculeFingerprintBuilder::_canonicalizeFragment(BaseMolecule& /* mol */, const Array<int>& vertices, const Array<int>& edges, bool use_atoms,
+                                                        bool use_bonds, int* different_vertex_count)
 {
     if (use_bonds)
         subgraph_hash->edge_codes = &_bond_codes;

--- a/core/indigo-core/molecule/src/molecule_gross_formula.cpp
+++ b/core/indigo-core/molecule/src/molecule_gross_formula.cpp
@@ -423,7 +423,7 @@ int MoleculeGrossFormula::_isotopeCount(BaseMolecule& mol)
             *val += 1;
     }
 
-    return isotopes.size();
+    return static_cast<int>(isotopes.size());
 }
 
 void MoleculeGrossFormula::fromString(Scanner& scanner, Array<int>& gross)

--- a/core/indigo-core/molecule/src/molecule_gross_formula.cpp
+++ b/core/indigo-core/molecule/src/molecule_gross_formula.cpp
@@ -29,7 +29,7 @@
 
 using namespace indigo;
 
-int MoleculeGrossFormula::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* context)
+int MoleculeGrossFormula::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* /* context */)
 {
     if (ec1.counter == 0)
         return 1;
@@ -58,7 +58,7 @@ int MoleculeGrossFormula::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* conte
 
 // comparator implementing the Hill system without carbon:
 // <all atoms in alphabetical order>
-int MoleculeGrossFormula::_cmp_hill_no_carbon(_ElemCounter& ec1, _ElemCounter& ec2, void* context)
+int MoleculeGrossFormula::_cmp_hill_no_carbon(_ElemCounter& ec1, _ElemCounter& ec2, void* /* context */)
 {
     if (ec1.counter == 0)
         return 1;
@@ -219,8 +219,8 @@ std::unique_ptr<GROSS_UNITS> MoleculeGrossFormula::collect(BaseMolecule& mol, bo
                 if (implicit_h >= 0)
                 {
                     key = ELEM_H;
-                    auto it = unit.isotopes.find(key);
-                    val = it != unit.isotopes.end() ? &(it->second) : nullptr;
+                    auto h_it = unit.isotopes.find(key);
+                    val = h_it != unit.isotopes.end() ? &(h_it->second) : nullptr;
 
                     if (!val)
                         unit.isotopes.emplace(key, implicit_h);
@@ -259,8 +259,7 @@ void MoleculeGrossFormula::toString_Hill(GROSS_UNITS& gross, Array<char>& str, b
         return;
 
     // First base molecule
-    auto it = gross[0].isotopes.find(ELEM_C);
-    if (it == gross[0].isotopes.end())
+    if (gross[0].isotopes.find(ELEM_C) == gross[0].isotopes.end())
         _toString(gross[0].isotopes, output, _cmp_hill_no_carbon, add_rsites);
     else
         _toString(gross[0].isotopes, output, _cmp_hill, add_rsites);
@@ -269,8 +268,7 @@ void MoleculeGrossFormula::toString_Hill(GROSS_UNITS& gross, Array<char>& str, b
     for (int i = 1; i < gross.size(); i++)
     {
         output.writeChar('(');
-        auto it = gross[0].isotopes.find(ELEM_C);
-        if (it == gross[0].isotopes.end())
+        if (gross[0].isotopes.find(ELEM_C) == gross[0].isotopes.end())
             _toString(gross[i].isotopes, output, _cmp_hill_no_carbon, add_rsites);
         else
             _toString(gross[i].isotopes, output, _cmp_hill, add_rsites);

--- a/core/indigo-core/molecule/src/molecule_inchi_component.cpp
+++ b/core/indigo-core/molecule/src/molecule_inchi_component.cpp
@@ -112,7 +112,7 @@ void MoleculeInChICompoment::_getCanonicalMolecule(Molecule& source_mol, Molecul
         dbg_handle_canonical_component_cb(cano_mol);
 }
 
-int MoleculeInChICompoment::_cmpVertex(Graph& graph, int v1, int v2, const void* context)
+int MoleculeInChICompoment::_cmpVertex(Graph& graph, int v1, int v2, const void* /* context */)
 {
     Molecule& mol = (Molecule&)graph;
 
@@ -133,7 +133,7 @@ int MoleculeInChICompoment::_cmpVertex(Graph& graph, int v1, int v2, const void*
     return 0;
 }
 
-int MoleculeInChICompoment::_cmpVertexStereo(Molecule& mol, int v1, int v2, const void* context)
+int MoleculeInChICompoment::_cmpVertexStereo(Molecule& mol, int v1, int v2, const void* /* context */)
 {
     // TODO: Implement as in InChI
     int diff = mol.stereocenters.getType(v1) - mol.stereocenters.getType(v2);

--- a/core/indigo-core/molecule/src/molecule_inchi_layers.cpp
+++ b/core/indigo-core/molecule/src/molecule_inchi_layers.cpp
@@ -238,7 +238,7 @@ int MainLayerConnections::compareComponentsConnectionTables(MainLayerConnections
         int value1 = comp1._connection_table[i];
         int value2 = comp2._connection_table[i];
 
-        int diff = value1 - value2;
+        diff = value1 - value2;
         if (diff != 0)
             return -diff;
     }
@@ -698,7 +698,7 @@ void CisTransStereochemistryLayer::_construct()
     }
 }
 
-int CisTransStereochemistryLayer::compareComponents(CisTransStereochemistryLayer& comp1, CisTransStereochemistryLayer& comp2)
+int CisTransStereochemistryLayer::compareComponents(CisTransStereochemistryLayer& /*comp1*/, CisTransStereochemistryLayer& /*comp2*/)
 {
     // TODO
     return 0;
@@ -831,7 +831,7 @@ int TetrahedralStereochemistryLayer::compareComponentsEnantiomers(TetrahedralSte
     return s2 - s1;
 }
 
-int TetrahedralStereochemistryLayer::compareComponents(TetrahedralStereochemistryLayer& comp1, TetrahedralStereochemistryLayer& comp2)
+int TetrahedralStereochemistryLayer::compareComponents(TetrahedralStereochemistryLayer& /*comp1*/, TetrahedralStereochemistryLayer& /*comp2*/)
 {
     return 0;
 }

--- a/core/indigo-core/molecule/src/molecule_inchi_utils.cpp
+++ b/core/indigo-core/molecule/src/molecule_inchi_utils.cpp
@@ -73,7 +73,7 @@ void MoleculeInChIUtils::_initializeAtomLabels()
     }
 }
 
-int MoleculeInChIUtils::_compareAtomLabels(int& label1, int& label2, void* context)
+int MoleculeInChIUtils::_compareAtomLabels(int& label1, int& label2, void* /*context*/)
 {
     // Compare atom labels in alphabetic order with exception that
     // atom C is the first atom and H as second atom

--- a/core/indigo-core/molecule/src/molecule_ionize.cpp
+++ b/core/indigo-core/molecule/src/molecule_ionize.cpp
@@ -87,8 +87,8 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
 
     for (;;)
     {
-        FileScanner scanner(filename);
-        SdfLoader loader(scanner);
+        FileScanner fscanner(filename);
+        SdfLoader loader(fscanner);
 
         int a_count = 0;
         int b_count = 0;
@@ -102,8 +102,8 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
         {
             mol_count++;
             loader.readNext();
-            BufferScanner scanner(loader.data);
-            MolfileLoader mol_loader(scanner);
+            BufferScanner bscanner(loader.data);
+            MolfileLoader mol_loader(bscanner);
             mol_loader.stereochemistry_options.ignore_errors = true;
             mol_loader.loadMolecule(mol);
 
@@ -225,7 +225,7 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
 
         for (int i = 0; i < acid_pkas.size(); i++)
         {
-            const char* fp = acid_pkas.key(i);
+            const char* fpkey = acid_pkas.key(i);
             Array<float>& pkas = acid_pkas.value(i);
             float pka_sum = 0.f;
             float pka_dev = 0.f;
@@ -249,11 +249,11 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
             if (pka_dev > max_deviation)
                 max_deviation = pka_dev;
 
-            if (_model.adv_a_pkas.find(fp))
-                _model.adv_a_pkas.remove(fp);
-            _model.adv_a_pkas.insert(fp);
-            _model.adv_a_pkas.at(fp).push(pka_sum / pkas.size());
-            _model.adv_a_pkas.at(fp).push(pka_dev);
+            if (_model.adv_a_pkas.find(fpkey))
+                _model.adv_a_pkas.remove(fpkey);
+            _model.adv_a_pkas.insert(fpkey);
+            _model.adv_a_pkas.at(fpkey).push(pka_sum / pkas.size());
+            _model.adv_a_pkas.at(fpkey).push(pka_dev);
 
             if (pka_dev > threshold)
                 model_ready = false;
@@ -261,7 +261,7 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
 
         for (int i = 0; i < basic_pkas.size(); i++)
         {
-            const char* fp = basic_pkas.key(i);
+            const char* fpkey = basic_pkas.key(i);
             Array<float>& pkas = basic_pkas.value(i);
             float pka_sum = 0.f;
             float pka_dev = 0.f;
@@ -285,11 +285,11 @@ int MoleculePkaModel::buildPkaModel(int max_level, float threshold, const char* 
             if (pka_dev > max_deviation)
                 max_deviation = pka_dev;
 
-            if (_model.adv_b_pkas.find(fp))
-                _model.adv_b_pkas.remove(fp);
-            _model.adv_b_pkas.insert(fp);
-            _model.adv_b_pkas.at(fp).push(pka_sum / pkas.size());
-            _model.adv_b_pkas.at(fp).push(pka_dev);
+            if (_model.adv_b_pkas.find(fpkey))
+                _model.adv_b_pkas.remove(fpkey);
+            _model.adv_b_pkas.insert(fpkey);
+            _model.adv_b_pkas.at(fpkey).push(pka_sum / pkas.size());
+            _model.adv_b_pkas.at(fpkey).push(pka_dev);
 
             if (pka_dev > threshold)
                 model_ready = false;
@@ -838,7 +838,7 @@ void MoleculePkaModel::_loadAdvancedPkaModel()
     _model.advanced_model_ready = true;
 }
 
-void MoleculePkaModel::_estimate_pKa_Simple(Molecule& mol, const IonizeOptions& options, Array<int>& acid_sites, Array<int>& basic_sites,
+void MoleculePkaModel::_estimate_pKa_Simple(Molecule& mol, const IonizeOptions& /* options */, Array<int>& acid_sites, Array<int>& basic_sites,
                                             Array<float>& acid_pkas, Array<float>& basic_pkas)
 {
     //   QS_DEF(Array<int>, can_order);
@@ -1346,7 +1346,7 @@ bool MoleculeIonizer::ionize(Molecule& mol, float ph, float ph_toll, const Ioniz
     return true;
 }
 
-void MoleculeIonizer::_setCharges(Molecule& mol, float pH, float pH_toll, const IonizeOptions& options, Array<int>& acid_sites, Array<int>& basic_sites,
+void MoleculeIonizer::_setCharges(Molecule& mol, float pH, float pH_toll, const IonizeOptions& /* options */, Array<int>& acid_sites, Array<int>& basic_sites,
                                   Array<float>& acid_pkas, Array<float>& basic_pkas)
 {
     for (auto i = 0; i < acid_sites.size(); i++)

--- a/core/indigo-core/molecule/src/molecule_json_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_loader.cpp
@@ -63,7 +63,7 @@ MoleculeJsonLoader::MoleculeJsonLoader(Document& ket)
     if (root.HasMember("templates"))
     {
         Value& templates = root["templates"];
-        for (int i = 0; i < templates.Size(); ++i)
+        for (rapidjson::SizeType i = 0; i < templates.Size(); ++i)
         {
             std::string template_id = templates[i]["$ref"].GetString();
             if (ket.HasMember(template_id.c_str()))
@@ -79,7 +79,7 @@ MoleculeJsonLoader::MoleculeJsonLoader(Document& ket)
     if (root.HasMember("connections"))
     {
         Value& connections = root["connections"];
-        for (int i = 0; i < connections.Size(); ++i)
+        for (rapidjson::SizeType i = 0; i < connections.Size(); ++i)
             _connection_array.PushBack(connections[i], ket.GetAllocator());
     }
 }
@@ -1260,7 +1260,7 @@ void MoleculeJsonLoader::parseMonomerTemplate(const rapidjson::Value& monomer_te
                                 auto rnum = label.substr(1);
                                 if (std::all_of(rnum.begin(), rnum.end(), ::isdigit))
                                 {
-                                    label = 'A' + std::stol(rnum);
+                                    label = static_cast<char>('A' + std::stol(rnum));
                                     label += 'x';
                                 }
                             }
@@ -1453,7 +1453,7 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
         if (ma.HasMember("position"))
         {
             auto& pos_val = ma["position"];
-            mol.setAtomXyz(idx, pos_val["x"].GetDouble(), pos_val["y"].GetDouble(), 0);
+            mol.setAtomXyz(idx, static_cast<float>(pos_val["x"].GetDouble()), static_cast<float>(pos_val["y"].GetDouble()), 0);
         }
 
         std::string template_id = ma["templateId"].GetString();
@@ -1535,7 +1535,7 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
     }
 
     // handle monomer's connections after all
-    for (int i = 0; i < _connection_array.Size(); ++i)
+    for (rapidjson::SizeType i = 0; i < _connection_array.Size(); ++i)
     {
         auto& connection = _connection_array[i];
         int order = _BOND_ANY;

--- a/core/indigo-core/molecule/src/molecule_json_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_loader.cpp
@@ -229,7 +229,7 @@ void MoleculeJsonLoader::parseAtoms(const rapidjson::Value& atoms, BaseMolecule&
     for (SizeType i = 0; i < atoms.Size(); i++)
     {
         std::string label;
-        int atom_idx = 0, charge = 0, valence = 0, radical = 0, isotope = 0, elem = 0, rsite_idx = 0, mapping = 0, atom_type = 0;
+        int atom_idx = 0, charge = 0, valence = 0, radical = 0, isotope = 0, elem = 0, rsite_idx = 0;
         bool is_not_list = false;
         std::unique_ptr<QueryMolecule::Atom> atomlist;
         const Value& a = atoms[i];
@@ -744,13 +744,13 @@ void indigo::MoleculeJsonLoader::parseHighlight(const rapidjson::Value& highligh
             std::string et = val["entityType"].GetString();
             if (et == "atoms")
             {
-                for (rapidjson::SizeType j = 0; i < items.Size(); ++i)
-                    mol.highlightAtom(items[i].GetInt());
+                for (rapidjson::SizeType j = 0; j < items.Size(); ++j)
+                    mol.highlightAtom(items[j].GetInt());
             }
             else if (et == "bonds")
             {
-                for (rapidjson::SizeType j = 0; i < items.Size(); ++i)
-                    mol.highlightBond(items[i].GetInt());
+                for (rapidjson::SizeType j = 0; j < items.Size(); ++j)
+                    mol.highlightBond(items[j].GetInt());
             }
         }
     }
@@ -767,13 +767,13 @@ void indigo::MoleculeJsonLoader::parseSelection(const rapidjson::Value& selectio
             std::string et = val["entityType"].GetString();
             if (et == "atoms")
             {
-                for (rapidjson::SizeType j = 0; i < items.Size(); ++i)
-                    mol.selectAtom(items[i].GetInt());
+                for (rapidjson::SizeType j = 0; j < items.Size(); ++j)
+                    mol.selectAtom(items[j].GetInt());
             }
             else if (et == "bonds")
             {
-                for (rapidjson::SizeType j = 0; i < items.Size(); ++i)
-                    mol.selectBond(items[i].GetInt());
+                for (rapidjson::SizeType j = 0; j < items.Size(); ++j)
+                    mol.selectBond(items[j].GetInt());
             }
         }
     }
@@ -1205,7 +1205,7 @@ void MoleculeJsonLoader::parseMonomerTemplate(const rapidjson::Value& monomer_te
             for (SizeType i = 0; i < att_points.Size(); i++)
             {
                 auto& ap = att_points[i];
-                std::string att_label(1, 'A' + i);
+                std::string att_label(1, 'A' + static_cast<char>(i));
                 MonomerAttachmentPoint att_desc = {-1, -1, att_label + (i > 0 ? (i > 1 ? 'x' : 'r') : 'l')};
                 if (ap.HasMember("leavingGroup"))
                 {
@@ -1431,7 +1431,7 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
     for (SizeType i = 0; i < _templates.Size(); i++)
     {
         auto& mt = _templates[i];
-        int tp = mt.GetType();
+        // int tp = mt.GetType();
         if (mt.HasMember("type") && mt["type"].GetString() == std::string("monomerTemplate"))
             parseMonomerTemplate(mt, mol);
     }

--- a/core/indigo-core/molecule/src/molecule_json_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_loader.cpp
@@ -593,7 +593,7 @@ void MoleculeJsonLoader::parseAtoms(const rapidjson::Value& atoms, BaseMolecule&
     }
 
     if (_pqmol)
-        for (int k = 0; k < hcounts.size(); k++)
+        for (int k = 0; k < static_cast<int>(hcounts.size()); k++)
         {
             int expl_h = 0;
 
@@ -1100,7 +1100,7 @@ void MoleculeJsonLoader::fillXBondsAndBrackets(Superatom& sa, BaseMolecule& mol)
 
     // fill brackets
 
-    for (int i = 0; i < brackets.size(); i += 2)
+    for (size_t i = 0; i < brackets.size(); i += 2)
     {
         Vec2f* brk_pos = sa.brackets.push();
         brk_pos[0].copy(brackets[i]);

--- a/core/indigo-core/molecule/src/molecule_json_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_saver.cpp
@@ -171,7 +171,7 @@ void MoleculeJsonSaver::saveSGroups(BaseMolecule& mol, JsonWriter& writer)
     {
         writer.Key("sgroups");
         writer.StartArray();
-        int idx = 1;
+        // int idx = 1;
         for (int i = 0; i < sgs_sorted.size(); i++)
         {
             int sg_idx = sgs_sorted[i];
@@ -766,13 +766,13 @@ void MoleculeJsonSaver::saveAtoms(BaseMolecule& mol, JsonWriter& writer)
                         buf.readString(Element::toString(anum), true);
                         if (anum == ELEM_H && query_atom_properties.count(QueryMolecule::ATOM_ISOTOPE) > 0)
                         {
-                            int isotope = query_atom_properties[QueryMolecule::ATOM_ISOTOPE]->value_min;
-                            if (isotope == DEUTERIUM)
+                            int h_isotope = query_atom_properties[QueryMolecule::ATOM_ISOTOPE]->value_min;
+                            if (h_isotope == DEUTERIUM)
                             {
                                 buf.clear();
                                 buf.appendString("D", true);
                             }
-                            else if (isotope == TRITIUM)
+                            else if (h_isotope == TRITIUM)
                             {
                                 buf.clear();
                                 buf.appendString("T", true);
@@ -936,7 +936,7 @@ void MoleculeJsonSaver::saveAtoms(BaseMolecule& mol, JsonWriter& writer)
             writer.Int(charge);
         }
 
-        int total_bond_count = 0;
+        // int total_bond_count = 0;
         if (evalence > 0)
         {
             writer.Key("explicitValence");
@@ -1104,7 +1104,7 @@ std::string MoleculeJsonSaver::monomerKETClass(const std::string& class_name)
         return mclass;
 
     for (auto it = mclass.begin(); it < mclass.end(); ++it)
-        *it = it > mclass.begin() ? std::tolower(*it) : std::toupper(*it);
+        *it = static_cast<char>(it > mclass.begin() ? std::tolower(*it) : std::toupper(*it));
 
     return mclass;
 }
@@ -1142,7 +1142,7 @@ std::string MoleculeJsonSaver::monomerAlias(const TGroup& tg)
     {
         alias = name;
         if (name.size() == 1)
-            alias = std::toupper(name.front());
+            alias = static_cast<char>(std::toupper(name.front()));
         else if (name.empty())
             alias = std::string("#") + std::to_string(tg.tgroup_id - 1);
     }
@@ -1342,7 +1342,7 @@ bool MoleculeJsonSaver::_checkAttPointOrder(BaseMolecule& mol, int rsite)
 void MoleculeJsonSaver::collectTemplates(BaseMolecule& mol)
 {
     _templates.clear();
-    int temp_idx = 0;
+    // int temp_idx = 0;
     for (int i = mol.tgroups.begin(); i != mol.tgroups.end(); i = mol.tgroups.next(i))
     {
         auto& tg = mol.tgroups.getTGroup(i);

--- a/core/indigo-core/molecule/src/molecule_layered_molecules.cpp
+++ b/core/indigo-core/molecule/src/molecule_layered_molecules.cpp
@@ -300,7 +300,7 @@ int LayeredMolecules::getAtomRadical(int idx)
     return _proto.getAtomRadical(idx);
 }
 
-int LayeredMolecules::getAtomAromaticity(int idx)
+int LayeredMolecules::getAtomAromaticity(int /* idx */)
 {
     //   return _proto.getAtomAromaticity(idx);
     return true;
@@ -326,7 +326,7 @@ int LayeredMolecules::getAtomRingBondsCount(int idx)
     return _proto.getAtomSubstCount(idx);
 }
 
-int LayeredMolecules::getAtomConnectivity(int idx)
+int LayeredMolecules::getAtomConnectivity(int /* idx */)
 {
     return 0;
 }
@@ -341,7 +341,7 @@ int LayeredMolecules::getAtomMinH(int idx)
     return getAtomTotalH(idx);
 }
 
-int LayeredMolecules::getAtomTotalH(int idx)
+int LayeredMolecules::getAtomTotalH(int /* idx */)
 {
     throw Error("getAtomTotalH method has no sense for LayeredMolecules");
 }
@@ -396,17 +396,17 @@ dword LayeredMolecules::getRSiteBits(int idx)
     return _proto.getRSiteBits(idx);
 }
 
-void LayeredMolecules::allowRGroupOnRSite(int atom_idx, int rg_idx)
+void LayeredMolecules::allowRGroupOnRSite(int /* atom_idx */, int /* rg_idx */)
 {
     throw Error("allowRGroupOnRSite method is not implemented in LayeredMolecules class");
 }
 
-int LayeredMolecules::getBondOrder(int idx) const
+int LayeredMolecules::getBondOrder(int /* idx */) const
 {
     throw Error("getBondOrder method has no sense for LayeredMolecules");
 }
 
-int LayeredMolecules::getBondTopology(int idx)
+int LayeredMolecules::getBondTopology(int /* idx */)
 {
     throw Error("getBondTopology method is not implemented in LayeredMolecules class");
 }
@@ -446,22 +446,22 @@ void LayeredMolecules::getAtomDescription(int idx, Array<char>& description)
     return _proto.getAtomDescription(idx, description);
 }
 
-void LayeredMolecules::getBondDescription(int idx, Array<char>& description)
+void LayeredMolecules::getBondDescription(int /* idx */, Array<char>& /* description */)
 {
     throw Error("getBondDescription method is not implemented in LayeredMolecules class");
 }
 
-bool LayeredMolecules::possibleBondOrder(int idx, int order)
+bool LayeredMolecules::possibleBondOrder(int /* idx */, int /* order */)
 {
     throw Error("possibleBondOrder method has no sense for LayeredMolecules");
 }
 
-bool LayeredMolecules::isSaturatedAtom(int idx)
+bool LayeredMolecules::isSaturatedAtom(int /* idx */)
 {
     throw Error("isSaturatedAtom method is not implemented in LayeredMolecules class");
 }
 
-bool LayeredMolecules::bondStereoCare(int idx)
+bool LayeredMolecules::bondStereoCare(int /* idx */)
 {
     throw Error("bondStereoCare method is not implemented in LayeredMolecules class");
 }
@@ -496,7 +496,8 @@ void LayeredMolecules::setImplicitH(int idx, int impl_h)
     return _proto.setImplicitH(idx, impl_h);
 }
 
-void LayeredMolecules::_mergeWithSubmolecule(BaseMolecule& bmol, const Array<int>& vertices, const Array<int>* edges, const Array<int>& mapping, int skip_flags)
+void LayeredMolecules::_mergeWithSubmolecule(BaseMolecule& /* bmol */, const Array<int>& /* vertices */, const Array<int>* /* edges */,
+                                             const Array<int>& /* mapping */, int /* skip_flags */)
 {
     throw Error("_mergeWithSubmolecule method is not implemented in LayeredMolecules class");
 }
@@ -681,7 +682,7 @@ void LayeredMolecules::_calcPiLabels(int layerFrom, int layerTo)
     }
 }
 
-bool LayeredMolecules::_cb_handle_cycle(Graph& graph, const Array<int>& vertices, const Array<int>& edges, void* context)
+bool LayeredMolecules::_cb_handle_cycle(Graph& /* graph */, const Array<int>& vertices, const Array<int>& /* edges */, void* context)
 {
     AromatizationContext* aromatizationContext = (AromatizationContext*)context;
     LayeredMolecules* self = aromatizationContext->self;
@@ -788,7 +789,7 @@ void LayeredMolecules::_registerAromatizedLayers(int layerFrom, int layerTo)
     }
 }
 
-bool LayeredMolecules::aromatize(int layerFrom, int layerTo, const AromaticityOptions& options)
+bool LayeredMolecules::aromatize(int layerFrom, int layerTo, const AromaticityOptions& /* options */)
 {
     if (layerFrom == layerTo)
         return false;

--- a/core/indigo-core/molecule/src/molecule_mass.cpp
+++ b/core/indigo-core/molecule/src/molecule_mass.cpp
@@ -294,7 +294,7 @@ int MoleculeMass::nominalMass(Molecule& mol)
     return molmass;
 }
 
-int MoleculeMass::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* context)
+int MoleculeMass::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* /*context*/)
 {
     if (ec1.weight == 0)
         return 1;

--- a/core/indigo-core/molecule/src/molecule_morgan_fingerprint_builder.cpp
+++ b/core/indigo-core/molecule/src/molecule_morgan_fingerprint_builder.cpp
@@ -219,16 +219,18 @@ dword MoleculeMorganFingerprintBuilder::initialStateCallback_ECFP(BaseMolecule& 
     return key;
 }
 
-dword MoleculeMorganFingerprintBuilder::initialStateCallback_FCFP(BaseMolecule& mol, int idx)
+dword MoleculeMorganFingerprintBuilder::initialStateCallback_FCFP(BaseMolecule& /* mol */, int /* idx */)
 {
     throw Exception("FCFP is not implemented"); // TODO: implement ionizability
 
+    /*
     dword key = 0;
 
     key |= (mol.getAtomAromaticity(0) == ATOM_AROMATIC) << 4;
     key |= Element::isHalogen(mol.getAtomNumber(idx)) << 5;
 
     return key;
+    //*/
 }
 
 int MoleculeMorganFingerprintBuilder::bondDescriptorCmp(const BondDescriptor& bd1, const BondDescriptor& bd2)

--- a/core/indigo-core/molecule/src/molecule_name_parser.cpp
+++ b/core/indigo-core/molecule/src/molecule_name_parser.cpp
@@ -302,8 +302,8 @@ void MoleculeNameParser::Parse::scan()
         size_t pos = separators.find(ch);
         if (pos != separators.npos)
         {
-            const auto& it = sd.find({ch});
-            if (it != sd.end())
+            const auto& sdit = sd.find({ch});
+            if (sdit != sd.end())
             {
                 // For locants, we need additional check if the number is multi-digit
                 if (std::isdigit(ch))
@@ -318,7 +318,7 @@ void MoleculeNameParser::Parse::scan()
                     locant.clear();
                     continue;
                 }
-                lexemes.push_back(Lexeme(ch, it->second));
+                lexemes.push_back(Lexeme(ch, sdit->second));
             }
             continue;
         }
@@ -1067,7 +1067,7 @@ bool MoleculeNameParser::TreeBuilder::_processBasicMultiplier(const Lexeme& lexe
 
 bool MoleculeNameParser::TreeBuilder::_processFactorMultiplier(const Lexeme& lexeme)
 {
-    const int value = _strToInt(lexeme.token.value);
+    int value = _strToInt(lexeme.token.value);
 
     if (_current->classType == FragmentClassType::SUBSTITUENT)
     {
@@ -1093,7 +1093,7 @@ bool MoleculeNameParser::TreeBuilder::_processFactorMultiplier(const Lexeme& lex
     else
     {
         const Multiplier& prev = multipliers.top();
-        int value = _strToInt(lexeme.token.value);
+        value = _strToInt(lexeme.token.value);
         value *= prev.first;
         multipliers.pop();
         multipliers.push({value, TokenType::BASIC});
@@ -1471,8 +1471,8 @@ bool MoleculeNameParser::SmilesBuilder::_processBaseNode(FragmentNodeBase* base,
 
         for (int i = 1; i < multipliers; i++)
         {
-            SmilesNode node(symbol, BOND_SINGLE, &root);
-            root.nodes.push_back(std::move(node));
+            SmilesNode node1(symbol, BOND_SINGLE, &root);
+            root.nodes.push_back(std::move(node1));
         }
     }
 

--- a/core/indigo-core/molecule/src/molecule_name_parser.cpp
+++ b/core/indigo-core/molecule/src/molecule_name_parser.cpp
@@ -1512,7 +1512,7 @@ void MoleculeNameParser::SmilesBuilder::_calcHydrogens(const Element& element, i
     int connections = indigo::Element::getMaximumConnectivity(number, 0, 0, false);
     int valence = indigo::Element::calcValenceMinusHyd(number, 0, 0, connections);
 
-    if ((pos - 1) < root.nodes.size())
+    if ((pos - 1) < static_cast<long long>(root.nodes.size()))
     {
         SmilesNode& sn = root.nodes.at(pos - 1);
 

--- a/core/indigo-core/molecule/src/molecule_scaffold_detection.cpp
+++ b/core/indigo-core/molecule/src/molecule_scaffold_detection.cpp
@@ -140,7 +140,7 @@ bool MoleculeScaffoldDetection::matchBonds(Graph& g1, Graph& g2, int i, int j, v
     return MoleculeSubstructureMatcher::matchQueryBond(q_bond, *target, sub_idx, super_idx, 0, 0xFFFFFFFF);
 }
 
-bool MoleculeScaffoldDetection::matchAtoms(Graph& g1, Graph& g2, const int*, int i, int j, void* userdata)
+bool MoleculeScaffoldDetection::matchAtoms(Graph& g1, Graph& g2, const int*, int i, int j, void* /*userdata*/)
 {
     BaseMolecule& mol1 = (BaseMolecule&)g1;
     BaseMolecule& mol2 = (BaseMolecule&)g2;

--- a/core/indigo-core/molecule/src/molecule_standardize.cpp
+++ b/core/indigo-core/molecule/src/molecule_standardize.cpp
@@ -519,7 +519,7 @@ void MoleculeStandardizer::_standardizeStereo(Molecule& mol)
     }
 }
 
-void MoleculeStandardizer::_standardizeStereo(QueryMolecule& mol)
+void MoleculeStandardizer::_standardizeStereo(QueryMolecule& /*mol*/)
 {
     throw Error("This option is not available for QueryMolecule object");
 }
@@ -641,7 +641,7 @@ void MoleculeStandardizer::_standardizeCharges(Molecule& mol)
     }
 }
 
-void MoleculeStandardizer::_standardizeCharges(QueryMolecule& mol)
+void MoleculeStandardizer::_standardizeCharges(QueryMolecule& /*mol*/)
 {
     throw Error("This option is not available for QueryMolecule object");
 }
@@ -826,7 +826,7 @@ void MoleculeStandardizer::_makeNonHAtomsCAtoms(QueryMolecule& mol)
     }
 }
 
-void MoleculeStandardizer::_makeNonHAtomsAAtoms(Molecule& mol)
+void MoleculeStandardizer::_makeNonHAtomsAAtoms(Molecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object");
 }
@@ -841,7 +841,7 @@ void MoleculeStandardizer::_makeNonHAtomsAAtoms(QueryMolecule& mol)
     }
 }
 
-void MoleculeStandardizer::_makeNonCHAtomsQAtoms(Molecule& mol)
+void MoleculeStandardizer::_makeNonCHAtomsQAtoms(Molecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object");
 }
@@ -880,7 +880,7 @@ void MoleculeStandardizer::_clearCoordinates(BaseMolecule& mol)
     mol.clearXyz();
 }
 
-void MoleculeStandardizer::_fixCoordinateDimension(BaseMolecule& mol)
+void MoleculeStandardizer::_fixCoordinateDimension(BaseMolecule& /*mol*/)
 {
     throw Error("This option is not used for Indigo");
 }
@@ -920,7 +920,7 @@ void MoleculeStandardizer::_clearMolecule(BaseMolecule& mol)
     mol.clear();
 }
 
-void MoleculeStandardizer::_removeMolecule(BaseMolecule& mol)
+void MoleculeStandardizer::_removeMolecule(BaseMolecule& /*mol*/)
 {
     throw Error("Not implemented yet");
 }
@@ -1190,7 +1190,7 @@ void MoleculeStandardizer::_clearCharges(QueryMolecule& mol)
     }
 }
 
-void MoleculeStandardizer::_clearPiBonds(BaseMolecule& mol)
+void MoleculeStandardizer::_clearPiBonds(BaseMolecule& /*mol*/)
 {
     throw Error("This option is not used for Indigo");
 }
@@ -1200,27 +1200,27 @@ void MoleculeStandardizer::_clearHighlightColors(BaseMolecule& mol)
     mol.unhighlightAll();
 }
 
-void MoleculeStandardizer::_clearQueryInfo(BaseMolecule& mol)
+void MoleculeStandardizer::_clearQueryInfo(BaseMolecule& /*mol*/)
 {
     throw Error("This option is not used for Indigo");
 }
 
-void MoleculeStandardizer::_clearAtomLabels(Molecule& mol)
+void MoleculeStandardizer::_clearAtomLabels(Molecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object?");
 }
 
-void MoleculeStandardizer::_clearAtomLabels(QueryMolecule& mol)
+void MoleculeStandardizer::_clearAtomLabels(QueryMolecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object?");
 }
 
-void MoleculeStandardizer::_clearBondLabels(Molecule& mol)
+void MoleculeStandardizer::_clearBondLabels(Molecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object?");
 }
 
-void MoleculeStandardizer::_clearBondLabels(QueryMolecule& mol)
+void MoleculeStandardizer::_clearBondLabels(QueryMolecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object?");
 }
@@ -1267,7 +1267,7 @@ void MoleculeStandardizer::_neutralizeBondedZwitterions(Molecule& mol)
     }
 }
 
-void MoleculeStandardizer::_neutralizeBondedZwitterions(QueryMolecule& mol)
+void MoleculeStandardizer::_neutralizeBondedZwitterions(QueryMolecule& /*mol*/)
 {
     throw Error("This option is not available for QueryMolecule object");
 }
@@ -1342,12 +1342,12 @@ void MoleculeStandardizer::_clearHydrogenBonds(BaseMolecule& mol)
         mol.removeBonds(remove_bonds);
 }
 
-void MoleculeStandardizer::_localizeMarkushRAtomsOnRings(Molecule& mol)
+void MoleculeStandardizer::_localizeMarkushRAtomsOnRings(Molecule& /*mol*/)
 {
     throw Error("This option is available only for QueryMolecule object?");
 }
 
-void MoleculeStandardizer::_localizeMarkushRAtomsOnRings(QueryMolecule& mol)
+void MoleculeStandardizer::_localizeMarkushRAtomsOnRings(QueryMolecule& /*mol*/)
 {
 }
 

--- a/core/indigo-core/molecule/src/molecule_stereocenters.cpp
+++ b/core/indigo-core/molecule/src/molecule_stereocenters.cpp
@@ -223,7 +223,7 @@ void MoleculeStereocenters::_buildOneFrom3dCoordinates(BaseMolecule& baseMolecul
         add(baseMolecule, idx, ATOM_ABS, 0, false);
 }
 
-bool MoleculeStereocenters::hasAtropoStereoBonds(BaseMolecule& baseMolecule, int atom_idx)
+bool MoleculeStereocenters::hasAtropoStereoBonds(BaseMolecule& /* baseMolecule */, int atom_idx)
 {
     return _atropocenters.find(atom_idx) && _atropocenters.at(atom_idx).bond_directions.size();
 }
@@ -232,12 +232,12 @@ bool MoleculeStereocenters::isPossibleAtropocenter(BaseMolecule& baseMolecule, i
 {
     if (baseMolecule.vertexInRing(atom_idx)) // check if the atom belongs to ring
     {
-        bool has_stereo = false;
+        // bool has_stereo = false;
         const Vertex& v = baseMolecule.getVertex(atom_idx);
         // check if the atom has at least one stereo-bond
-        for (int i = v.neiBegin(); i != v.neiEnd(); i = v.neiNext(i))
+        for (int vi = v.neiBegin(); vi != v.neiEnd(); vi = v.neiNext(vi))
         {
-            if (baseMolecule.getBondDirection(v.neiEdge(i)))
+            if (baseMolecule.getBondDirection(v.neiEdge(vi)))
             {
                 for (int i = v.neiBegin(); i != v.neiEnd(); i = v.neiNext(i))
                 {
@@ -1264,7 +1264,7 @@ bool MoleculeStereocenters::isPyramidMappingRigid(const int* pyramid, int size, 
 }
 
 void MoleculeStereocenters::getPyramidMapping(BaseMolecule& query, BaseMolecule& target, int query_atom, const int* mapping, int* mapping_out,
-                                              bool reset_h_isotopes)
+                                              bool /* reset_h_isotopes */)
 {
     int i, j;
 
@@ -1473,7 +1473,7 @@ void MoleculeStereocenters::add(BaseMolecule& baseMolecule, int atom_idx, int ty
     add(baseMolecule, atom_idx, type, group, pyramid);
 }
 
-void MoleculeStereocenters::add(BaseMolecule& baseMolecule, int atom_idx, int type, int group, const int pyramid[4])
+void MoleculeStereocenters::add(BaseMolecule& /* baseMolecule */, int atom_idx, int type, int group, const int pyramid[4])
 {
     if (atom_idx < 0)
         throw Error("stereocenter index is invalid");
@@ -1496,7 +1496,7 @@ void MoleculeStereocenters::add_ignore(BaseMolecule& baseMolecule, int atom_idx,
     add_ignore(baseMolecule, atom_idx, type, group, pyramid);
 }
 
-void MoleculeStereocenters::add_ignore(BaseMolecule& baseMolecule, int atom_idx, int type, int group, const int pyramid[4])
+void MoleculeStereocenters::add_ignore(BaseMolecule& /* baseMolecule */, int atom_idx, int type, int group, const int pyramid[4])
 {
     if (atom_idx < 0)
         throw Error("stereocenter index is invalid");

--- a/core/indigo-core/molecule/src/molecule_substructure_matcher.cpp
+++ b/core/indigo-core/molecule/src/molecule_substructure_matcher.cpp
@@ -37,7 +37,7 @@ using namespace indigo;
 
 CP_DEF(MoleculeSubstructureMatcher::MarkushContext);
 
-MoleculeSubstructureMatcher::MarkushContext::MarkushContext(QueryMolecule& query_, BaseMolecule& target_)
+MoleculeSubstructureMatcher::MarkushContext::MarkushContext(QueryMolecule& query_, BaseMolecule& /* target_ */)
     : CP_INIT, TL_CP_GET(query), TL_CP_GET(query_marking), TL_CP_GET(sites), depth(0)
 {
     int i;
@@ -705,7 +705,7 @@ bool MoleculeSubstructureMatcher::_matchBonds(Graph& subgraph, Graph& supergraph
     return true;
 }
 
-void MoleculeSubstructureMatcher::removeAtom(Graph& subgraph, int sub_idx, AromaticityMatcher* am)
+void MoleculeSubstructureMatcher::removeAtom(Graph& /* subgraph */, int sub_idx, AromaticityMatcher* am)
 {
     if (am == 0)
         return;
@@ -720,7 +720,7 @@ void MoleculeSubstructureMatcher::_removeAtom(Graph& subgraph, int sub_idx, void
     removeAtom(subgraph, sub_idx, self->_am.get());
 }
 
-void MoleculeSubstructureMatcher::addBond(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, AromaticityMatcher* am)
+void MoleculeSubstructureMatcher::addBond(Graph& /* subgraph */, Graph& supergraph, int sub_idx, int super_idx, AromaticityMatcher* am)
 {
     if (am == 0)
         return;
@@ -736,7 +736,7 @@ void MoleculeSubstructureMatcher::_addBond(Graph& subgraph, Graph& supergraph, i
     addBond(subgraph, supergraph, sub_idx, super_idx, self->_am.get());
 }
 
-int MoleculeSubstructureMatcher::_embedding(Graph& subgraph, Graph& supergraph, int* core_sub, int* core_super, void* userdata)
+int MoleculeSubstructureMatcher::_embedding(Graph& /* subgraph */, Graph& /* supergraph */, int* core_sub, int* core_super, void* userdata)
 {
     MoleculeSubstructureMatcher* self = (MoleculeSubstructureMatcher*)userdata;
 
@@ -949,7 +949,7 @@ bool MoleculeSubstructureMatcher::_attachRGroupAndContinue(int* core1, int* core
 
     // Parameters for stereocenter restoration
     bool stereo_was_saved = false;
-    int saved_stereo_type, saved_stereo_group, saved_stereo_pyramid[4];
+    int saved_stereo_type = -1, saved_stereo_group = -1, saved_stereo_pyramid[4];
 
     // If some rgroup must be attached
     if (rgroup_idx != -1)
@@ -1211,7 +1211,7 @@ bool MoleculeSubstructureMatcher::_checkRGroupConditions()
         if (context.sites[i] >= 0)
             occurrences[context.sites[i]]++;
 
-    for (int i = 1; i <= n_rgroups; i++)
+    for (i = 1; i <= n_rgroups; i++)
     {
         RGroup& rgroup = rgroups.getRGroup(i);
 
@@ -1264,7 +1264,7 @@ bool MoleculeSubstructureMatcher::_checkRGroupConditions()
     }
 
     // Check if/then relations
-    for (int i = 1; i <= n_rgroups; i++)
+    for (i = 1; i <= n_rgroups; i++)
     {
         if (nontop_rgroups[i] == 1 || conditions[i] == -1)
             continue;

--- a/core/indigo-core/molecule/src/molecule_tautomer_enumerator.cpp
+++ b/core/indigo-core/molecule/src/molecule_tautomer_enumerator.cpp
@@ -142,9 +142,9 @@ TautomerEnumerator::TautomerEnumerator(Molecule& molecule, TautomerMethod method
             {
                 occupied = false;
                 const Vertex& v = molecule.getVertex(i);
-                for (auto i = v.neiBegin(); i != v.neiEnd(); i = v.neiNext(i))
+                for (auto k = v.neiBegin(); k != v.neiEnd(); k = v.neiNext(k))
                 {
-                    int e_inx = v.neiEdge(i);
+                    int e_inx = v.neiEdge(k);
                     if (molecule.getBondOrder(e_inx) == 1 || molecule.getBondOrder(e_inx) == 4)
                     {
                         occupied = true;
@@ -268,7 +268,7 @@ void TautomerEnumerator::constructMolecule(Molecule& molecule, int n) const
         ; // error!
 }
 
-bool TautomerEnumerator::refine_proc(const Molecule& uncleaned_fragments, Molecule& product, Array<int>& mapping, void* userdata)
+bool TautomerEnumerator::refine_proc(const Molecule& uncleaned_fragments, Molecule& product, Array<int>& mapping, void* /* userdata */)
 {
     bool changed = true;
     while (changed)
@@ -354,7 +354,7 @@ bool TautomerEnumerator::refine_proc(const Molecule& uncleaned_fragments, Molecu
     return true;
 }
 
-void TautomerEnumerator::product_proc(Molecule& product, Array<int>& monomers_indices, Array<int>& mapping, void* userdata)
+void TautomerEnumerator::product_proc(Molecule& product, Array<int>& /* monomers_indices */, Array<int>& mapping, void* userdata)
 {
     LayeredMolecules* lm = (LayeredMolecules*)userdata;
     lm->addLayerFromMolecule(product, mapping);
@@ -514,7 +514,7 @@ bool TautomerEnumerator::_aromatize(int from, int to)
 }
 
 #ifdef USE_DEPRECATED_INCHI
-bool TautomerEnumerator::matchEdge(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
+bool TautomerEnumerator::matchEdge(Graph& /* subgraph */, Graph& supergraph, int /* sub_idx */, int super_idx, void* userdata)
 {
     LayeredMolecules& layeredMolecules = (LayeredMolecules&)supergraph;
     Breadcrumps& breadcrumps = *(Breadcrumps*)userdata;
@@ -527,7 +527,7 @@ bool TautomerEnumerator::matchEdge(Graph& subgraph, Graph& supergraph, int sub_i
     return breadcrumps.forwardMask.intersects(forwardMask) || breadcrumps.backwardMask.intersects(backwardMask);
 }
 
-bool TautomerEnumerator::matchVertex(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool TautomerEnumerator::matchVertex(Graph& /* subgraph */, Graph& supergraph, const int* /* core_sub */, int /* sub_idx */, int super_idx, void* userdata)
 {
     // The first vertice matched shall be the mobile hydrogen position.
     Breadcrumps& breadcrumps = *(Breadcrumps*)userdata;
@@ -537,7 +537,7 @@ bool TautomerEnumerator::matchVertex(Graph& subgraph, Graph& supergraph, const i
     return true;
 }
 
-void TautomerEnumerator::edgeAdd(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
+void TautomerEnumerator::edgeAdd(Graph& /* subgraph */, Graph& supergraph, int /* sub_idx */, int super_idx, void* userdata)
 {
     LayeredMolecules& layeredMolecules = (LayeredMolecules&)supergraph;
     Breadcrumps& breadcrumps = *(Breadcrumps*)userdata;
@@ -557,7 +557,7 @@ void TautomerEnumerator::edgeAdd(Graph& subgraph, Graph& supergraph, int sub_idx
     breadcrumps.backwardMask.andWith(backwardMask);
 }
 
-void TautomerEnumerator::vertexAdd(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
+void TautomerEnumerator::vertexAdd(Graph& /* subgraph */, Graph& supergraph, int /* sub_idx */, int super_idx, void* userdata)
 {
     LayeredMolecules& layeredMolecules = (LayeredMolecules&)supergraph;
     Breadcrumps& breadcrumps = *(Breadcrumps*)userdata;
@@ -586,7 +586,7 @@ void TautomerEnumerator::vertexAdd(Graph& subgraph, Graph& supergraph, int sub_i
     }
 }
 
-void TautomerEnumerator::vertexRemove(Graph& subgraph, int sub_idx, void* userdata)
+void TautomerEnumerator::vertexRemove(Graph& /* subgraph */, int /* sub_idx */, void* userdata)
 {
     Breadcrumps& breadcrumps = *(Breadcrumps*)userdata;
 

--- a/core/indigo-core/molecule/src/molecule_tautomer_match.cpp
+++ b/core/indigo-core/molecule/src/molecule_tautomer_match.cpp
@@ -57,7 +57,7 @@ TautomerSearchContext::~TautomerSearchContext()
 {
 }
 
-bool TautomerMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool TautomerMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int* /*core_sub*/, int sub_idx, int super_idx, void* /*userdata*/)
 {
     QueryMolecule& query = ((BaseMolecule&)subgraph).asQueryMolecule();
     QueryMolecule::Atom* atom = &query.getAtom(sub_idx);
@@ -81,7 +81,7 @@ bool TautomerMatcher::_matchAtoms(Graph& subgraph, Graph& supergraph, const int*
     return true;
 }
 
-bool TautomerMatcher::_matchAtomsEx(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool TautomerMatcher::_matchAtomsEx(Graph& subgraph, Graph& supergraph, const int* /*core_sub*/, int sub_idx, int super_idx, void* /*userdata*/)
 {
     return MoleculeExactMatcher::matchAtoms(((BaseMolecule&)subgraph).asMolecule(), (BaseMolecule&)supergraph, sub_idx, super_idx, 0xFFFFFFFFUL);
 }
@@ -117,7 +117,7 @@ bool TautomerMatcher::matchBondsTau(Graph& subgraph, Graph& supergraph, int sub_
     return false;
 }
 
-bool TautomerMatcher::matchBondsTauSub(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
+bool TautomerMatcher::matchBondsTauSub(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* /*userdata*/)
 {
     BaseMolecule& molecule = (BaseMolecule&)supergraph;
     QueryMolecule& query = ((BaseMolecule&)subgraph).asQueryMolecule();
@@ -197,7 +197,7 @@ int TautomerMatcher::_remainderEmbedding(Graph& g1, Graph& g2, int* core1, int* 
     return 0;
 }
 
-int TautomerMatcher::_preliminaryEmbedding(Graph& g1, Graph& g2, int* core1, int* core2, void* userdata)
+int TautomerMatcher::_preliminaryEmbedding(Graph& /*g1*/, Graph& g2, int* core1, int* core2, void* userdata)
 {
     TautomerMatcher::MatchData& d = *(TautomerMatcher::MatchData*)userdata;
 
@@ -525,7 +525,7 @@ bool TautomerMatcher::findMatch()
     return true;
 }
 
-bool TautomerMatcher::fixBondsNotInChains(TautomerSearchContext& context, const int* core1, const int* core2)
+bool TautomerMatcher::fixBondsNotInChains(TautomerSearchContext& context, const int* /*core1*/, const int* core2)
 {
     bool ok = true;
 

--- a/core/indigo-core/molecule/src/molecule_tautomer_superstructure.cpp
+++ b/core/indigo-core/molecule/src/molecule_tautomer_superstructure.cpp
@@ -66,7 +66,7 @@ TautomerSuperStructure::TautomerSuperStructure(Molecule& mol)
     // Detect distances from _atomsEmitBond elements to _atomsAcceptBond elements
     QS_DEF(Array<int>, distancesMatrix);
     distancesMatrix.resize(_atomsEmitBond.size() * _atomsAcceptBond.size());
-    for (int i = 0; i < _atomsEmitBond.size(); i++)
+    for (i = 0; i < _atomsEmitBond.size(); i++)
     {
         int* result = distancesMatrix.ptr() + _atomsAcceptBond.size() * i;
         _findMinDistance(_atomsEmitBond[i], 6, _atomsAcceptBond, result);
@@ -74,7 +74,7 @@ TautomerSuperStructure::TautomerSuperStructure(Molecule& mol)
 
     QS_DEF(Array<int>, attachedBonds);
     attachedBonds.clear();
-    for (int i = 0; i < _atomsEmitBond.size(); i++)
+    for (i = 0; i < _atomsEmitBond.size(); i++)
         for (int j = 0; j < _atomsAcceptBond.size(); j++)
         {
             int v1 = _atomsEmitBond[i];
@@ -91,7 +91,7 @@ TautomerSuperStructure::TautomerSuperStructure(Molecule& mol)
 
     _isBondAttachedArray.resize(edgeEnd());
     _isBondAttachedArray.zerofill();
-    for (int i = 0; i < attachedBonds.size(); i++)
+    for (i = 0; i < attachedBonds.size(); i++)
         _isBondAttachedArray[attachedBonds[i]] = true;
 
     _inside_ctor = false;
@@ -131,7 +131,7 @@ bool TautomerSuperStructure::possibleBondOrder(int idx, int order)
     return Molecule::possibleBondOrder(idx, order);
 }
 
-int TautomerSuperStructure::getSubgraphType(const Array<int>& vertices, const Array<int>& edges)
+int TautomerSuperStructure::getSubgraphType(const Array<int>& /*vertices*/, const Array<int>& edges)
 {
     // For any atoms number of attached bonds must be 0 or 1
 

--- a/core/indigo-core/molecule/src/molecule_tgroups.cpp
+++ b/core/indigo-core/molecule/src/molecule_tgroups.cpp
@@ -36,7 +36,7 @@ void TGroup::clear()
 {
 }
 
-int TGroup::cmp(TGroup& tg1, TGroup& tg2, void* context)
+int TGroup::cmp(TGroup& tg1, TGroup& tg2, void* /*context*/)
 {
     QS_DEF(Array<int>, lgrps)
     QS_DEF(Array<int>, bgrps)

--- a/core/indigo-core/molecule/src/molfile_loader.cpp
+++ b/core/indigo-core/molecule/src/molfile_loader.cpp
@@ -1119,8 +1119,7 @@ void MolfileLoader::_readCtab2000()
                     {
                         if (strscan.isEOF())
                             break;
-                        int c = strscan.readChar();
-                        sgroup.name.push(c);
+                        sgroup.name.push(strscan.readChar());
                     }
                     // Remove last spaces because name can have multiple words
                     while (sgroup.name.size() > 0)
@@ -1139,8 +1138,7 @@ void MolfileLoader::_readCtab2000()
                     {
                         if (strscan.isEOF())
                             break;
-                        int c = strscan.readChar();
-                        sgroup.type.push(c);
+                        sgroup.type.push(strscan.readChar());
                     }
                     sgroup.type.push(0);
 
@@ -1150,8 +1148,7 @@ void MolfileLoader::_readCtab2000()
                     {
                         if (strscan.isEOF())
                             break;
-                        int c = strscan.readChar();
-                        sgroup.description.push(c);
+                        sgroup.description.push(strscan.readChar());
                     }
                     // Remove last spaces because dscription can have multiple words?
                     while (sgroup.description.size() > 0)
@@ -1169,8 +1166,7 @@ void MolfileLoader::_readCtab2000()
                     {
                         if (strscan.isEOF())
                             break;
-                        int c = strscan.readChar();
-                        sgroup.querycode.push(c);
+                        sgroup.querycode.push(strscan.readChar());
                     }
                     while (sgroup.querycode.size() > 0)
                     {
@@ -1187,8 +1183,7 @@ void MolfileLoader::_readCtab2000()
                     {
                         if (strscan.isEOF())
                             break;
-                        int c = strscan.readChar();
-                        sgroup.queryoper.push(c);
+                        sgroup.queryoper.push(strscan.readChar());
                     }
                     while (sgroup.queryoper.size() > 0)
                     {
@@ -1360,10 +1355,8 @@ void MolfileLoader::_readCtab2000()
                         _scanner.skip(1);
                         ap.lvidx = _scanner.readIntFix(3) - 1;
                         _scanner.skip(1);
-                        char c = _scanner.readChar();
-                        ap.apid.push(c);
-                        c = _scanner.readChar();
-                        ap.apid.push(c);
+                        ap.apid.push(_scanner.readChar());
+                        ap.apid.push(_scanner.readChar());
                         ap.apid.push(0);
                     }
                 }
@@ -1873,7 +1866,7 @@ void MolfileLoader::_readRGroupOccurrenceRanges(const char* str, Array<int>& ran
     ranges.push((beg << 16) | end);
 }
 
-int MolfileLoader::_asc_cmp_cb(int& v1, int& v2, void* context)
+int MolfileLoader::_asc_cmp_cb(int& v1, int& v2, void* /*context*/)
 {
     return v2 - v1;
 }
@@ -1935,10 +1928,10 @@ void MolfileLoader::_postLoad()
             DataSGroup& dsg = static_cast<DataSGroup&>(sgroup);
             if (dsg.parent_idx > -1 && std::string(dsg.name.ptr()) == "SMMX:class")
             {
-                SGroup& sgroup = _bmol->sgroups.getSGroup(dsg.parent_idx);
-                if (sgroup.sgroup_type == SGroup::SG_TYPE_SUP)
+                SGroup& parent_sgroup = _bmol->sgroups.getSGroup(dsg.parent_idx);
+                if (parent_sgroup.sgroup_type == SGroup::SG_TYPE_SUP)
                 {
-                    auto& sa = (Superatom&)sgroup;
+                    auto& sa = static_cast<Superatom&>(parent_sgroup);
                     if (sa.sa_natreplace.size() == 0)
                         sa.sa_natreplace.copy(dsg.sa_natreplace);
                     if (sa.sa_class.size() == 0)
@@ -3502,7 +3495,7 @@ void MolfileLoader::_readSGroup3000(const char* str)
             n = scanner.readInt1();
             while (n-- > 0)
             {
-                int idx = scanner.readInt() - 1;
+                idx = scanner.readInt() - 1;
 
                 if (sgroup->sgroup_type == SGroup::SG_TYPE_MUL)
                     ((MultipleGroup*)sgroup)->parent_atoms.push(idx);
@@ -3711,7 +3704,7 @@ void MolfileLoader::_readSGroup3000(const char* str)
                     throw Error("CSTATE number is %d (must be 4)", n);
                 scanner.skipSpace();
                 Superatom::_BondConnection& bond = sup->bond_connections.push();
-                int idx = scanner.readInt() - 1;
+                idx = scanner.readInt() - 1;
                 bond.bond_idx = idx;
                 scanner.skipSpace();
                 bond.bond_dir.x = scanner.readFloat();
@@ -3737,7 +3730,7 @@ void MolfileLoader::_readSGroup3000(const char* str)
                 if (n != 3)
                     throw Error("SAP number is %d (must be 3)", n);
                 scanner.skipSpace();
-                int idx = scanner.readInt() - 1;
+                idx = scanner.readInt() - 1;
                 int idap = sup->attachment_points.add();
                 Superatom::_AttachmentPoint& ap = sup->attachment_points.at(idap);
                 ap.aidx = idx;

--- a/core/indigo-core/molecule/src/molfile_saver.cpp
+++ b/core/indigo-core/molecule/src/molfile_saver.cpp
@@ -1519,13 +1519,13 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
                 constexpr int SYMBOL_WIDTH = 4;
                 if (strlen(str) > 4)
                 {
-                    for (int i = 0; i < SYMBOL_WIDTH; i++)
-                        output.writeChar(str[i]);
+                    for (int k = 0; k < SYMBOL_WIDTH; k++)
+                        output.writeChar(str[k]);
                 }
                 else
                 {
                     output.writeString(str);
-                    for (auto i = strlen(str); i < SYMBOL_WIDTH; i++)
+                    for (auto k = strlen(str); k < SYMBOL_WIDTH; k++)
                         output.writeChar(' ');
                 }
             }
@@ -1569,7 +1569,7 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
 
     for (i = mol.sgroups.begin(); i != mol.sgroups.end(); i = mol.sgroups.next(i))
     {
-        SGroup& sgroup = mol.sgroups.getSGroup(i);
+        /*SGroup& sgroup =*/std::ignore = mol.sgroups.getSGroup(i);
         sgroup_ids.push(i);
     }
 
@@ -1688,7 +1688,7 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
                     bool next_line = true;
                     int nrem = superatom.attachment_points.size();
                     int k = 0;
-                    for (int j = superatom.attachment_points.begin(); j < superatom.attachment_points.end(); j = superatom.attachment_points.next(j))
+                    for (j = superatom.attachment_points.begin(); j < superatom.attachment_points.end(); j = superatom.attachment_points.next(j))
                     {
                         if (next_line)
                         {
@@ -1756,7 +1756,6 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
                 char* ptr = datasgroup.data.ptr();
                 while (k > 0)
                 {
-                    int j;
                     for (j = 0; j < 69 && j < k; j++)
                         if (ptr[j] == '\n')
                             break;

--- a/core/indigo-core/molecule/src/molfile_saver.cpp
+++ b/core/indigo-core/molecule/src/molfile_saver.cpp
@@ -1500,8 +1500,6 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
 
         output.printf("M  ALS %3d%3d %c ", _atom_mapping[atom_idx], list.size(), query_atom_type == QueryMolecule::QUERY_ATOM_NOTLIST ? 'T' : 'F');
 
-        int j;
-
         for (auto& qatom : list)
         {
             if (qatom->type == QueryMolecule::ATOM_NUMBER)
@@ -1527,7 +1525,7 @@ void MolfileSaver::_writeCtab2000(Output& output, BaseMolecule& mol, bool query)
                 else
                 {
                     output.writeString(str);
-                    for (int i = strlen(str); i < SYMBOL_WIDTH; i++)
+                    for (auto i = strlen(str); i < SYMBOL_WIDTH; i++)
                         output.writeChar(' ');
                 }
             }

--- a/core/indigo-core/molecule/src/monomer_commons.cpp
+++ b/core/indigo-core/molecule/src/monomer_commons.cpp
@@ -157,9 +157,9 @@ namespace indigo
     int getAttachmentOrder(const std::string& label)
     {
         if (label == kLeftAttachmentPoint)
-            return 0;
+            return kLeftAttachmentPointIdx;
         if (label == kRightAttachmentPoint)
-            return 1;
+            return kRightAttachmentPointIdx;
         if (label.size() > 1 || isupper(label[0]))
         {
             if (label[0] == 'R')
@@ -171,6 +171,9 @@ namespace indigo
             if (label[1] == 'x')
                 return label[0] - 'A';
         }
+        // TODO: return right value at this point
+        //       this value returned just to avoid warnings
+        return kBranchAttachmentPointIdx;
     }
 
     bool isAttachmentPointsInOrder(int order, const std::string& label)

--- a/core/indigo-core/molecule/src/monomer_commons.cpp
+++ b/core/indigo-core/molecule/src/monomer_commons.cpp
@@ -18,7 +18,6 @@
 
 #ifdef _MSC_VER
 #pragma warning(push, 4)
-#pragma warning(error : 4100 4101 4189 4244 4456 4458 4715)
 #endif
 
 #include <unordered_map>
@@ -152,7 +151,7 @@ namespace indigo
     {
         std::string second_chars = "lrx";
         std::string label(1, static_cast<char>('A' + order));
-        if (static_cast<long long>(order) > second_chars.size() - 1)
+        if (order > static_cast<long>(second_chars.size()) - 1)
             label += second_chars.back();
         else
             label += second_chars[order];

--- a/core/indigo-core/molecule/src/monomer_commons.cpp
+++ b/core/indigo-core/molecule/src/monomer_commons.cpp
@@ -152,7 +152,7 @@ namespace indigo
     {
         std::string second_chars = "lrx";
         std::string label(1, static_cast<char>('A' + order));
-        if (order > second_chars.size() - 1)
+        if (static_cast<long long>(order) > second_chars.size() - 1)
             label += second_chars.back();
         else
             label += second_chars[order];

--- a/core/indigo-core/molecule/src/monomer_commons.cpp
+++ b/core/indigo-core/molecule/src/monomer_commons.cpp
@@ -16,6 +16,11 @@
  * limitations under the License.
  ***************************************************************************/
 
+#ifdef _MSC_VER
+#pragma warning(push, 4)
+#pragma warning(error : 4100 4101 4189 4244 4456 4458 4715)
+#endif
+
 #include <unordered_map>
 
 #include "molecule/monomer_commons.h"
@@ -126,7 +131,7 @@ namespace indigo
         {
             if (is_lower_case(name) || is_upper_case(name))
                 for (auto it = res.begin(); it < res.end(); ++it)
-                    *it = it > res.begin() ? std::tolower(*it) : std::toupper(*it);
+                    *it = it > res.begin() ? std::tolower(*it, std::locale()) : std::toupper(*it, std::locale());
         }
         // do not add prefix
         auto prefix = classToPrefix(monomer_class);
@@ -146,7 +151,7 @@ namespace indigo
     std::string getAttachmentLabel(int order)
     {
         std::string second_chars = "lrx";
-        std::string label(1, 'A' + order);
+        std::string label(1, static_cast<char>('A' + order));
         if (order > second_chars.size() - 1)
             label += second_chars.back();
         else
@@ -205,3 +210,7 @@ namespace indigo
         return false;
     }
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/src/multiple_cdx_loader.cpp
+++ b/core/indigo-core/molecule/src/multiple_cdx_loader.cpp
@@ -384,7 +384,7 @@ void MultipleCdxLoader::_getString(int size, Array<char>& buf, bool no_style)
             style_count = _scanner.readBinaryWord();
             auto styles_size = sizeof(style_count) + sizeof(CDXTextStyle) * style_count;
             _scanner.seek(style_count * sizeof(CDXTextStyle), SEEK_CUR);
-            _scanner.read(size - styles_size, buf);
+            _scanner.read(static_cast<int>(size - styles_size), buf);
         }
     }
     return;

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2643,7 +2643,7 @@ bool QueryMolecule::_tryToConvertToList(Atom* p_query_atom, std::vector<std::uni
             std::sort(props.begin(), props.end(), compare);
             if (props.size() != atoms_properties.size())
                 return false;
-            for (int j = 0; j < props.size(); j++)
+            for (auto j = 0; j < props.size(); j++)
             {
                 if (props[j]->type != atoms_properties[j]->type || props[j]->value_min != atoms_properties[j]->value_min ||
                     props[j]->value_max != atoms_properties[j]->value_max)

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -27,7 +27,6 @@
 
 #ifdef _MSC_VER
 #pragma warning(push, 4)
-#pragma warning(error : 4100 4100 4189 4244 4456 4458 4715)
 #endif
 
 using namespace indigo;
@@ -599,6 +598,7 @@ static void _write_num_if_set(indigo::Output& output, unsigned char ch, int min,
     }
 }
 
+/*/
 static void writeAnd(Output& _output, QueryMolecule::Node* node, bool has_or_parent)
 {
     if (has_or_parent)
@@ -606,6 +606,7 @@ static void writeAnd(Output& _output, QueryMolecule::Node* node, bool has_or_par
     else if (node->hasOP_OR())
         _output.writeChar(';');
 }
+//*/
 
 void QueryMolecule::writeSmartsAtom(Output& output, Atom* atom, int aam, int chirality, int depth, bool has_or_parent, bool has_not_parent, int original_format)
 {
@@ -1705,10 +1706,12 @@ bool QueryMolecule::Node::possibleValuePairInv(int what_type1, int what_value1, 
         int val1, val2;
         bool sure1, sure2;
 
-        if ((sure1 = _sureValue(what_type1, val1)) && !hasConstraint(what_type2) && val1 == what_value1)
+        sure1 = _sureValue(what_type1, val1);
+        if (sure1 && !hasConstraint(what_type2) && val1 == what_value1)
             return false;
 
-        if ((sure2 = _sureValue(what_type2, val2)) && !hasConstraint(what_type1) && val2 == what_value2)
+        sure2 = _sureValue(what_type2, val2);
+        if (sure2 && !hasConstraint(what_type1) && val2 == what_value2)
             return false;
 
         if (sure1 && sure2 && val1 == what_value1 && val2 == what_value2)

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -2646,7 +2646,7 @@ bool QueryMolecule::_tryToConvertToList(Atom* p_query_atom, std::vector<std::uni
             std::sort(props.begin(), props.end(), compare);
             if (props.size() != atoms_properties.size())
                 return false;
-            for (auto j = 0; j < props.size(); j++)
+            for (size_t j = 0; j < props.size(); j++)
             {
                 if (props[j]->type != atoms_properties[j]->type || props[j]->value_min != atoms_properties[j]->value_min ||
                     props[j]->value_max != atoms_properties[j]->value_max)

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -25,6 +25,11 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef _MSC_VER
+#pragma warning(push, 4)
+#pragma warning(error : 4100 4100 4189 4244 4456 4458 4715)
+#endif
+
 using namespace indigo;
 
 bool QueryMolecule::isAtomProperty(OpType type)
@@ -140,7 +145,7 @@ int QueryMolecule::getBondTopology(int idx)
     return -1;
 }
 
-int QueryMolecule::getAtomValence(int idx)
+int QueryMolecule::getAtomValence(int /*idx*/)
 {
     throw Error("not implemented");
 }
@@ -199,7 +204,7 @@ bool QueryMolecule::isOrganicSubset(QueryMolecule::Atom* atom)
     return QueryMolecule::isOrganicSubset(atom->value_max);
 }
 
-int QueryMolecule::getAtomConnectivity(int idx)
+int QueryMolecule::getAtomConnectivity(int /*idx*/)
 {
     return 0;
 }
@@ -536,7 +541,6 @@ std::string QueryMolecule::getMolMrvSmaExtension(QueryMolecule& qm, int aid)
     {
         // Just atom or list and list of properties.
         bool atoms_writed = false;
-        bool not_first_property = false;
         for (int property : {ATOM_TOTAL_H, ATOM_IMPLICIT_H, ATOM_CONNECTIVITY, ATOM_SSSR_RINGS, ATOM_SMALLEST_RING_SIZE, ATOM_AROMATICITY})
         {
             if (atom_props.count(property) < 1)
@@ -565,10 +569,6 @@ std::string QueryMolecule::getMolMrvSmaExtension(QueryMolecule& qm, int aid)
                 output.writeChar(';');
                 atoms_writed = true;
             }
-            if (not_first_property)
-                output.writeChar('&');
-            else
-                bool not_first_property = true;
             writeSmartsAtom(output, atom_props[property].get(), -1, -1, 1, false, false, qm.original_format);
         }
     }
@@ -663,7 +663,7 @@ void QueryMolecule::writeSmartsAtom(Output& output, Atom* atom, int aam, int chi
         if (has_aromatic && has_number)
         { // Convert a & #6 -> c,  A & #6 -> C
             if (aromatic)
-                atom_name[0] = tolower(atom_name[0]);
+                atom_name[0] = static_cast<char>(tolower(atom_name[0]));
             output.printf("%s", atom_name);
         }
         for (i = 0; i < atom->children.size(); i++)
@@ -1014,27 +1014,27 @@ const char* QueryMolecule::getTemplateAtom(int idx)
     throw Error("getTemplateAtom() applied to something that is not a template atom");
 }
 
-const char* QueryMolecule::getTemplateAtomClass(int idx)
+const char* QueryMolecule::getTemplateAtomClass(int /*idx*/)
 {
     return 0;
 }
 
-const int QueryMolecule::getTemplateAtomSeqid(int idx)
+const int QueryMolecule::getTemplateAtomSeqid(int /*idx*/)
 {
     return -1;
 }
 
-const int QueryMolecule::getTemplateAtomTemplateIndex(int idx)
+const int QueryMolecule::getTemplateAtomTemplateIndex(int /*idx*/)
 {
     return -1;
 }
 
-const int QueryMolecule::getTemplateAtomDisplayOption(int idx)
+const int QueryMolecule::getTemplateAtomDisplayOption(int /*idx*/)
 {
     return -1;
 }
 
-bool QueryMolecule::isSaturatedAtom(int idx)
+bool QueryMolecule::isSaturatedAtom(int /*idx*/)
 {
     throw Error("not implemented");
 }
@@ -1391,8 +1391,8 @@ void QueryMolecule::_mergeWithSubmolecule(BaseMolecule& bmol, const Array<int>& 
     updateEditRevision();
 }
 
-void QueryMolecule::_postMergeWithSubmolecule(BaseMolecule& bmol, const Array<int>& vertices, const Array<int>* edges, const Array<int>& mapping,
-                                              int skip_flags)
+void QueryMolecule::_postMergeWithSubmolecule(BaseMolecule& /*bmol*/, const Array<int>& /*vertices*/, const Array<int>* /*edges*/,
+                                              const Array<int>& /*mapping*/, int /*skip_flags*/)
 {
     // Remove stereocare flags for bonds that are not cis-trans
     for (int i = edgeBegin(); i != edgeEnd(); i = edgeNext(i))
@@ -1945,7 +1945,7 @@ bool QueryMolecule::Bond::_sureValue(int what_type, int& value_out) const
     return false;
 }
 
-bool QueryMolecule::Bond::_sureValueBelongs(int what_type, const int* arr, int count)
+bool QueryMolecule::Bond::_sureValueBelongs(int /*what_type*/, const int* /*arr*/, int /*count*/)
 {
     throw QueryMolecule::Error("not implemented");
 }
@@ -3171,9 +3171,8 @@ int QueryMolecule::addBond(int beg, int end, int order)
     return addBond(beg, end, QueryMolecule::createQueryMoleculeBond(order, BOND_ZERO, BOND_ZERO));
 }
 
-int QueryMolecule::getImplicitH(int idx, bool impl_h_no_throw)
+int QueryMolecule::getImplicitH(int idx, bool /*impl_h_no_throw*/)
 {
-    Atom& atom = getAtom(idx);
     std::vector<std::unique_ptr<Atom>> atoms;
     std::map<int, std::unique_ptr<Atom>> properties;
 
@@ -3211,3 +3210,7 @@ void QueryMolecule::setImplicitH(int idx, int impl_h)
 {
     getAtom(idx).updateConstraintWithValue(ATOM_IMPLICIT_H, impl_h);
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/src/smiles_loader.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader.cpp
@@ -92,10 +92,10 @@ static char readSgChar(Scanner& scanner)
         {
             std::string sgroup_field_sep = ",;:|{}";
             // Decode only ,;:|{}
-            if (sgroup_field_sep.find(code) != std::string::npos)
+            if (sgroup_field_sep.find(static_cast<char>(code)) != std::string::npos)
             {
-                scanner.skip(1); // skip ';'
-                return code;     // return decoded character
+                scanner.skip(1);                // skip ';'
+                return static_cast<char>(code); // return decoded character
             }
         }
         // no decoded char returned - restore position and return '&' as is.
@@ -875,7 +875,7 @@ void SmilesLoader::_readOtherStuff()
             //     The brackets are written between parentheses and separated with semicolons.
             if (sg_type == -1)
             {
-                char sg = _scanner.lookNext();
+                int sg = _scanner.lookNext();
                 constexpr size_t sg_type_max_len = 3;
                 char pchar_sg_type[sg_type_max_len];
                 std::string sg_type_str;
@@ -932,7 +932,6 @@ void SmilesLoader::_readOtherStuff()
 
             if (sg_type == SGroup::SG_TYPE_DAT)
             {
-                char c;
                 DataSGroup& dsg = static_cast<DataSGroup&>(sgroup);
                 // field_name
                 _scanner.readWord(dsg.name, word_delimiter);
@@ -955,18 +954,17 @@ void SmilesLoader::_readOtherStuff()
                     continue;
                 _scanner.skip(1); // Skip :
                 // tag
-                c = _scanner.lookNext();
-                if (c != ':' && c != ',')
+                int next = _scanner.lookNext();
+                if (next > 0 && next != ':' && next != ',')
                 {
-                    dsg.tag = c;
+                    dsg.tag = static_cast<char>(next);
                     _scanner.skip(1); // Skip tag
                 }
                 if (_scanner.lookNext() != ':') // No more fields
                     continue;
                 _scanner.skip(1); // Skip :
                 // (coords)
-                c = _scanner.lookNext();
-                if (c != '(') // No more fields
+                if (_scanner.lookNext() != '(') // No more fields
                     continue;
                 long long pos = _scanner.tell();
                 constexpr char minus1[] = "(-1)";
@@ -1042,7 +1040,7 @@ void SmilesLoader::_readOtherStuff()
                 // head_bond_indexes - Head crossing bond indexes. This field can be empty.
                 while (isdigit(_scanner.lookNext()))
                 {
-                    auto atom_idx = _scanner.readUnsigned();
+                    /*auto atom_idx =*/std::ignore = _scanner.readUnsigned();
                     // no support for now
                     if (_scanner.lookNext() == ',')
                         _scanner.skip(1);
@@ -1053,7 +1051,7 @@ void SmilesLoader::_readOtherStuff()
                 // tail_bond_indexes - Tail crossing bond indexes. This field can be empty.
                 while (isdigit(_scanner.lookNext()))
                 {
-                    auto atom_idx = _scanner.readUnsigned();
+                    /*auto atom_idx =*/std::ignore = _scanner.readUnsigned();
                     // no support for now
                     if (_scanner.lookNext() == ',')
                         _scanner.skip(1);
@@ -1065,17 +1063,17 @@ void SmilesLoader::_readOtherStuff()
                 if (_scanner.lookNext() != '(')
                     continue;
                 _scanner.skip(1); // skip (
-                char br_orient = _scanner.readChar();
+                /*char br_orient = */ std::ignore = _scanner.readChar();
                 c = _scanner.readChar();
                 if (c != ',')
                     throw Error("S-group bracket orientation format error");
-                char br_type = _scanner.readChar();
+                /*char br_type =*/std::ignore = _scanner.readChar();
                 c = _scanner.readChar();
                 int count = 0;
                 constexpr int bracket_coord_count = 8;
                 while (c == ',' && count < bracket_coord_count)
                 {
-                    float tmp = _scanner.readFloat();
+                    std::ignore = _scanner.readFloat();
                     c = _scanner.readChar();
                     ++count;
                 }
@@ -1205,7 +1203,6 @@ void SmilesLoader::_readOtherStuff()
                             if (label.size() > 0)
                             {
                                 label.push(0);
-                                int rnum;
 
                                 if (label.size() > 3 && strncmp(label.ptr(), "_R", 2) == 0 && sscanf(label.ptr() + 2, "%d", &rnum) == 1)
                                 {
@@ -1222,7 +1219,7 @@ void SmilesLoader::_readOtherStuff()
                                         {
                                             if (_scanner.isEOF())
                                                 throw Error("end of input while reading LOG block");
-                                            c = _scanner.lookNext();
+                                            c = static_cast<char>(_scanner.lookNext());
                                             if (c == ';')
                                                 break;
                                             label.push(c);
@@ -1709,7 +1706,7 @@ void SmilesLoader::_parseMolecule()
         else
         {
             _scanner.skip(1);
-            atom_str.push(next);
+            atom_str.push(static_cast<char>(next));
             if (next == 'B' && _scanner.lookNext() == 'r')
                 atom_str.push(_scanner.readChar());
             else if (next == 'C' && _scanner.lookNext() == 'l')
@@ -2703,7 +2700,7 @@ bool SmilesLoader::_readAtomLogic(Array<char>& atom_str, bool first_in_brackets,
     {
         QS_DEF(Array<char>, substring);
         std::unique_ptr<QueryMolecule::Atom> subqatom;
-        int i, k = 0;
+        k = 0;
 
         if (qatom.get() == 0 || !smarts_mode)
             throw Error("';' is allowed only for query molecules with smarts_mode");
@@ -2729,7 +2726,7 @@ bool SmilesLoader::_readAtomLogic(Array<char>& atom_str, bool first_in_brackets,
     {
         QS_DEF(Array<char>, substring);
         std::unique_ptr<QueryMolecule::Atom> subqatom;
-        int i, k = 0;
+        k = 0;
 
         if (qatom.get() == 0 || !smarts_mode)
             throw Error("',' is allowed only for query molecules with smarts_mode");
@@ -2758,7 +2755,7 @@ bool SmilesLoader::_readAtomLogic(Array<char>& atom_str, bool first_in_brackets,
     {
         QS_DEF(Array<char>, substring);
         std::unique_ptr<QueryMolecule::Atom> subqatom;
-        int i, k = 0;
+        k = 0;
 
         if (qatom.get() == 0 || !smarts_mode)
             throw Error("'&' is allowed only for query molecules with smarts_mode");
@@ -3197,9 +3194,10 @@ void SmilesLoader::_readAtom(Array<char>& atom_str, bool first_in_brackets, _Ato
                      // They can possibly not form an element: for example,
                      // [Nr] is formally a nitrogen in a ring (although nobody would
                      // write it that way: [N;r] is much more clear).
-                     (Element::fromTwoChars2(next, scanner.lookNext())) > 0 && (Element::fromTwoChars2(next, scanner.lookNext()) != ELEM_Cn))
+                     (Element::fromTwoChars2(static_cast<char>(next), scanner.lookNext())) > 0 &&
+                     (Element::fromTwoChars2(static_cast<char>(next), scanner.lookNext()) != ELEM_Cn))
             {
-                element = Element::fromTwoChars2(next, scanner.lookNext());
+                element = Element::fromTwoChars2(static_cast<char>(next), scanner.lookNext());
                 scanner.skip(1);
                 if (smarts_mode)
                     if (element == ELEM_As || element == ELEM_Se || element == ELEM_Si || element == ELEM_Te)
@@ -3213,7 +3211,7 @@ void SmilesLoader::_readAtom(Array<char>& atom_str, bool first_in_brackets, _Ato
             else
             {
                 // It is a single-char uppercase element identifier then
-                element = Element::fromChar(next);
+                element = Element::fromChar(static_cast<char>(next));
 
                 if (smarts_mode)
                     if (element == ELEM_C || element == ELEM_N || element == ELEM_O || element == ELEM_P || element == ELEM_S)

--- a/core/indigo-core/molecule/src/smiles_loader.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader.cpp
@@ -2435,7 +2435,7 @@ void SmilesLoader::readSmartsBondStr(const std::string& bond_str, std::unique_pt
 {
     _BondDesc bond;
     Array<char> ac_str;
-    ac_str.copy(bond_str.c_str(), bond_str.size());
+    ac_str.copy(bond_str.c_str(), static_cast<int>(bond_str.size()));
     _readBond(ac_str, bond, qbond, true);
 }
 
@@ -2787,7 +2787,7 @@ void SmilesLoader::readSmartsAtomStr(const std::string& atom_str, std::unique_pt
     Pool<List<int>::Elem> neipool;
     _AtomDesc atom{neipool};
     Array<char> ac_str;
-    ac_str.copy(atom_str.c_str(), atom_str.size());
+    ac_str.copy(atom_str.c_str(), static_cast<int>(atom_str.size()));
     _readAtom(ac_str, true, atom, qatom, true, false);
 }
 

--- a/core/indigo-core/molecule/src/smiles_loader.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader.cpp
@@ -3234,7 +3234,7 @@ void SmilesLoader::_readAtom(Array<char>& atom_str, bool first_in_brackets, _Ato
             }
             else
             {
-                std::string current(static_cast<const char*>(scanner.curptr()), scanner.length() - scanner.tell());
+                std::string current(static_cast<const char*>(scanner.curptr()), static_cast<size_t>(scanner.length() - scanner.tell()));
                 std::smatch match;
                 if (std::regex_search(current, match, std::regex("^(TH|AL)([1-2])")))
                 {

--- a/core/indigo-core/molecule/src/smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/smiles_saver.cpp
@@ -196,7 +196,7 @@ void SmilesSaver::_saveMolecule()
             return; // No atoms to save
         std::set<int> components;
         int cur_component = -1;
-        for (int i = 0; i < v_seq.size(); ++i && _qmol->components.size() > 0)
+        for (i = 0; i < v_seq.size(); ++i && _qmol->components.size() > 0)
         {
             // In v_seq each fragment started with vertex which parent == -1
             // In SMARTS some fragments could be grouped (component-level grouping)
@@ -245,7 +245,6 @@ void SmilesSaver::_saveMolecule()
         {
             if (walk.isClosure(e_idx))
             {
-                int k;
                 for (k = atom.neighbors.begin(); k != atom.neighbors.end(); k = atom.neighbors.next(k))
                 {
                     if (atom.neighbors[k] == -1)
@@ -415,10 +414,9 @@ void SmilesSaver::_saveMolecule()
 
     if (canonize_chiralities)
     {
-        int i, j;
         QS_DEF(Array<int>, marked);
         QS_DEF(Array<int>, ids);
-        const MoleculeStereocenters& stereocenters = _bmol->stereocenters;
+        stereocenters = _bmol->stereocenters;
 
         marked.clear_resize(_bmol->vertexEnd());
         marked.zerofill();
@@ -729,7 +727,7 @@ void SmilesSaver::_writeCycleNumber(int n) const
         throw Error("bad cycle number: %d", n);
 }
 
-void SmilesSaver::_writeAtom(int idx, bool aromatic, bool lowercase, int chirality) const
+void SmilesSaver::_writeAtom(int idx, bool /*aromatic*/, bool lowercase, int chirality) const
 {
     int i;
     bool need_brackets = false;
@@ -1701,7 +1699,7 @@ void SmilesSaver::_writeWedges()
         for (int i = 0; i < _written_bonds.size(); ++i)
         {
             auto bond_idx = _written_bonds[i];
-            auto& e = _bmol->getEdge(bond_idx);
+            // auto& e = _bmol->getEdge(bond_idx);
             auto bdir = _bmol->getBondDirection(bond_idx);
             if (bdir)
             {

--- a/core/indigo-core/molecule/src/structure_checker.cpp
+++ b/core/indigo-core/molecule/src/structure_checker.cpp
@@ -121,12 +121,12 @@ static bool hasPseudoAtoms(BaseMolecule& mol)
 
 //
 
-static void check_none(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
-                       StructureChecker::CheckResult& result)
+static void check_none(BaseMolecule& /*mol*/, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
+                       StructureChecker::CheckResult& /*result*/)
 {
 }
 
-static void check_load(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_load(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                        StructureChecker::CheckResult& result)
 {
     if (mol.vertexCount() == 0)
@@ -138,7 +138,7 @@ static void check_load(BaseMolecule& mol, const std::unordered_set<int>& selecte
 #define FILTER_ATOMS(MSG, FILTER) filter_atoms(mol, selected_atoms, result, MSG, FILTER, false);
 #define FILTER_ATOMS_DEFAULT(MSG, FILTER) filter_atoms(mol, selected_atoms, result, MSG, FILTER);
 
-static void check_valence(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_valence(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                           StructureChecker::CheckResult& result)
 {
 
@@ -164,7 +164,7 @@ static void check_valence(BaseMolecule& mol, const std::unordered_set<int>& sele
     }
 }
 
-static void check_radical(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_radical(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                           StructureChecker::CheckResult& result)
 {
     if (hasPseudoAtoms(mol))
@@ -177,12 +177,12 @@ static void check_radical(BaseMolecule& mol, const std::unordered_set<int>& sele
                              [](BaseMolecule& mol, int idx) { return mol.getAtomRadical_NoThrow(idx, -1) > 0; });
     }
 }
-static void check_pseudoatom(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_pseudoatom(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                              StructureChecker::CheckResult& result)
 {
     FILTER_ATOMS(StructureChecker::CheckMessageCode::CHECK_MSG_PSEUDOATOM, [](BaseMolecule& mol, int idx) { return mol.isPseudoAtom(idx); });
 }
-static void check_stereo(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_stereo(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                          StructureChecker::CheckResult& result)
 {
     if (!isQueryMolecule(mol))
@@ -249,7 +249,7 @@ static void check_stereo(BaseMolecule& mol, const std::unordered_set<int>& selec
         message(result, StructureChecker::CheckMessageCode::CHECK_MSG_UNDEFINED_STEREO);
     }
 }
-static void check_query(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_query(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                         StructureChecker::CheckResult& result)
 {
     if (isQueryMolecule(mol))
@@ -283,7 +283,7 @@ static float calc_mean_dist(BaseMolecule& mol)
     return mean_dist;
 }
 
-static void check_overlap_atom(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_overlap_atom(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                                StructureChecker::CheckResult& result)
 {
     auto mean_dist = calc_mean_dist(mol);
@@ -308,7 +308,7 @@ static void check_overlap_atom(BaseMolecule& mol, const std::unordered_set<int>&
         message(result, StructureChecker::CheckMessageCode::CHECK_MSG_OVERLAP_ATOM, ids);
     }
 }
-static void check_overlap_bond(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_overlap_bond(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& selected_bonds,
                                StructureChecker::CheckResult& result)
 {
     if (BaseMolecule::hasCoord(mol))
@@ -347,7 +347,7 @@ static void check_overlap_bond(BaseMolecule& mol, const std::unordered_set<int>&
     }
 }
 
-static void check_rgroup(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_rgroup(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                          StructureChecker::CheckResult& result)
 {
     if (!isQueryMolecule(mol) && hasRGroups(mol))
@@ -356,7 +356,7 @@ static void check_rgroup(BaseMolecule& mol, const std::unordered_set<int>& selec
     }
 }
 
-static void check_sgroup(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_sgroup(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                          StructureChecker::CheckResult& result)
 {
     if (mol.sgroups.getSGroupCount() > 0)
@@ -365,7 +365,7 @@ static void check_sgroup(BaseMolecule& mol, const std::unordered_set<int>& selec
     }
 }
 
-static void check_tgroup(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_tgroup(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                          StructureChecker::CheckResult& result)
 {
     if (mol.tgroups.getTGroupCount() > 0)
@@ -374,7 +374,7 @@ static void check_tgroup(BaseMolecule& mol, const std::unordered_set<int>& selec
     }
 }
 
-static void check_chirality(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_chirality(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                             StructureChecker::CheckResult& result)
 {
     if (mol.isChiral())
@@ -383,7 +383,7 @@ static void check_chirality(BaseMolecule& mol, const std::unordered_set<int>& se
     }
 }
 
-static void check_chiral_flag(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_chiral_flag(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                               StructureChecker::CheckResult& result)
 {
     if (mol.getChiralFlag() > 0 && mol.stereocenters.size() == 0)
@@ -392,13 +392,13 @@ static void check_chiral_flag(BaseMolecule& mol, const std::unordered_set<int>& 
     }
 }
 
-static void check_3d_coord(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_3d_coord(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                            StructureChecker::CheckResult& result)
 {
     FILTER_ATOMS(StructureChecker::CheckMessageCode::CHECK_MSG_3D_COORD, [](BaseMolecule& mol, int idx) { return fabs(mol.getAtomXyz(idx).z) > 0.001; });
 }
 
-static void check_charge(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_charge(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                          StructureChecker::CheckResult& result)
 {
     if (std::accumulate(selected_atoms.begin(), selected_atoms.end(), 0, [&mol](int sum, int idx) { return sum + mol.getAtomCharge(idx); }))
@@ -407,14 +407,16 @@ static void check_charge(BaseMolecule& mol, const std::unordered_set<int>& selec
     }
 }
 
+/*
 static void check_salt(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
                        StructureChecker::CheckResult& result)
 {
     // not impl
     message(result, StructureChecker::CheckMessageCode::CHECK_MSG_SALT_NOT_IMPL);
 }
+*/
 
-static void check_ambiguous_h(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_ambiguous_h(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& /*selected_bonds*/,
                               StructureChecker::CheckResult& result)
 {
     if (isQueryMolecule(mol))
@@ -429,7 +431,7 @@ static void check_ambiguous_h(BaseMolecule& mol, const std::unordered_set<int>& 
     }
 }
 
-static void check_coord(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_coord(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                         StructureChecker::CheckResult& result)
 {
     if (mol.vertexCount() > 1 && !BaseMolecule::hasCoord(mol))
@@ -438,7 +440,7 @@ static void check_coord(BaseMolecule& mol, const std::unordered_set<int>& select
     }
 }
 
-static void check_v3000(BaseMolecule& mol, const std::unordered_set<int>& selected_atoms, const std::unordered_set<int>& selected_bonds,
+static void check_v3000(BaseMolecule& mol, const std::unordered_set<int>& /*selected_atoms*/, const std::unordered_set<int>& /*selected_bonds*/,
                         StructureChecker::CheckResult& result)
 {
     if (mol.hasHighlighting() || (!mol.stereocenters.haveAllAbsAny() && !mol.stereocenters.haveAllAndAny()) || mol.vertexCount() > 999 || mol.edgeCount() > 999)

--- a/core/indigo-core/molecule/structure_checker.h
+++ b/core/indigo-core/molecule/structure_checker.h
@@ -19,6 +19,11 @@
 #ifndef __structure_checker__
 #define __structure_checker__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
 #include "base_cpp/exception.h"
 #include <string>
 #include <vector>
@@ -136,5 +141,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/reaction/reaction_auto_loader.h
+++ b/core/indigo-core/reaction/reaction_auto_loader.h
@@ -19,6 +19,11 @@
 #ifndef __reaction_auto_loader__
 #define __reaction_auto_loader__
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251 4275)
+#endif
+
 #include "base_cpp/array.h"
 #include "molecule/molecule_arom.h"
 #include "molecule/molecule_stereocenter_options.h"
@@ -69,5 +74,9 @@ namespace indigo
     };
 
 } // namespace indigo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/core/indigo-core/reaction/reaction_json_loader.h
+++ b/core/indigo-core/reaction/reaction_json_loader.h
@@ -67,8 +67,8 @@ namespace indigo
         bool treat_x_as_pseudoatom;
         bool ignore_no_chiral_flag;
 
-        const Vec2f PLUS_BBOX_SHIFT = {0.9, 0.9};
-        const Vec2f ARROW_BBOX_SHIFT = {0.0, 0.9};
+        const Vec2f PLUS_BBOX_SHIFT = {0.9f, 0.9f};
+        const Vec2f ARROW_BBOX_SHIFT = {0.0f, 0.9f};
 
     private:
         ReactionJsonLoader(const ReactionJsonLoader&); // no implicit copy

--- a/core/indigo-core/reaction/reaction_json_saver.h
+++ b/core/indigo-core/reaction/reaction_json_saver.h
@@ -31,7 +31,7 @@ namespace indigo
     class Output;
     class BaseReaction;
     class BaseMolecule;
-    class Vec2f;
+    struct Vec2f;
     class MoleculeJsonSaver;
 
     class ReactionJsonSaver

--- a/core/indigo-core/reaction/src/crf_saver.cpp
+++ b/core/indigo-core/reaction/src/crf_saver.cpp
@@ -176,6 +176,6 @@ void CrfSaver::_writeAam(const int* aam, const Array<int>& sequence)
         if (_encoder.get() != 0)
             _encoder->send(value);
         else
-            _output.writeByte(value);
+            _output.writeByte(static_cast<byte>(value));
     }
 }

--- a/core/indigo-core/reaction/src/query_reaction.cpp
+++ b/core/indigo-core/reaction/src/query_reaction.cpp
@@ -191,7 +191,7 @@ bool QueryReaction::aromatize(const AromaticityOptions& options)
     return arom_found;
 }
 
-bool QueryReaction::dearomatize(const AromaticityOptions& options)
+bool QueryReaction::dearomatize(const AromaticityOptions& /*options*/)
 {
     throw Error("Dearomatization of query reactions is not implemented");
 }

--- a/core/indigo-core/reaction/src/reaction.cpp
+++ b/core/indigo-core/reaction/src/reaction.cpp
@@ -116,7 +116,7 @@ void Reaction::checkForConsistency(Reaction& rxn)
 void Reaction::unfoldHydrogens()
 {
     QS_DEF(Array<int>, markers);
-    int i, j;
+    int i;
 
     for (i = begin(); i != end(); i = next(i))
     {

--- a/core/indigo-core/reaction/src/reaction_auto_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_auto_loader.cpp
@@ -300,7 +300,7 @@ void ReactionAutoLoader::_loadReaction(BaseReaction& reaction)
             {
                 loader.loadQueryReaction(static_cast<QueryReaction&>(reaction));
             }
-            catch (Exception& e)
+            catch (Exception&)
             {
                 loader.smarts_mode = true;
                 _scanner->seek(pos, SEEK_SET);

--- a/core/indigo-core/reaction/src/reaction_auto_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_auto_loader.cpp
@@ -109,7 +109,7 @@ void ReactionAutoLoader::_loadReaction(BaseReaction& reaction)
         base64_str.erase(std::remove_if(base64_str.begin(), base64_str.end(), [](char c) { return c == '\n' || c == '\r'; }), base64_str.end());
         if (validate_base64(base64_str))
         {
-            base64_data.copy(base64_str.data(), base64_str.size());
+            base64_data.copy(base64_str.data(), static_cast<int>(base64_str.size()));
             base64_scanner = std::make_unique<BufferScanner>(base64_data, true);
             local_scanner = base64_scanner.get();
         }

--- a/core/indigo-core/reaction/src/reaction_automapper.cpp
+++ b/core/indigo-core/reaction/src/reaction_automapper.cpp
@@ -1815,7 +1815,7 @@ bool RSubstructureMcs::bondConditionReactStrict(Graph& g1, Graph& g2, int i, int
     return true;
 }
 
-bool RSubstructureMcs::bondConditionReactSimple(Graph& g1, Graph& g2, int i, int j, void* userdata)
+bool RSubstructureMcs::bondConditionReactSimple(Graph& g1, Graph& g2, int i, int j, void* /*userdata*/)
 {
     BaseMolecule& mol1 = (BaseMolecule&)g1;
     BaseMolecule& mol2 = (BaseMolecule&)g2;
@@ -2141,7 +2141,7 @@ int RSubstructureMcs::_cbAutoVertexReact(Graph& graph, int idx1, int idx2, const
     return atomConditionReact(graph, graph, 0, idx1, idx2, (void*)context);
 }
 
-bool RSubstructureMcs::_cbAutoCheckAutomorphismReact(Graph& graph, const Array<int>& mapping, const void* context)
+bool RSubstructureMcs::_cbAutoCheckAutomorphismReact(Graph& /*graph*/, const Array<int>& mapping, const void* context)
 {
     RSubstructureMcs& rsm = *(RSubstructureMcs*)context;
     rsm._autoMaps.push().copy(mapping);

--- a/core/indigo-core/reaction/src/reaction_enumerator_state.cpp
+++ b/core/indigo-core/reaction/src/reaction_enumerator_state.cpp
@@ -503,7 +503,7 @@ void ReactionEnumeratorState::_foldHydrogens(BaseMolecule& molecule, Array<int>*
     }
 }
 
-bool ReactionEnumeratorState::_nextMatchProcess(EmbeddingEnumerator& ee, const QueryMolecule& reactant, const Molecule& monomer)
+bool ReactionEnumeratorState::_nextMatchProcess(EmbeddingEnumerator& ee, const QueryMolecule& /*reactant*/, const Molecule& /*monomer*/)
 {
     ReactionEnumeratorState rpe_state(*this);
 
@@ -688,7 +688,7 @@ void ReactionEnumeratorState::_changeQueryNode(QueryMolecule& ee_reactant, int c
     ee_reactant.clone(reactant_copy, NULL, NULL);
 }
 
-bool ReactionEnumeratorState::_matchVertexCallback(Graph& subgraph, Graph& supergraph, const int* core_sub, int sub_idx, int super_idx, void* userdata)
+bool ReactionEnumeratorState::_matchVertexCallback(Graph& subgraph, Graph& supergraph, const int* /*core_sub*/, int sub_idx, int super_idx, void* userdata)
 {
     ReactionEnumeratorState* rpe_state = (ReactionEnumeratorState*)userdata;
     Molecule& supermolecule = (Molecule&)supergraph;
@@ -720,7 +720,7 @@ bool ReactionEnumeratorState::_matchVertexCallback(Graph& subgraph, Graph& super
         }
 
         int super_free_atoms_count = 0;
-        const Vertex& super_v = supermolecule.getVertex(super_idx);
+        // const Vertex& super_v = supermolecule.getVertex(super_idx);
         int super_nei = super_v.neiVertex(super_v.neiBegin());
         const Vertex& super_nei_v = supermolecule.getVertex(super_nei);
         for (int i = super_nei_v.neiBegin(); i != super_nei_v.neiEnd(); i = super_nei_v.neiNext(i))
@@ -765,7 +765,7 @@ bool ReactionEnumeratorState::_matchEdgeCallback(Graph& subgraph, Graph& supergr
     return res;
 }
 
-void ReactionEnumeratorState::_findFragAtoms(Array<byte>& unfrag_mon_atoms, QueryMolecule& submolecule, Molecule& fragment, int* core_sub, int* core_super)
+void ReactionEnumeratorState::_findFragAtoms(Array<byte>& unfrag_mon_atoms, QueryMolecule& submolecule, Molecule& fragment, int* core_sub, int* /*core_super*/)
 {
     for (int i = submolecule.vertexBegin(); i != submolecule.vertexEnd(); i = submolecule.vertexNext(i))
     {
@@ -898,7 +898,7 @@ void ReactionEnumeratorState::_invertStereocenters(Molecule& molecule, int edge_
     }
 }
 
-void ReactionEnumeratorState::_cistransUpdate(QueryMolecule& submolecule, Molecule& supermolecule, int* frag_mapping, const Array<int>& rp_mapping,
+void ReactionEnumeratorState::_cistransUpdate(QueryMolecule& submolecule, Molecule& supermolecule, int* /*frag_mapping*/, const Array<int>& rp_mapping,
                                               int* core_sub)
 {
     QS_DEF(Array<int>, cistrans_changed_bonds);
@@ -1173,8 +1173,8 @@ void ReactionEnumeratorState::_buildMolProduct(QueryMolecule& product, Molecule&
             else
             {
                 // If there is no information about this bond in smarts
-                QueryMolecule::Atom& q_pr_beg = product.getAtom(pr_edge.beg);
-                QueryMolecule::Atom& q_pr_end = product.getAtom(pr_edge.end);
+                // QueryMolecule::Atom& q_pr_beg = product.getAtom(pr_edge.beg);
+                // QueryMolecule::Atom& q_pr_end = product.getAtom(pr_edge.end);
 
                 // int beg_value, end_value;
                 bool can_be_aromatic = product.getBond(i).possibleValue(QueryMolecule::BOND_ORDER, BOND_AROMATIC);
@@ -1500,7 +1500,7 @@ bool ReactionEnumeratorState::_attachFragments(Molecule& ready_product_out, Arra
                 int mon_atom = frags_mapping[_att_points[i][j]];
                 int pr_atom = mapping[i];
                 const Vertex& mon_v = mol_product.getVertex(mon_atom);
-                const Vertex& pr_v = mol_product.getVertex(pr_atom);
+                // const Vertex& pr_v = mol_product.getVertex(pr_atom);
 
                 for (int k = mon_v.neiBegin(); k != mon_v.neiEnd(); k = mon_v.neiNext(k))
                     if (MoleculeCisTrans::isGeomStereoBond(mol_product, mon_v.neiEdge(k), NULL, false))
@@ -1730,7 +1730,7 @@ void ReactionEnumeratorState::_checkFragmentNecessity(Array<int>& is_needless_at
     }
 }
 
-bool ReactionEnumeratorState::_addFragment(Molecule& fragment, QueryMolecule& submolecule, Array<int>& rp_mapping, const Array<int>& sub_rg_atoms,
+bool ReactionEnumeratorState::_addFragment(Molecule& fragment, QueryMolecule& submolecule, Array<int>& rp_mapping, const Array<int>& /*sub_rg_atoms*/,
                                            int* core_sub, int* core_super)
 {
     QS_DEF(Array<byte>, unfrag_mon_atoms);
@@ -1873,7 +1873,7 @@ bool ReactionEnumeratorState::_addFragment(Molecule& fragment, QueryMolecule& su
         }
         else
         {
-            int frag_rg_idx = frag_mapping[core_sub[i]];
+            frag_rg_idx = frag_mapping[core_sub[i]];
             _att_points[pr_i].push(frag_rg_idx);
         }
     }
@@ -1883,7 +1883,7 @@ bool ReactionEnumeratorState::_addFragment(Molecule& fragment, QueryMolecule& su
     return true;
 }
 
-bool ReactionEnumeratorState::_allowManyToOneCallback(Graph& subgraph, int sub_idx, void* userdata)
+bool ReactionEnumeratorState::_allowManyToOneCallback(Graph& subgraph, int sub_idx, void* /*userdata*/)
 {
     QueryMolecule& submolecule = (QueryMolecule&)subgraph;
 
@@ -1913,7 +1913,7 @@ void ReactionEnumeratorState::_removeAtomCallback(Graph& subgraph, int sub_idx, 
     }
 }
 
-void ReactionEnumeratorState::_addBondCallback(Graph& subgraph, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
+void ReactionEnumeratorState::_addBondCallback(Graph& /*subgraph*/, Graph& supergraph, int sub_idx, int super_idx, void* userdata)
 {
     ReactionEnumeratorState* rpe_state = (ReactionEnumeratorState*)userdata;
 

--- a/core/indigo-core/reaction/src/reaction_exact_matcher.cpp
+++ b/core/indigo-core/reaction/src/reaction_exact_matcher.cpp
@@ -58,7 +58,7 @@ bool ReactionExactMatcher::_match_atoms(BaseReaction& query_, Reaction& target, 
 }
 
 bool ReactionExactMatcher::_match_bonds(BaseReaction& query_, Reaction& target, int sub_mol_idx, int sub_bond_idx, int super_mol_idx, int super_bond_idx,
-                                        AromaticityMatcher* am, void* context)
+                                        AromaticityMatcher* /*am*/, void* context)
 {
     ReactionExactMatcher& self = *(ReactionExactMatcher*)context;
     Reaction& query = query_.asReaction();

--- a/core/indigo-core/reaction/src/reaction_hash.cpp
+++ b/core/indigo-core/reaction/src/reaction_hash.cpp
@@ -26,9 +26,9 @@ namespace indigo
             catalystHash += MoleculeHash::calculate(rxn.getMolecule(j));
         }
         dword hash = 0;
-        hash = (hash + (324723947 + reactantHash)) ^ 93485734985;
-        hash = (hash + (324723947 + productHash)) ^ 93485734985;
-        hash = (hash + (324723947 + catalystHash)) ^ 93485734985;
+        hash = static_cast<dword>((hash + (324723947 + reactantHash)) ^ 93485734985);
+        hash = static_cast<dword>((hash + (324723947 + productHash)) ^ 93485734985);
+        hash = static_cast<dword>((hash + (324723947 + catalystHash)) ^ 93485734985);
         return hash;
     }
 }

--- a/core/indigo-core/reaction/src/reaction_json_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_json_loader.cpp
@@ -250,7 +250,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
         Rect2f bbox(plus_pos - PLUS_BBOX_SHIFT, plus_pos + PLUS_BBOX_SHIFT);
         _reaction_components.emplace_back(ReactionComponent::PLUS, bbox, i, std::unique_ptr<BaseMolecule>(nullptr));
         _reaction_components.back().coordinates.push_back(plus_pos);
-        int index = _reaction_components.size() - 1;
+        int index = static_cast<int>(_reaction_components.size() - 1);
         mol_tops.emplace_back(bbox.top(), index);
         mol_bottoms.emplace_back(bbox.bottom(), index);
         mol_lefts.emplace_back(bbox.left(), index);
@@ -267,7 +267,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
         _reaction_components.emplace_back(arrow_type, bbox, i, std::unique_ptr<BaseMolecule>(nullptr));
         _reaction_components.back().coordinates.push_back(arr_begin);
         _reaction_components.back().coordinates.push_back(arr_end);
-        int index = _reaction_components.size() - 1;
+        int index = static_cast<int>(_reaction_components.size() - 1);
         mol_tops.emplace_back(bbox.top(), index);
         mol_bottoms.emplace_back(bbox.bottom(), index);
         mol_lefts.emplace_back(bbox.left(), index);
@@ -365,7 +365,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
     for (auto& csb : _component_summ_blocks_list)
     {
         for (int v : csb.indexes)
-            _reaction_components[v].summ_block_idx = _component_summ_blocks.size();
+            _reaction_components[v].summ_block_idx = static_cast<int>(_component_summ_blocks.size());
         _component_summ_blocks.push_back(csb);
     }
 
@@ -377,7 +377,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
             break;
         if (rc.summ_block_idx == ReactionComponent::NOT_CONNECTED)
         {
-            rc.summ_block_idx = _component_summ_blocks.size();
+            rc.summ_block_idx = static_cast<int>(_component_summ_blocks.size());
             _component_summ_blocks.push_back(_reaction_components[i].bbox);
             _component_summ_blocks.back().indexes.push_back(i);
         }
@@ -390,14 +390,14 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
         int arrow_type = arrow._arrow_type;
         const Vec2f& arr_begin = arrow._begin;
         const Vec2f& arr_end = arrow._end;
-        float min_dist_prod = -1, min_dist_reac = -1;
+        double min_dist_prod = -1, min_dist_reac = -1;
         int idx_cs_min_prod = -1, idx_cs_min_reac = -1;
         for (int index_cs = 0; index_cs < _component_summ_blocks.size(); ++index_cs)
         {
             auto& csb = _component_summ_blocks[index_cs];
             if (csb.bbox.rayIntersectsRect(arr_end, arr_begin))
             {
-                float dist = csb.bbox.pointDistance(arr_end);
+                double dist = csb.bbox.pointDistance(arr_end);
                 if (min_dist_prod < 0 || dist < min_dist_prod)
                 {
                     min_dist_prod = dist;
@@ -406,7 +406,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
             }
             else if (csb.bbox.rayIntersectsRect(arr_begin, arr_end))
             {
-                float dist = csb.bbox.pointDistance(arr_begin);
+                double dist = csb.bbox.pointDistance(arr_begin);
                 if (min_dist_reac < 0 || dist < min_dist_reac)
                 {
                     min_dist_reac = dist;

--- a/core/indigo-core/reaction/src/reaction_json_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_json_loader.cpp
@@ -379,7 +379,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
         {
             rc.summ_block_idx = static_cast<int>(_component_summ_blocks.size());
             _component_summ_blocks.push_back(_reaction_components[i].bbox);
-            _component_summ_blocks.back().indexes.push_back(i);
+            _component_summ_blocks.back().indexes.push_back(static_cast<int>(i));
         }
     }
 

--- a/core/indigo-core/reaction/src/reaction_json_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_json_loader.cpp
@@ -370,7 +370,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
     }
 
     // add all single molecules to _component_summ_blocks
-    for (int i = 0; i < _reaction_components.size(); ++i)
+    for (size_t i = 0; i < _reaction_components.size(); ++i)
     {
         auto& rc = _reaction_components[i];
         if (rc.component_type != ReactionComponent::MOLECULE)
@@ -392,7 +392,7 @@ void ReactionJsonLoader::parseMultipleArrowReaction(BaseReaction& rxn)
         const Vec2f& arr_end = arrow._end;
         double min_dist_prod = -1, min_dist_reac = -1;
         int idx_cs_min_prod = -1, idx_cs_min_reac = -1;
-        for (int index_cs = 0; index_cs < _component_summ_blocks.size(); ++index_cs)
+        for (int index_cs = 0; index_cs < static_cast<int>(_component_summ_blocks.size()); ++index_cs)
         {
             auto& csb = _component_summ_blocks[index_cs];
             if (csb.bbox.rayIntersectsRect(arr_end, arr_begin))

--- a/core/indigo-core/reaction/src/reaction_json_saver.cpp
+++ b/core/indigo-core/reaction/src/reaction_json_saver.cpp
@@ -117,7 +117,7 @@ static void _processSideBoxes(std::unique_ptr<BaseReaction>& reaction, BaseMolec
     // For REACTANT and PRODUCT insert pluses between boxes
     if (side != BaseReaction::CATALYST && boxes.size() > 1)
     {
-        std::accumulate(std::next(boxes.begin()), boxes.end(), boxes[0], [&pluses](Rect2f left, Rect2f right) {
+        std::ignore = std::accumulate(std::next(boxes.begin()), boxes.end(), boxes[0], [&pluses](Rect2f left, Rect2f right) {
             pluses.emplace_back(right.between_left_box(left), left.middleY());
             return right;
         });

--- a/core/indigo-core/reaction/src/reaction_transformation.cpp
+++ b/core/indigo-core/reaction/src/reaction_transformation.cpp
@@ -134,7 +134,7 @@ bool ReactionTransformation::transform(ReusableObjArray<Molecule>& molecules, Qu
     return true;
 }
 
-void ReactionTransformation::_product_proc(Molecule& product, Array<int>& monomers_indices, Array<int>& mapping, void* userdata)
+void ReactionTransformation::_product_proc(Molecule& product, Array<int>& /*monomers_indices*/, Array<int>& mapping, void* userdata)
 {
     ReactionTransformation* rt = (ReactionTransformation*)userdata;
 

--- a/core/indigo-core/reaction/src/rsmiles_loader.cpp
+++ b/core/indigo-core/reaction/src/rsmiles_loader.cpp
@@ -567,7 +567,7 @@ void RSmilesLoader::_loadReaction()
                 }
             }
 
-            int idx;
+            int idx = 0; // TODO: investigate right value for default idx
             if (v == 0)
                 idx = _brxn->addReactantCopy(*mol, 0, 0);
             else if (v == 1)

--- a/core/indigo-core/reaction/src/rxnfile_saver.cpp
+++ b/core/indigo-core/reaction/src/rxnfile_saver.cpp
@@ -66,8 +66,6 @@ void RxnfileSaver::saveQueryReaction(QueryReaction& reaction)
 
 void RxnfileSaver::_saveReaction()
 {
-    int i;
-
     if (molfile_saving_mode == MolfileSaver::MODE_3000)
         _v2000 = false;
     else if (molfile_saving_mode == MolfileSaver::MODE_2000)
@@ -76,7 +74,7 @@ void RxnfileSaver::_saveReaction()
     {
         _v2000 = true;
 
-        for (i = _brxn->begin(); i != _brxn->end(); i = _brxn->next(i))
+        for (int i = _brxn->begin(); i != _brxn->end(); i = _brxn->next(i))
         {
             if (_brxn->getBaseMolecule(i).hasHighlighting())
             {
@@ -101,7 +99,7 @@ void RxnfileSaver::_saveReaction()
 
     _writeReactantsHeader();
 
-    for (i = _brxn->reactantBegin(); i < _brxn->reactantEnd(); i = _brxn->reactantNext(i))
+    for (int i = _brxn->reactantBegin(); i < _brxn->reactantEnd(); i = _brxn->reactantNext(i))
     {
         _writeMolHeader();
         _writeMol(molfileSaver, i);

--- a/core/indigo-core/tests/tests/mcs.cpp
+++ b/core/indigo-core/tests/tests/mcs.cpp
@@ -150,7 +150,7 @@ TEST_F(IndigoCoreMcsTest, finish_on_timeout)
         mcs.findExactMCS();
         ASSERT_TRUE(false);
     }
-    catch (Exception& e)
+    catch (Exception& /*e*/)
     {
         //      ASSERT_STREQ("", e.message());
     }

--- a/core/render2d/CMakeLists.txt
+++ b/core/render2d/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.6)
 project(render2d LANGUAGES C CXX)
 
 if (MSVC)
-    string(APPEND CMAKE_C_FLAGS " -WX")
-    string(APPEND CMAKE_CXX_FLAGS " -WX")
+    string(APPEND CMAKE_C_FLAGS " -W4 -WX")
+    string(APPEND CMAKE_CXX_FLAGS " -W4 -WX")
 endif ()
 
 file(GLOB ${PROJECT_NAME}_SOURCES CONFIGURE_DEPENDS

--- a/core/render2d/CMakeLists.txt
+++ b/core/render2d/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.6)
 
 project(render2d LANGUAGES C CXX)
 
+if (MSVC)
+    string(APPEND CMAKE_C_FLAGS " -WX")
+    string(APPEND CMAKE_CXX_FLAGS " -WX")
+endif ()
+
 file(GLOB ${PROJECT_NAME}_SOURCES CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 

--- a/core/render2d/render_single.h
+++ b/core/render2d/render_single.h
@@ -45,8 +45,8 @@ namespace indigo
 
     private:
         float _getScaleGivenSize(int w, int h);
-        int _getDefaultWidth(const float s);
-        int _getDefaultHeight(const float s);
+        int _getDefaultWidth(float s);
+        int _getDefaultHeight(float s);
         void _drawComment();
         void _drawObj();
     };

--- a/core/render2d/src/render_cdxml.cpp
+++ b/core/render2d/src/render_cdxml.cpp
@@ -169,7 +169,6 @@ void RenderParamCdxmlInterface::_renderMols(RenderParams& params)
     else if (params.mol.get() != 0)
         mols.push(params.mol.get());
 
-    Vec2f offset(0, 0);
     Array<float> column_widths;
     column_widths.resize(params.cnvOpt.gridColumnNumber);
     column_widths.fill(0);

--- a/core/render2d/src/render_context.cpp
+++ b/core/render2d/src/render_context.cpp
@@ -211,7 +211,7 @@ cairo_status_t RenderContext::writer(void* closure, const unsigned char* data, u
     return CAIRO_STATUS_SUCCESS;
 }
 
-void RenderContext::createSurface(cairo_write_func_t writer, Output* output, int width, int height)
+void RenderContext::createSurface(cairo_write_func_t writer, Output* /*output*/, int /*width*/, int /*height*/)
 {
     int mode = opt.mode;
     if (writer == NULL && (mode == MODE_HDC || mode == MODE_PRN))
@@ -965,7 +965,7 @@ void RenderContext::drawHalfEllipse(const Vec2f& v1, const Vec2f& v2, const floa
     cairo_set_matrix(_cr, &save_matrix);
 }
 
-void RenderContext::drawTriangleArrowHeader(const Vec2f& v, const Vec2f& dir, const float width, const float headwidth, const float headsize)
+void RenderContext::drawTriangleArrowHeader(const Vec2f& v, const Vec2f& dir, const float /*width*/, const float headwidth, const float headsize)
 {
     Vec2f n(dir), p(v), d(dir);
     n.rotate(1, 0);
@@ -1059,7 +1059,7 @@ void RenderContext::drawArrowHeader(const Vec2f& v, const Vec2f& dir, const floa
 void RenderContext::drawEllipticalArrow(const Vec2f& p1, const Vec2f& p2, const float width, const float headwidth, const float headsize, const float height,
                                         int arrow_type)
 {
-    float h_sign = height > 0 ? 1 : -1;
+    float h_sign = height > 0 ? 1.f : -1.f;
     Vec2f d, n_orig, pa(p1), pb(p2);
     d.diff(p2, p1);
     d.normalize();
@@ -1071,7 +1071,7 @@ void RenderContext::drawEllipticalArrow(const Vec2f& p1, const Vec2f& p2, const 
     Vec2f n(d);
     n.rotate(-h_sign, 0);
 
-    float len = d.length();
+    // float len = d.length();
 
     n_orig.negate();
     switch (arrow_type)
@@ -1165,7 +1165,7 @@ void RenderContext::drawDashedArrow(const Vec2f& p1, const Vec2f& p2, const floa
     n.rotate(1, 0);
     double brick_size = 0.3;
     double filled_part = brick_size * 0.7;
-    int whole_bricks = floor(len / brick_size);
+    int whole_bricks = static_cast<int>(floor(len / brick_size));
     double brick_part = len - whole_bricks * brick_size;
     if (brick_part > filled_part)
         brick_part = filled_part;
@@ -1182,19 +1182,19 @@ void RenderContext::drawDashedArrow(const Vec2f& p1, const Vec2f& p2, const floa
         moveTo(p);
         p.addScaled(n, width / 2);
         lineTo(p);
-        p.addScaled(d, is_last ? brick_part : filled_part);
+        p.addScaled(d, static_cast<float>(is_last ? brick_part : filled_part));
         lineTo(p);
         n.negate();
         p.addScaled(n, width);
         lineTo(p);
         d.negate();
-        p.addScaled(d, is_last ? brick_part : filled_part);
+        p.addScaled(d, static_cast<float>(is_last ? brick_part : filled_part));
         lineTo(p);
         n.negate();
         d.negate();
         p.addScaled(n, width / 2);
         lineTo(p);
-        p.addScaled(d, brick_size);
+        p.addScaled(d, static_cast<float>(brick_size));
     }
     drawArrowHeader(p2, d, width, headwidth, headsize, false);
     checkPathNonEmpty();
@@ -1231,8 +1231,8 @@ void RenderContext::drawBar(const Vec2f& p1, const Vec2f& p2, const float width,
 void RenderContext::drawEquillibriumHalf(const Vec2f& p1, const Vec2f& p2, const float width, float headwidth, const float headsize, const ArrowType arrow_type,
                                          const bool is_large, const bool is_unbalanced)
 {
-    float margin = arrow_type == ArrowType::ETriangleArrow ? headsize : width * 1.5;
-    float width_scale = is_large ? 1.5 : 1;
+    float margin = arrow_type == ArrowType::ETriangleArrow ? headsize : static_cast<float>(width * 1.5);
+    float width_scale = is_large ? 1.5f : 1.f;
     Vec2f d, n, pa(p1);
     d.diff(p2, p1);
     float len = d.length();
@@ -1344,7 +1344,7 @@ void RenderContext::drawCustomArrow(const Vec2f& p1, const Vec2f& p2, const floa
             p.set(p1.x, p1.y);
             p.addScaled(d, len / 2); // set to middle
             Vec2f d45(d);
-            d45.rotate((arr_ind ? 1 : -1) * sqrt(2) / 2, sqrt(2) / 2); // rotate 45 degrees clockwise
+            d45.rotate(static_cast<float>((arr_ind ? 1 : -1) * sqrt(2) / 2.), static_cast<float>(sqrt(2) / 2.)); // rotate 45 degrees clockwise
             auto len_cross = len / 10;
             p.addScaled(d45, len_cross / 2);
             Vec2f n90(d45);

--- a/core/render2d/src/render_fonts.cpp
+++ b/core/render2d/src/render_fonts.cpp
@@ -128,7 +128,7 @@ void RenderContext::fontsSetFont(const TextItem& ti)
 }
 #endif
 
-void RenderContext::fontsGetTextExtents(cairo_t* cr, const char* text, int size, float& dx, float& dy, float& rx, float& ry)
+void RenderContext::fontsGetTextExtents(cairo_t* cr, const char* text, int /*size*/, float& dx, float& dy, float& rx, float& ry)
 {
     std::lock_guard<std::mutex> _lock(_cairo_mutex);
     cairo_text_extents_t te;

--- a/core/render2d/src/render_internal.cpp
+++ b/core/render2d/src/render_internal.cpp
@@ -2297,7 +2297,7 @@ void MoleculeRenderInternal::_initBondData()
 
         d.stereodir = _mol->getBondDirection(i);
         d.cistrans = _mol->cis_trans.isIgnored(i);
-        int ubid = _bondMappingInv.size() > i ? _bondMappingInv.at(i) : i;
+        int ubid = static_cast<long>(_bondMappingInv.size()) > i ? _bondMappingInv.at(i) : i;
         if (_data.reactingCenters.size() > ubid)
             d.reactingCenter = _data.reactingCenters[ubid];
     }

--- a/core/render2d/src/render_internal.cpp
+++ b/core/render2d/src/render_internal.cpp
@@ -222,11 +222,11 @@ void MoleculeRenderInternal::setMolecule(BaseMolecule* mol)
     auto isThereAtLeastOneContracted = false;
     if (superatoms || mulsgroups)
     {
-        auto count = _mol->sgroups.getSGroupCount(SGroup::SG_TYPE_SUP);
-        BaseMolecule& mol = *_mol;
-        for (int i = mol.sgroups.begin(); i != mol.sgroups.end(); i = mol.sgroups.next(i))
+        // auto count = _mol->sgroups.getSGroupCount(SGroup::SG_TYPE_SUP);
+        BaseMolecule& bmol = *_mol;
+        for (int i = bmol.sgroups.begin(); i != bmol.sgroups.end(); i = bmol.sgroups.next(i))
         {
-            SGroup& sgroup = mol.sgroups.getSGroup(i);
+            SGroup& sgroup = bmol.sgroups.getSGroup(i);
             if (sgroup.contracted == DisplayOption::Contracted || sgroup.contracted == DisplayOption::Undefined)
             {
                 isThereAtLeastOneContracted = true;
@@ -254,9 +254,9 @@ void MoleculeRenderInternal::setMolecule(BaseMolecule* mol)
     }
 }
 
-void MoleculeRenderInternal::setIsRFragment(bool isRFragment)
+void MoleculeRenderInternal::setIsRFragment(bool new_isRFragment)
 {
-    this->isRFragment = isRFragment;
+    this->isRFragment = new_isRFragment;
 }
 
 void MoleculeRenderInternal::setScaleFactor(const float scaleFactor, const Vec2f& min, const Vec2f& max)
@@ -836,7 +836,7 @@ void MoleculeRenderInternal::_positionIndex(Sgroup& sg, int ti, bool lower)
     index.bbp.addScaled(bracket.d, lower ? -yShift : yShift);
 }
 
-void MoleculeRenderInternal::_placeBrackets(Sgroup& sg, const Array<int>& atoms, Array<Vec2f[2]>& brackets)
+void MoleculeRenderInternal::_placeBrackets(Sgroup& /*sg*/, const Array<int>& atoms, Array<Vec2f[2]>& brackets)
 {
     auto left = brackets.push();
     auto right = brackets.push();
@@ -898,9 +898,9 @@ void MoleculeRenderInternal::_prepareSGroups(bool collapseAtLeastOneSuperatom)
                 {
                     const Superatom& group = (Superatom&)sgroup;
                     Vec3f centre;
-                    for (int i = 0; i < group.atoms.size(); ++i)
+                    for (int j = 0; j < group.atoms.size(); ++j)
                     {
-                        int atomID = group.atoms[i];
+                        int atomID = group.atoms[j];
                         centre.add(mol.getAtomXyz(atomID));
                     }
                     centre.scale(1.0f / group.atoms.size());
@@ -985,7 +985,7 @@ void MoleculeRenderInternal::_prepareSGroups(bool collapseAtLeastOneSuperatom)
     }
 }
 
-int dblcmp(double a, double b, void* context)
+int dblcmp(double a, double b, void* /*context*/)
 {
     return a > b ? 1 : (a < b ? -1 : 0);
 }
@@ -1005,7 +1005,7 @@ struct Event
     bool begin;
 };
 
-int evcmp(const Event& a, const Event& b, void* context)
+int evcmp(const Event& a, const Event& b, void* /*context*/)
 {
     if (a.p.x > b.p.x)
         return 1;
@@ -1266,8 +1266,8 @@ void MoleculeRenderInternal::_findRings()
         }
         if (i != j || ring.bondEnds.size() < 3)
         {
-            for (int j = 0; j < ring.bondEnds.size(); ++j)
-                _be(ring.bondEnds[j]).lRing = -2;
+            for (int k = 0; k < ring.bondEnds.size(); ++k)
+                _be(ring.bondEnds[k]).lRing = -2;
             _data.rings.pop();
             continue;
         }
@@ -1275,8 +1275,8 @@ void MoleculeRenderInternal::_findRings()
         bool selfIntersection = _ringHasSelfIntersections(ring);
         if (selfIntersection)
         {
-            for (int j = 0; j < ring.bondEnds.size(); ++j)
-                _be(ring.bondEnds[j]).lRing = -2;
+            for (int k = 0; k < ring.bondEnds.size(); ++k)
+                _be(ring.bondEnds[k]).lRing = -2;
             _data.rings.pop();
             continue;
         }
@@ -1284,10 +1284,10 @@ void MoleculeRenderInternal::_findRings()
         // for the inner loops, sum of the angles should be (n-2)*pi,
         // for the outer ones (n+2)*pi
         float angleSum = 0;
-        for (int j = 0; j < ring.bondEnds.size(); ++j)
+        for (int k = 0; k < ring.bondEnds.size(); ++k)
         {
-            int j1 = (j + 1) % ring.bondEnds.size();
-            const Vec2f& da = _be(ring.bondEnds[j]).dir;
+            int j1 = (k + 1) % ring.bondEnds.size();
+            const Vec2f& da = _be(ring.bondEnds[k]).dir;
             const Vec2f& db = _be(ring.bondEnds[j1]).dir;
             float angle = (float)M_PI - atan2(-Vec2f::cross(da, db), Vec2f::dot(da, db));
             angleSum += angle;
@@ -1298,27 +1298,27 @@ void MoleculeRenderInternal::_findRings()
 
         if (!inner)
         {
-            for (int j = 0; j < ring.bondEnds.size(); ++j)
-                _be(ring.bondEnds[j]).lRing = -2;
+            for (int k = 0; k < ring.bondEnds.size(); ++k)
+                _be(ring.bondEnds[k]).lRing = -2;
             _data.rings.pop();
             continue;
         }
 
-        for (int j = 0; j < ring.bondEnds.size(); ++j)
-            _be(ring.bondEnds[j]).lRing = rid;
+        for (int k = 0; k < ring.bondEnds.size(); ++k)
+            _be(ring.bondEnds[k]).lRing = rid;
 
         if (_opt.showCycles)
         {
             float cycleLineOffset = _settings.unit * 9;
             QS_DEF(Array<Vec2f>, vv);
             vv.clear();
-            for (int j = 0; j < ring.bondEnds.size() + 1; ++j)
+            for (int k = 0; k < ring.bondEnds.size() + 1; ++k)
             {
-                const BondEnd& be = _be(ring.bondEnds[j % ring.bondEnds.size()]);
-                Vec2f v = be.dir;
-                v.rotateL(be.lang / 2);
+                const BondEnd& be1 = _be(ring.bondEnds[k % ring.bondEnds.size()]);
+                Vec2f v = be1.dir;
+                v.rotateL(be1.lang / 2);
                 v.scale(cycleLineOffset);
-                v.add(_ad(be.aid).pos);
+                v.add(_ad(be1.aid).pos);
                 vv.push(v);
             }
             _cw.setSingleSource(CWC_BLUE);
@@ -1363,9 +1363,9 @@ void MoleculeRenderInternal::_findRings()
 
         ring.aromatic = true;
         int dblBondCount = 0;
-        for (int i = 0; i < ring.bondEnds.size(); ++i)
+        for (int j = 0; j < ring.bondEnds.size(); ++j)
         {
-            int type = _bd(_be(ring.bondEnds[i]).bid).type;
+            int type = _bd(_be(ring.bondEnds[j]).bid).type;
             if (type != BOND_AROMATIC)
                 ring.aromatic = false;
             if (type == BOND_DOUBLE)
@@ -1946,9 +1946,9 @@ void MoleculeRenderInternal::_renderAtomIds()
         for (int i = _mol->vertexBegin(); i < _mol->vertexEnd(); i = _mol->vertexNext(i))
         {
             const AtomDesc& desc = _ad(i);
-            for (int i = 0; i < desc.ticount; ++i)
+            for (int j = 0; j < desc.ticount; ++j)
             {
-                const TextItem& ti = _data.textitems[i + desc.tibegin];
+                const TextItem& ti = _data.textitems[j + desc.tibegin];
                 if (ti.ritype == RenderItem::RIT_ATOMID)
                 {
                     _cw.drawItemBackground(ti);
@@ -2054,9 +2054,9 @@ void MoleculeRenderInternal::_renderSGroups()
         for (int i = _mol->vertexBegin(); i < _mol->vertexEnd(); i = _mol->vertexNext(i))
         {
             const AtomDesc& desc = _ad(i);
-            for (int i = 0; i < desc.ticount; ++i)
+            for (int j = 0; j < desc.ticount; ++j)
             {
-                const TextItem& ti = _data.textitems[i + desc.tibegin];
+                const TextItem& ti = _data.textitems[j + desc.tibegin];
                 _cw.drawItemBackground(ti);
             }
         }
@@ -2848,7 +2848,7 @@ void MoleculeRenderInternal::_preparePseudoAtom(int aid, int color, bool highlig
     int i0 = 0, i1;
     SCRIPT script = MAIN, newscript = MAIN;
     int len = (int)strlen(str);
-    GraphItem::TYPE signType;
+    GraphItem::TYPE signType = GraphItem::DOT;
     // TODO: replace remembering item ids and shifting each of them with single offset value for an atom
     Array<int> tis, gis;
 
@@ -3057,7 +3057,7 @@ void MoleculeRenderInternal::_prepareLabelText(int aid)
     int color = ad.color;
     bool highlighted = _vertexIsHighlighted(aid);
 
-    int tilabel = -1, tihydro = -1, tiHydroIndex = -1, tiChargeValue = -1, tiValence = -1, tiIsotope = -1, tiindex = -1;
+    int tilabel = -1, tihydro = -1, tiHydroIndex = -1, tiValence = -1, tiIsotope = -1, tiindex = -1;
     int giChargeSign = -1, giRadical = -1, giRadical1 = -1, giRadical2 = -1;
     ad.rightMargin = ad.leftMargin = ad.ypos = ad.height = 0;
     int isotope = bm.getAtomIsotope(aid);
@@ -3818,7 +3818,7 @@ void MoleculeRenderInternal::_drawReactingCenter(BondDescr& bd, int rc)
     }
 }
 
-double MoleculeRenderInternal::_getAdjustmentFactor(const int aid, const int anei, const double acos, const double asin, const double tgb, const double csb,
+double MoleculeRenderInternal::_getAdjustmentFactor(const int aid, const int anei, const double acos, const double asin, const double /*tgb*/, const double csb,
                                                     const double snb, const double len, const double w, double& csg, double& sng)
 {
     csg = csb;
@@ -3890,7 +3890,7 @@ void MoleculeRenderInternal::_bondBoldStereo(BondDescr& bd, const BondEnd& be1, 
 void MoleculeRenderInternal::_bondHydrogen(BondDescr& bd, const BondEnd& be1, const BondEnd& be2)
 {
     _cw.setDash(_settings.bondDashHydro, Vec2f::dist(be1.p, be2.p));
-    double len = Vec2f::dist(be2.p, be1.p);
+    // double len = Vec2f::dist(be2.p, be1.p);
     Vec2f l(be2.p), r(be2.p);
     float w = _settings.bondSpace;
     l.addScaled(bd.norm, -w);
@@ -3924,10 +3924,10 @@ void MoleculeRenderInternal::_bondCoordination(BondDescr& bd, const BondEnd& be1
 
     double arrow_length = lw * 5;
     double shorten = len - arrow_length;
-    Vec2f reduced = (be2.p - be1.p) * (1 - shorten / len);
-    Vec2f slope_right(-reduced.y * 0.25, reduced.x * 0.25);
+    Vec2f reduced = (be2.p - be1.p) * static_cast<float>((1 - shorten / len));
+    Vec2f slope_right(-reduced.y * 0.25f, reduced.x * 0.25f);
     _cw.drawLine(be2.p, (be2.p - reduced) + slope_right);
-    Vec2f slope_left(reduced.y * 0.25, -reduced.x * 0.25);
+    Vec2f slope_left(reduced.y * 0.25f, -reduced.x * 0.25f);
     _cw.drawLine(be2.p, (be2.p - reduced) + slope_left);
 }
 
@@ -4083,7 +4083,7 @@ void MoleculeRenderInternal::_prepareDoubleBondCoords(Vec2f* coord, BondDescr& b
     }
 }
 
-void MoleculeRenderInternal::_drawStereoCareBox(BondDescr& bd, const BondEnd& be1, const BondEnd& be2)
+void MoleculeRenderInternal::_drawStereoCareBox(BondDescr& bd, const BondEnd& be1, const BondEnd& /*be2*/)
 {
     Vec2f ns;
     ns.scaled(bd.norm, _settings.bondSpace);

--- a/core/render2d/src/render_item_aux.cpp
+++ b/core/render2d/src/render_item_aux.cpp
@@ -25,6 +25,11 @@
 #include "render_internal.h"
 #include <codecvt>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 using namespace indigo;
 
 IMPL_ERROR(RenderItemAuxiliary, "RenderItemAuxiliary");
@@ -316,11 +321,11 @@ void RenderItemAuxiliary::_drawMeta(bool idle)
                     {
                         if (first_index == -1)
                         {
-                            first_index = kvp.first;
+                            first_index = static_cast<int>(kvp.first);
                             current_styles = kvp.second;
                             continue;
                         }
-                        second_index = kvp.first;
+                        second_index = static_cast<int>(kvp.first);
 
                         std::wstring_convert<std::codecvt_utf8<wchar_t>> utf82w;
                         std::wstring_convert<std::codecvt_utf8<wchar_t>> w2utf8;
@@ -329,8 +334,8 @@ void RenderItemAuxiliary::_drawMeta(bool idle)
                         ti.text.readString(sub_text.c_str(), true);
                         fillKETStyle(ti, current_styles);
                         _rc.setTextItemSize(ti);
-                        ti.bbp.x = text_origin.x - ti.relpos.x + text_offset_x;
-                        ti.bbp.y = text_origin.y - ti.relpos.y + text_max_height / 2 + text_offset_y;
+                        ti.bbp.x = static_cast<float>(text_origin.x - ti.relpos.x + text_offset_x);
+                        ti.bbp.y = static_cast<float>(text_origin.y - ti.relpos.y + text_max_height / 2 + text_offset_y);
                         _rc.drawTextItemText(ti, Vec3f(0, 0, 0), idle);
 
                         text_offset_x += ti.bbsz.x + _settings.boundExtent;
@@ -458,11 +463,11 @@ float RenderItemAuxiliary::_getMaxHeight(const KETTextObject::KETTextLine& tl)
     {
         if (first_index == -1)
         {
-            first_index = kvp.first;
+            first_index = static_cast<int>(kvp.first);
             current_styles = kvp.second;
             continue;
         }
-        second_index = kvp.first;
+        second_index = static_cast<int>(kvp.first);
 
         std::wstring_convert<std::codecvt_utf8<wchar_t>> utf82w;
         std::wstring_convert<std::codecvt_utf8<wchar_t>> w2utf8;
@@ -477,3 +482,7 @@ float RenderItemAuxiliary::_getMaxHeight(const KETTextObject::KETTextLine& tl)
     }
     return sz;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/render2d/src/render_item_column.cpp
+++ b/core/render2d/src/render_item_column.cpp
@@ -42,9 +42,9 @@ void RenderItemColumn::setVerticalSpacing(float spacing)
     vSpace = spacing;
 }
 
-void RenderItemColumn::setAlignment(MultilineTextLayout::Alignment alignment)
+void RenderItemColumn::setAlignment(MultilineTextLayout::Alignment new_alignment)
 {
-    this->alignment = alignment;
+    this->alignment = new_alignment;
 }
 
 void RenderItemColumn::estimateSize()

--- a/utils/indigo-depict/main.c
+++ b/utils/indigo-depict/main.c
@@ -852,7 +852,7 @@ int main(int argc, char* argv[])
     indigoSetOption("ignore-stereochemistry-errors", "on");
     indigoSetOption("ignore-bad-valence", "on");
     indigoSetOption("molfile-saving-mode", "3000");
-    indigoSetOptionBool("json-saving-pretty", "on");
+    indigoSetOptionBool("json-saving-pretty", 1);
 
     if (parseParams(&p, argc, argv) < 0)
         return -1;
@@ -923,7 +923,7 @@ int main(int argc, char* argv[])
                 indigoSaveJsonToFile(obj, p.outfile);
             else if (p.out_ext == OEXT_SMI)
             {
-                char* pMol;
+                const char* pMol;
                 if (p.query_set)
                     pMol = indigoSmarts(obj);
                 else
@@ -950,7 +950,7 @@ int main(int argc, char* argv[])
             }
             else if (p.out_ext == OEXT_CDX64)
             {
-                char* pMol = indigoCdxBase64(obj);
+                const char* pMol = indigoCdxBase64(obj);
                 FILE* fp = fopen(p.outfile, "w+");
                 if (fp)
                 {
@@ -976,7 +976,7 @@ int main(int argc, char* argv[])
                     indigoFree(frag_id);
                 }
                 indigoFree(comp_it);
-                char* pSdf = indigoToString(buffer);
+                const char* pSdf = indigoToString(buffer);
                 FILE* fp = fopen(p.outfile, "w+");
                 if (fp)
                 {
@@ -1028,7 +1028,7 @@ int main(int argc, char* argv[])
             }
             else if (p.out_ext == OEXT_SMI)
             {
-                char* pReaction;
+                const char* pReaction;
                 if (p.query_set)
                     pReaction = indigoSmarts(obj);
                 else


### PR DESCRIPTION
For MSVC add #pragma warning to disable DLLEXPORT related warnings which generated a lot of warnings.
For MSVC add "-WX" option (treat compiler warnings as errors) in projects "indigo-core" and "render2d"
Cleanup "render2d" project to "W4" level and set warning level to W4 for MSVC
Cleanup "indigo-core" project to "W3" level and set warning level to W3 for MSVC

build_indigo_libs_x86_64 (windows) log size reduced from 6400 lines to 2100 lines.