### PR TITLE
Pull IndigoRecord attribute as the document ID for index updates in bingo-elastic

### DIFF
--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
@@ -2,7 +2,6 @@ package com.epam.indigo.elastic;
 
 import com.epam.indigo.BingoElasticException;
 import com.epam.indigo.GenericRepository;
-import com.epam.indigo.elastic.ElasticStream;
 import com.epam.indigo.model.IndigoRecord;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
@@ -204,10 +204,10 @@ public class ElasticRepository<T extends IndigoRecord> implements GenericReposit
                 request.add(indexRequest);
                 this.elasticClient.bulkAsync(request, RequestOptions.DEFAULT, actionListener);
             }
-            //        TODO do we need it?
-            //        FlushRequest flushRequest = new FlushRequest();
-            //        this.elasticClient.indices().flushAsync(flushRequest, RequestOptions.DEFAULT);
         }
+//        TODO do we need it?
+//        FlushRequest flushRequest = new FlushRequest();
+//        this.elasticClient.indices().flushAsync(flushRequest, RequestOptions.DEFAULT);
     }
 
     @Override

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
@@ -217,11 +217,13 @@ public class ElasticRepository<T extends IndigoRecord> implements GenericReposit
                 IndexRequest indexRequest = new IndexRequest(this.indexName)
                         .source(builder);
 
-                if (documentIdProvider != null) {
+                if (this.documentIdProvider != null) {
                     String documentId = this.documentIdProvider.apply(t);
 
-                    indexRequest = indexRequest
-                            .id(documentId);
+                    if (documentId != null && !documentId.isEmpty()) {
+                        indexRequest = indexRequest
+                                .id(documentId);
+                    }
                 }
 
                 request.add(indexRequest);

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
@@ -204,6 +204,9 @@ public class ElasticRepository<T extends IndigoRecord> implements GenericReposit
                 request.add(indexRequest);
                 this.elasticClient.bulkAsync(request, RequestOptions.DEFAULT, actionListener);
             }
+            //        TODO do we need it?
+            //        FlushRequest flushRequest = new FlushRequest();
+            //        this.elasticClient.indices().flushAsync(flushRequest, RequestOptions.DEFAULT);
         }
     }
 

--- a/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
+++ b/bingo/bingo-elastic/java/src/main/java/com/epam/indigo/elastic/ElasticRepository.java
@@ -332,7 +332,7 @@ public class ElasticRepository<T extends IndigoRecord> implements GenericReposit
          * Use IndigoRecord.internalID as the ElasticSearch document _id
          * unique identifier, to allow for updating existing records
          * if they exist.
-         * Mutually exclusive with withDocumentId
+         * Mutually exclusive with withDocumentIdProvider
          *
          * @return the repository builder
          */


### PR DESCRIPTION
Currently, there is no way to update existing records in ElasticSearch when calling ElasticRepository.indexRecords in bingo.  This leads to lots of duplicate documents being inserted.

This uses the IndigoRecord internalID field as the ID field for the document, so that existing documents can be updated.