### PR TITLE
Backmerge: #1652 Unfold hydrogens does not select added bonds (#1653)

### DIFF
--- a/api/tests/integration/tests/basic/ref/issue_1589.ket
+++ b/api/tests/integration/tests/basic/ref/issue_1589.ket
@@ -135,6 +135,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     3,
                     6
@@ -142,6 +143,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     4,
                     7
@@ -149,6 +151,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     5,
                     8

--- a/api/tests/integration/tests/basic/ref/issue_1632.ket
+++ b/api/tests/integration/tests/basic/ref/issue_1632.ket
@@ -79,6 +79,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     1,
                     3
@@ -86,6 +87,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     1,
                     4
@@ -93,6 +95,7 @@
             },
             {
                 "type": 1,
+                "selected": true,
                 "atoms": [
                     1,
                     5

--- a/core/indigo-core/molecule/src/base_molecule.cpp
+++ b/core/indigo-core/molecule/src/base_molecule.cpp
@@ -4557,10 +4557,14 @@ void BaseMolecule::unfoldHydrogens(Array<int>* markers_out, int max_h_cnt, bool 
             for (int j = 0; j < h_cnt; j++)
             {
                 int new_h_idx = addAtom(ELEM_H);
-                if (only_selected) // if only selected atoms - select new H too
-                    selectAtom(new_h_idx);
+                int new_bond_idx = addBond(i, new_h_idx, BOND_SINGLE);
 
-                addBond(i, new_h_idx, BOND_SINGLE);
+                if (only_selected) // if only selected atoms - select new H too
+                {
+                    selectAtom(new_h_idx);
+                    selectBond(new_bond_idx);
+                }
+
                 if (markers_out != 0)
                 {
                     markers_out->expandFill(new_h_idx + 1, 0);


### PR DESCRIPTION
## Backmerge request
- [x] PR name follows the pattern `Backmerge: #1234 – issue name`
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] code contains only backmerge changes
