### PR TITLE
#1891 - When building api/http container, it cannot run due to mismatch in pydantic version

### DIFF
--- a/api/http/setup.py
+++ b/api/http/setup.py
@@ -5,6 +5,7 @@ packages = ["indigo_service"]
 package_data = {"": ["*"]}
 
 install_requires = [
+    "pydantic==1.10.8",
     "aiofiles>=0.7.0",
     "epam.indigo>=1.4.3",
     "fastapi>=0.63.0",


### PR DESCRIPTION
## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [x] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated

### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
### Optional
- [ ] unit-tests written
- [ ] documentation updated

## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes

## Bump request
- [ ] PR name follows the pattern `Bump version to ...`
- [ ] add brackets \[ \] for 'skip ci' and put it into the body
- [ ] milestone is linked to PR
- [ ] all tickets are closed inside the relevant milestone

Resolve: #1891

It seems that because a higher version of pydantic is installed by carrying dependencies in setup.py, the lower version of pydantic is no longer installed during pip install. Just add a line "pydantic==1.10.8", at the beginning of install_requires in setup.py and it will be fine