### PR TITLE
 #1730 UT cano/permutations is too slow

### DIFF
--- a/api/c/indigo/indigo.h
+++ b/api/c/indigo/indigo.h
@@ -468,6 +468,7 @@ CEXPORT float* indigoXYZ(int atom);
 
 CEXPORT int indigoSetXYZ(int atom, float x, float y, float z);
 
+CEXPORT int indigoClearXYZ(int molecule);
 CEXPORT int indigoCountSuperatoms(int molecule);
 CEXPORT int indigoCountDataSGroups(int molecule);
 CEXPORT int indigoCountRepeatingUnits(int molecule);

--- a/api/c/indigo/src/indigo_molecule.cpp
+++ b/api/c/indigo/src/indigo_molecule.cpp
@@ -2145,6 +2145,16 @@ CEXPORT float indigoAlignAtoms(int molecule, int natoms, int* atom_ids, float* d
     INDIGO_END(-1);
 }
 
+CEXPORT int indigoClearXYZ(int molecule)
+{
+    INDIGO_BEGIN
+    {
+        self.getObject(molecule).getBaseMolecule().clearXyz();
+        return molecule;
+    }
+    INDIGO_END(-1);
+}
+
 CEXPORT int indigoCountSuperatoms(int molecule)
 {
     INDIGO_BEGIN

--- a/api/dotnet/src/IndigoLib.cs
+++ b/api/dotnet/src/IndigoLib.cs
@@ -910,6 +910,9 @@ namespace com.epam.indigo
         public static extern int indigoFoldUnfoldHydrogens(int item);
 
         [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
+        public static extern int indigoClearXYZ(int item);
+
+        [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
         public static extern int indigoLayout(int item);
 
         [DllImport("indigo"), SuppressUnmanagedCodeSecurity]

--- a/api/dotnet/src/IndigoObject.cs
+++ b/api/dotnet/src/IndigoObject.cs
@@ -1628,6 +1628,12 @@ namespace com.epam.indigo
             dispatcher.checkResult(IndigoLib.indigoFoldUnfoldHydrogens(self));
         }
 
+        public void clearXYZ()
+        {
+            dispatcher.setSessionID();
+            dispatcher.checkResult(IndigoLib.indigoClearXYZ(self));
+        }
+
         public void layout()
         {
             dispatcher.setSessionID();

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
@@ -668,6 +668,8 @@ public interface IndigoLib extends Library {
 
     int indigoFoldUnfoldHydrogens(int item);
 
+    int indigoClearXYZ(int item);
+
     int indigoLayout(int object);
 
     int indigoClean2d(int object);

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -1462,6 +1462,11 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
         Indigo.checkResult(this, lib.indigoFoldUnfoldHydrogens(self));
     }
 
+    public void сlearXYZ() {
+        dispatcher.setSessionID();
+        Indigo.checkResult(this, lib.indigoClearXYZ(self));
+    }
+
     public void layout() {
         dispatcher.setSessionID();
         Indigo.checkResult(this, lib.indigoLayout(self));

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -1462,7 +1462,7 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
         Indigo.checkResult(this, lib.indigoFoldUnfoldHydrogens(self));
     }
 
-    public void сlearXYZ() {
+    public void clearXYZ() {
         dispatcher.setSessionID();
         Indigo.checkResult(this, lib.indigoClearXYZ(self));
     }

--- a/api/python/indigo/indigo/indigo_lib.py
+++ b/api/python/indigo/indigo/indigo_lib.py
@@ -857,6 +857,8 @@ class IndigoLib:
         IndigoLib.lib.indigoUnfoldHydrogens.argtypes = [c_int]
         IndigoLib.lib.indigoFoldUnfoldHydrogens.restype = c_int
         IndigoLib.lib.indigoFoldUnfoldHydrogens.argtypes = [c_int]
+        IndigoLib.lib.indigoClearXYZ.restype = c_int
+        IndigoLib.lib.indigoClearXYZ.argtypes = [c_int]
         IndigoLib.lib.indigoLayout.restype = c_int
         IndigoLib.lib.indigoLayout.argtypes = [c_int]
         IndigoLib.lib.indigoClean2d.restype = c_int
@@ -1011,8 +1013,6 @@ class IndigoLib:
         IndigoLib.lib.indigoNameToStructure.argtypes = [c_char_p, c_char_p]
         IndigoLib.lib.indigoResetOptions.restype = c_int
         IndigoLib.lib.indigoResetOptions.argtypes = []
-        IndigoLib.lib.indigoClearXYZ.restype = c_int
-        IndigoLib.lib.indigoClearXYZ.argtypes = [c_int]
 
     @staticmethod
     def checkResult(

--- a/api/python/indigo/indigo/indigo_lib.py
+++ b/api/python/indigo/indigo/indigo_lib.py
@@ -1011,6 +1011,8 @@ class IndigoLib:
         IndigoLib.lib.indigoNameToStructure.argtypes = [c_char_p, c_char_p]
         IndigoLib.lib.indigoResetOptions.restype = c_int
         IndigoLib.lib.indigoResetOptions.argtypes = []
+        IndigoLib.lib.indigoClearXYZ.restype = c_int
+        IndigoLib.lib.indigoClearXYZ.argtypes = [c_int]
 
     @staticmethod
     def checkResult(

--- a/api/python/indigo/indigo/indigo_object.py
+++ b/api/python/indigo/indigo/indigo_object.py
@@ -4122,3 +4122,15 @@ class IndigoObject:
         return IndigoLib.checkResultString(
             self._lib().indigoDbgInternalType(self.id)
         )
+
+    def clearXyz(self):
+        """Molecule method clear coordinates of atoms
+
+        Raises:
+            IndigoException: on error
+
+        Returns:
+            list: molecule ID
+        """
+        self._lib().indigoClearXYZ(self.id)
+        return

--- a/api/python/indigo/indigo/indigo_object.py
+++ b/api/python/indigo/indigo/indigo_object.py
@@ -4123,7 +4123,7 @@ class IndigoObject:
             self._lib().indigoDbgInternalType(self.id)
         )
 
-    def clearXyz(self):
+    def clearXYZ(self):
         """Molecule method clear coordinates of atoms
 
         Raises:

--- a/api/tests/integration/tests/cano/permutations.py
+++ b/api/tests/integration/tests/cano/permutations.py
@@ -75,7 +75,7 @@ def random_permutation(iterable, r=None):
 
 
 def testMol(mol):
-    mol.clearXyz()
+    mol.clearXYZ()
     mol_for_test = mol.clone()
     base_smiles = mol_for_test.canonicalSmiles()
     print(base_smiles)

--- a/api/tests/integration/tests/cano/permutations.py
+++ b/api/tests/integration/tests/cano/permutations.py
@@ -75,6 +75,7 @@ def random_permutation(iterable, r=None):
 
 
 def testMol(mol):
+    mol.clearXyz()
     mol_for_test = mol.clone()
     base_smiles = mol_for_test.canonicalSmiles()
     print(base_smiles)


### PR DESCRIPTION
Call clearXyz for molecule before unfold it.

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
