### PR TITLE
Backmerge: #1608 convert_explicit_hydrogens response doesn't comply with the ket schema (#1613)

### DIFF
--- a/api/tests/integration/tests/basic/ref/issue_1589.ket
+++ b/api/tests/integration/tests/basic/ref/issue_1589.ket
@@ -154,18 +154,6 @@
                     8
                 ]
             }
-        ],
-        "highlight": [
-            "entityType",
-            "atom",
-            {
-                "items": []
-            },
-            "entityType",
-            "bond",
-            {
-                "items": []
-            }
         ]
     }
 }

--- a/core/indigo-core/molecule/src/molecule_json_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_saver.cpp
@@ -583,8 +583,8 @@ void MoleculeJsonSaver::saveStereoCenter(BaseMolecule& mol, int atom_idx, JsonWr
 
 void MoleculeJsonSaver::saveHighlights(BaseMolecule& mol, JsonWriter& writer)
 {
-    int ca = mol.countSelectedAtoms();
-    int cb = mol.countSelectedBonds();
+    int ca = mol.countHighlightedAtoms();
+    int cb = mol.countHighlightedBonds();
     if (ca || cb)
     {
         writer.Key("highlight");


### PR DESCRIPTION

## Check list for backmerge request
- [x] branch name does not contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] reviewers are notified about the pull request
