### PR TITLE
#1826 - Pagination and sorting for ElasticStream

### DIFF
--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/FieldComparator.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/FieldComparator.java
@@ -1,0 +1,27 @@
+package com.epam.indigo.sort;
+
+import com.epam.indigo.model.IndigoRecord;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+public class FieldComparator<T extends IndigoRecord> extends IndigoComparator<T> {
+
+    protected String fieldName;
+
+    public FieldComparator(final String fieldName, final SortOrder sortOrder) {
+        super(sortOrder);
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public int compare(final T o1, final T o2) {
+        // does not expect to be called
+        return 0;
+    }
+
+    @Override
+    public SortBuilder<FieldSortBuilder> toSortBuilder() {
+        return new FieldSortBuilder(this.fieldName).order(this.sortOrder);
+    }
+}

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/IndigoComparator.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/IndigoComparator.java
@@ -1,0 +1,19 @@
+package com.epam.indigo.sort;
+
+import com.epam.indigo.model.IndigoRecord;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.Comparator;
+
+
+public abstract class IndigoComparator<T extends IndigoRecord> implements Comparator<T> {
+    protected SortOrder sortOrder;
+
+    public IndigoComparator(SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public abstract SortBuilder toSortBuilder();
+
+}

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/ScoreComparator.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/sort/ScoreComparator.java
@@ -1,0 +1,28 @@
+package com.epam.indigo.sort;
+
+import com.epam.indigo.model.IndigoRecord;
+import org.elasticsearch.search.sort.ScoreSortBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+public class ScoreComparator<T extends IndigoRecord> extends IndigoComparator<T> {
+
+    public ScoreComparator() {
+        super(SortOrder.DESC);
+    }
+
+    public ScoreComparator(SortOrder sortOrder) {
+        super(sortOrder);
+    }
+
+    @Override
+    public SortBuilder<ScoreSortBuilder> toSortBuilder() {
+        return new ScoreSortBuilder().order(sortOrder);
+    }
+
+    @Override
+    public int compare(final T o1, final T o2) {
+        // does not expect to be called
+        return 0;
+    }
+}

--- a/bingo/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/FullUsageMoleculeTest.java
+++ b/bingo/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/FullUsageMoleculeTest.java
@@ -187,7 +187,7 @@ public class FullUsageMoleculeTest {
                     .filter(new RangeQuery<>(fieldName, 10, 100))
                     .collect(Collectors.toList());
 
-            assertEquals(Math.min(10, cnt), similarRecords.size());
+            assertEquals(cnt, similarRecords.size());
         } catch (Exception exception) {
             Assertions.fail("Exception happened during test " + exception.getMessage());
         }
@@ -272,11 +272,11 @@ public class FullUsageMoleculeTest {
     }
 
     @Test
-    @DisplayName("Page size of 2000 should throw exception")
+    @DisplayName("Page size of Integer.MAX_VALUE should throw exception")
     public void pageSizeOverLimit() {
         assertThrows(IllegalArgumentException.class, () -> repository.stream()
                 .filter(new KeywordQuery<>("test", "test"))
-                .limit(2000)
+                .limit((long) Integer.MAX_VALUE + 1)
                 .collect(Collectors.toList()));
     }
 }

--- a/bingo/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/SaveMoleculeFromIndigoRecordTest.java
+++ b/bingo/bingo-elastic/java/src/test/java/com/epam/indigo/elastic/SaveMoleculeFromIndigoRecordTest.java
@@ -77,8 +77,10 @@ public class SaveMoleculeFromIndigoRecordTest {
             Helpers.iterateSdf("src/test/resources/rand_queries_small.sdf").forEach(indigoRecordList::add);
             repository.indexRecords(indigoRecordList, indigoRecordList.size());
             TimeUnit.SECONDS.sleep(5);
-            List<IndigoRecordMolecule> collect = repository.stream().collect(Collectors.toList());
-            assertEquals(10, collect.size());
+            List<IndigoRecordMolecule> fullCollection = repository.stream().collect(Collectors.toList());
+            List<IndigoRecordMolecule> limitCollection = repository.stream().limit(20).collect(Collectors.toList());
+            assertEquals(20, limitCollection.size());
+            assertEquals(371, fullCollection.size());
         } catch (Exception exception) {
             Assertions.fail(exception);
         }
@@ -93,7 +95,7 @@ public class SaveMoleculeFromIndigoRecordTest {
             repository.indexRecords(indigoRecordList, indigoRecordList.size());
             TimeUnit.SECONDS.sleep(5);
             List<IndigoRecord> collect = repository.stream().collect(Collectors.toList());
-            assertEquals(10, collect.size());
+            assertEquals(163, collect.size());
         } catch (Exception exception) {
             Assertions.fail(exception);
         }


### PR DESCRIPTION
## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated


Implementation is done for the expected behaviour. Four cases were considered:

- The stream has sorting and limit: return all records. the amout limited by the result hits count or limit parameter.
<img width="400" alt="image" src="https://github.com/epam/Indigo/assets/3823261/9343d987-6d72-4f5b-afcc-05dfe8b8909f">

- The steam has sorting only: return all records sorted. (even more then 10k)
<img width="400" alt="image" src="https://github.com/epam/Indigo/assets/3823261/12860db8-57f6-4a97-8fca-fafe0a89d15b">

- The steam has limit only: return the amount of records from the limit parameters but not more than 10k records.
<img width="350" alt="image" src="https://github.com/epam/Indigo/assets/3823261/a8b102b6-3ade-4b17-8f9b-1682cc60f51b">
<img width="350" alt="image" src="https://github.com/epam/Indigo/assets/3823261/859d6dc7-b554-4a93-8347-decbbdd1e2d6">

- The stream has no limit and sorting: return not more then 10k records
<img width="400" alt="image" src="https://github.com/epam/Indigo/assets/3823261/49b6a022-00c4-4e94-bb84-4d99a3c1c1b3">

