### PR TITLE
Change variant to ambiguous in ket loader/writer

### DIFF
--- a/api/tests/integration/tests/formats/ref/aminoacids_variants.ket
+++ b/api/tests/integration/tests/formats/ref/aminoacids_variants.ket
@@ -2,49 +2,49 @@
     "root": {
         "nodes": [
             {
-                "$ref": "variantMonomer-0"
+                "$ref": "ambiguousMonomer-0"
             },
             {
-                "$ref": "variantMonomer-1"
+                "$ref": "ambiguousMonomer-1"
             },
             {
-                "$ref": "variantMonomer-2"
+                "$ref": "ambiguousMonomer-2"
             },
             {
-                "$ref": "variantMonomer-3"
+                "$ref": "ambiguousMonomer-3"
             }
         ],
         "connections": [
             {
                 "connectionType": "single",
                 "endpoint1": {
-                    "monomerId": "variantMonomer-0",
+                    "monomerId": "ambiguousMonomer-0",
                     "attachmentPointId": "R2"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R1"
                 }
             },
             {
                 "connectionType": "single",
                 "endpoint1": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R2"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-2",
+                    "monomerId": "ambiguousMonomer-2",
                     "attachmentPointId": "R1"
                 }
             },
             {
                 "connectionType": "single",
                 "endpoint1": {
-                    "monomerId": "variantMonomer-2",
+                    "monomerId": "ambiguousMonomer-2",
                     "attachmentPointId": "R2"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-3",
+                    "monomerId": "ambiguousMonomer-3",
                     "attachmentPointId": "R1"
                 }
             }
@@ -117,20 +117,20 @@
                 "$ref": "monomerTemplate-Y___Tyrosine"
             },
             {
-                "$ref": "variantMonomerTemplate-B"
+                "$ref": "ambiguousMonomerTemplate-B"
             },
             {
-                "$ref": "variantMonomerTemplate-J"
+                "$ref": "ambiguousMonomerTemplate-J"
             },
             {
-                "$ref": "variantMonomerTemplate-Z"
+                "$ref": "ambiguousMonomerTemplate-Z"
             },
             {
-                "$ref": "variantMonomerTemplate-X"
+                "$ref": "ambiguousMonomerTemplate-X"
             }
         ]
     },
-    "variantMonomer-0": {
+    "ambiguousMonomer-0": {
         "type": "ambiguousMonomer",
         "id": "0",
         "position": {
@@ -140,7 +140,7 @@
         "seqid": 1,
         "templateId": "B"
     },
-    "variantMonomer-1": {
+    "ambiguousMonomer-1": {
         "type": "ambiguousMonomer",
         "id": "1",
         "position": {
@@ -150,7 +150,7 @@
         "seqid": 2,
         "templateId": "J"
     },
-    "variantMonomer-2": {
+    "ambiguousMonomer-2": {
         "type": "ambiguousMonomer",
         "id": "2",
         "position": {
@@ -160,7 +160,7 @@
         "seqid": 3,
         "templateId": "Z"
     },
-    "variantMonomer-3": {
+    "ambiguousMonomer-3": {
         "type": "ambiguousMonomer",
         "id": "3",
         "position": {
@@ -4661,7 +4661,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-B": {
+    "ambiguousMonomerTemplate-B": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "B",
@@ -4675,7 +4675,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-J": {
+    "ambiguousMonomerTemplate-J": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "J",
@@ -4689,7 +4689,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-Z": {
+    "ambiguousMonomerTemplate-Z": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "Z",
@@ -4703,7 +4703,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-X": {
+    "ambiguousMonomerTemplate-X": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "X",

--- a/api/tests/integration/tests/formats/ref/aminoacids_variants.ket
+++ b/api/tests/integration/tests/formats/ref/aminoacids_variants.ket
@@ -131,7 +131,7 @@
         ]
     },
     "variantMonomer-0": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "0",
         "position": {
             "x": 0.000000,
@@ -141,7 +141,7 @@
         "templateId": "B"
     },
     "variantMonomer-1": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "1",
         "position": {
             "x": 1.600000,
@@ -151,7 +151,7 @@
         "templateId": "J"
     },
     "variantMonomer-2": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "2",
         "position": {
             "x": 3.200000,
@@ -161,7 +161,7 @@
         "templateId": "Z"
     },
     "variantMonomer-3": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "3",
         "position": {
             "x": 4.800000,
@@ -4662,7 +4662,7 @@
         ]
     },
     "variantMonomerTemplate-B": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "B",
         "name": "B",
@@ -4676,7 +4676,7 @@
         ]
     },
     "variantMonomerTemplate-J": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "J",
         "name": "J",
@@ -4690,7 +4690,7 @@
         ]
     },
     "variantMonomerTemplate-Z": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "Z",
         "name": "Z",
@@ -4704,7 +4704,7 @@
         ]
     },
     "variantMonomerTemplate-X": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "X",
         "name": "X",

--- a/api/tests/integration/tests/formats/ref/dna_variants.ket
+++ b/api/tests/integration/tests/formats/ref/dna_variants.ket
@@ -5,13 +5,13 @@
                 "$ref": "monomer0"
             },
             {
-                "$ref": "variantMonomer-1"
+                "$ref": "ambiguousMonomer-1"
             },
             {
                 "$ref": "monomer2"
             },
             {
-                "$ref": "variantMonomer-3"
+                "$ref": "ambiguousMonomer-3"
             },
             {
                 "$ref": "monomer4"
@@ -25,7 +25,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R1"
                 }
             },
@@ -36,7 +36,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-3",
+                    "monomerId": "ambiguousMonomer-3",
                     "attachmentPointId": "R1"
                 }
             },
@@ -83,10 +83,10 @@
                 "$ref": "monomerTemplate-P___Phosphate"
             },
             {
-                "$ref": "variantMonomerTemplate-B"
+                "$ref": "ambiguousMonomerTemplate-B"
             },
             {
-                "$ref": "variantMonomerTemplate-N"
+                "$ref": "ambiguousMonomerTemplate-N"
             }
         ]
     },
@@ -101,7 +101,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-1": {
+    "ambiguousMonomer-1": {
         "type": "ambiguousMonomer",
         "id": "1",
         "position": {
@@ -122,7 +122,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-3": {
+    "ambiguousMonomer-3": {
         "type": "ambiguousMonomer",
         "id": "3",
         "position": {
@@ -1197,7 +1197,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-B": {
+    "ambiguousMonomerTemplate-B": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "B",
@@ -1214,7 +1214,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-N": {
+    "ambiguousMonomerTemplate-N": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",

--- a/api/tests/integration/tests/formats/ref/dna_variants.ket
+++ b/api/tests/integration/tests/formats/ref/dna_variants.ket
@@ -102,7 +102,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-1": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "1",
         "position": {
             "x": 0.000000,
@@ -123,7 +123,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-3": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "3",
         "position": {
             "x": 3.200000,
@@ -1198,7 +1198,7 @@
         ]
     },
     "variantMonomerTemplate-B": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "B",
         "name": "B",
@@ -1215,7 +1215,7 @@
         ]
     },
     "variantMonomerTemplate-N": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",
         "name": "N",

--- a/api/tests/integration/tests/formats/ref/helm_mixed_base.ket
+++ b/api/tests/integration/tests/formats/ref/helm_mixed_base.ket
@@ -14,7 +14,7 @@
                 "$ref": "monomer3"
             },
             {
-                "$ref": "variantMonomer-4"
+                "$ref": "ambiguousMonomer-4"
             },
             {
                 "$ref": "monomer5"
@@ -32,7 +32,7 @@
                 "$ref": "monomer9"
             },
             {
-                "$ref": "variantMonomer-10"
+                "$ref": "ambiguousMonomer-10"
             }
         ],
         "connections": [
@@ -76,7 +76,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-4",
+                    "monomerId": "ambiguousMonomer-4",
                     "attachmentPointId": "R1"
                 }
             },
@@ -142,7 +142,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-10",
+                    "monomerId": "ambiguousMonomer-10",
                     "attachmentPointId": "R1"
                 }
             }
@@ -164,10 +164,10 @@
                 "$ref": "monomerTemplate-C___Cytosine"
             },
             {
-                "$ref": "variantMonomerTemplate-R"
+                "$ref": "ambiguousMonomerTemplate-R"
             },
             {
-                "$ref": "variantMonomerTemplate-S"
+                "$ref": "ambiguousMonomerTemplate-S"
             }
         ]
     },
@@ -215,7 +215,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-4": {
+    "ambiguousMonomer-4": {
         "type": "ambiguousMonomer",
         "id": "4",
         "position": {
@@ -280,7 +280,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-10": {
+    "ambiguousMonomer-10": {
         "type": "ambiguousMonomer",
         "id": "10",
         "position": {
@@ -1170,7 +1170,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-R": {
+    "ambiguousMonomerTemplate-R": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "R",
@@ -1184,7 +1184,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-S": {
+    "ambiguousMonomerTemplate-S": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "S",

--- a/api/tests/integration/tests/formats/ref/helm_mixed_base.ket
+++ b/api/tests/integration/tests/formats/ref/helm_mixed_base.ket
@@ -216,7 +216,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-4": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "4",
         "position": {
             "x": 3.200000,
@@ -281,7 +281,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-10": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "10",
         "position": {
             "x": 9.600000,
@@ -1171,7 +1171,7 @@
         ]
     },
     "variantMonomerTemplate-R": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "R",
         "name": "R",
@@ -1185,7 +1185,7 @@
         ]
     },
     "variantMonomerTemplate-S": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "S",
         "name": "S",

--- a/api/tests/integration/tests/formats/ref/helm_mixed_custom.ket
+++ b/api/tests/integration/tests/formats/ref/helm_mixed_custom.ket
@@ -5,7 +5,7 @@
                 "$ref": "monomer0"
             },
             {
-                "$ref": "variantMonomer-1"
+                "$ref": "ambiguousMonomer-1"
             },
             {
                 "$ref": "monomer2"
@@ -14,7 +14,7 @@
                 "$ref": "monomer3"
             },
             {
-                "$ref": "variantMonomer-4"
+                "$ref": "ambiguousMonomer-4"
             },
             {
                 "$ref": "monomer5"
@@ -23,7 +23,7 @@
                 "$ref": "monomer6"
             },
             {
-                "$ref": "variantMonomer-7"
+                "$ref": "ambiguousMonomer-7"
             }
         ],
         "connections": [
@@ -34,7 +34,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R1"
                 }
             },
@@ -67,7 +67,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-4",
+                    "monomerId": "ambiguousMonomer-4",
                     "attachmentPointId": "R1"
                 }
             },
@@ -100,7 +100,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-7",
+                    "monomerId": "ambiguousMonomer-7",
                     "attachmentPointId": "R1"
                 }
             }
@@ -125,10 +125,10 @@
                 "$ref": "monomerTemplate-P___Phosphate"
             },
             {
-                "$ref": "variantMonomerTemplate-N0"
+                "$ref": "ambiguousMonomerTemplate-N0"
             },
             {
-                "$ref": "variantMonomerTemplate-N"
+                "$ref": "ambiguousMonomerTemplate-N"
             }
         ]
     },
@@ -143,7 +143,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-1": {
+    "ambiguousMonomer-1": {
         "type": "ambiguousMonomer",
         "id": "1",
         "position": {
@@ -175,7 +175,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-4": {
+    "ambiguousMonomer-4": {
         "type": "ambiguousMonomer",
         "id": "4",
         "position": {
@@ -207,7 +207,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-7": {
+    "ambiguousMonomer-7": {
         "type": "ambiguousMonomer",
         "id": "7",
         "position": {
@@ -1271,7 +1271,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-N0": {
+    "ambiguousMonomerTemplate-N0": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N0",
@@ -1295,7 +1295,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-N": {
+    "ambiguousMonomerTemplate-N": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",

--- a/api/tests/integration/tests/formats/ref/helm_mixed_custom.ket
+++ b/api/tests/integration/tests/formats/ref/helm_mixed_custom.ket
@@ -144,7 +144,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-1": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "1",
         "position": {
             "x": 0.000000,
@@ -176,7 +176,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-4": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "4",
         "position": {
             "x": 3.200000,
@@ -208,7 +208,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-7": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "7",
         "position": {
             "x": 6.400000,
@@ -1272,7 +1272,7 @@
         ]
     },
     "variantMonomerTemplate-N0": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N0",
         "name": "N0",
@@ -1296,7 +1296,7 @@
         ]
     },
     "variantMonomerTemplate-N": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",
         "name": "N",

--- a/api/tests/integration/tests/formats/ref/idt_mixed_custom.ket
+++ b/api/tests/integration/tests/formats/ref/idt_mixed_custom.ket
@@ -5,7 +5,7 @@
                 "$ref": "monomer0"
             },
             {
-                "$ref": "variantMonomer-1"
+                "$ref": "ambiguousMonomer-1"
             },
             {
                 "$ref": "monomer2"
@@ -14,7 +14,7 @@
                 "$ref": "monomer3"
             },
             {
-                "$ref": "variantMonomer-4"
+                "$ref": "ambiguousMonomer-4"
             },
             {
                 "$ref": "monomer5"
@@ -23,7 +23,7 @@
                 "$ref": "monomer6"
             },
             {
-                "$ref": "variantMonomer-7"
+                "$ref": "ambiguousMonomer-7"
             }
         ],
         "connections": [
@@ -34,7 +34,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R1"
                 }
             },
@@ -56,7 +56,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-4",
+                    "monomerId": "ambiguousMonomer-4",
                     "attachmentPointId": "R1"
                 }
             },
@@ -89,7 +89,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-7",
+                    "monomerId": "ambiguousMonomer-7",
                     "attachmentPointId": "R1"
                 }
             },
@@ -125,10 +125,10 @@
                 "$ref": "monomerTemplate-P___Phosphate"
             },
             {
-                "$ref": "variantMonomerTemplate-(N1)"
+                "$ref": "ambiguousMonomerTemplate-(N1)"
             },
             {
-                "$ref": "variantMonomerTemplate-N"
+                "$ref": "ambiguousMonomerTemplate-N"
             }
         ]
     },
@@ -143,7 +143,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-1": {
+    "ambiguousMonomer-1": {
         "type": "ambiguousMonomer",
         "id": "1",
         "position": {
@@ -175,7 +175,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-4": {
+    "ambiguousMonomer-4": {
         "type": "ambiguousMonomer",
         "id": "4",
         "position": {
@@ -207,7 +207,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-7": {
+    "ambiguousMonomer-7": {
         "type": "ambiguousMonomer",
         "id": "7",
         "position": {
@@ -1271,7 +1271,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-(N1)": {
+    "ambiguousMonomerTemplate-(N1)": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "(N1)",
@@ -1295,7 +1295,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-N": {
+    "ambiguousMonomerTemplate-N": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",

--- a/api/tests/integration/tests/formats/ref/idt_mixed_custom.ket
+++ b/api/tests/integration/tests/formats/ref/idt_mixed_custom.ket
@@ -144,7 +144,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-1": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "1",
         "position": {
             "x": 0.000000,
@@ -176,7 +176,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-4": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "4",
         "position": {
             "x": 3.200000,
@@ -208,7 +208,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-7": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "7",
         "position": {
             "x": 6.400000,
@@ -1272,7 +1272,7 @@
         ]
     },
     "variantMonomerTemplate-(N1)": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "(N1)",
         "name": "(N1)",
@@ -1296,7 +1296,7 @@
         ]
     },
     "variantMonomerTemplate-N": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",
         "name": "N",

--- a/api/tests/integration/tests/formats/ref/idt_mixed_std.ket
+++ b/api/tests/integration/tests/formats/ref/idt_mixed_std.ket
@@ -14,7 +14,7 @@
                 "$ref": "monomer3"
             },
             {
-                "$ref": "variantMonomer-4"
+                "$ref": "ambiguousMonomer-4"
             },
             {
                 "$ref": "monomer5"
@@ -32,7 +32,7 @@
                 "$ref": "monomer9"
             },
             {
-                "$ref": "variantMonomer-10"
+                "$ref": "ambiguousMonomer-10"
             }
         ],
         "connections": [
@@ -65,7 +65,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-4",
+                    "monomerId": "ambiguousMonomer-4",
                     "attachmentPointId": "R1"
                 }
             },
@@ -131,7 +131,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-10",
+                    "monomerId": "ambiguousMonomer-10",
                     "attachmentPointId": "R1"
                 }
             },
@@ -164,10 +164,10 @@
                 "$ref": "monomerTemplate-C___Cytosine"
             },
             {
-                "$ref": "variantMonomerTemplate-R"
+                "$ref": "ambiguousMonomerTemplate-R"
             },
             {
-                "$ref": "variantMonomerTemplate-S"
+                "$ref": "ambiguousMonomerTemplate-S"
             }
         ]
     },
@@ -215,7 +215,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-4": {
+    "ambiguousMonomer-4": {
         "type": "ambiguousMonomer",
         "id": "4",
         "position": {
@@ -280,7 +280,7 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-10": {
+    "ambiguousMonomer-10": {
         "type": "ambiguousMonomer",
         "id": "10",
         "position": {
@@ -1170,7 +1170,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-R": {
+    "ambiguousMonomerTemplate-R": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "R",
@@ -1184,7 +1184,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-S": {
+    "ambiguousMonomerTemplate-S": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "S",

--- a/api/tests/integration/tests/formats/ref/idt_mixed_std.ket
+++ b/api/tests/integration/tests/formats/ref/idt_mixed_std.ket
@@ -216,7 +216,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-4": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "4",
         "position": {
             "x": 3.200000,
@@ -281,7 +281,7 @@
         "templateId": "dR___Deoxy-Ribose"
     },
     "variantMonomer-10": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "10",
         "position": {
             "x": 9.600000,
@@ -1171,7 +1171,7 @@
         ]
     },
     "variantMonomerTemplate-R": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "R",
         "name": "R",
@@ -1185,7 +1185,7 @@
         ]
     },
     "variantMonomerTemplate-S": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "S",
         "name": "S",

--- a/api/tests/integration/tests/formats/ref/rna_variants.ket
+++ b/api/tests/integration/tests/formats/ref/rna_variants.ket
@@ -5,13 +5,13 @@
                 "$ref": "monomer0"
             },
             {
-                "$ref": "variantMonomer-1"
+                "$ref": "ambiguousMonomer-1"
             },
             {
                 "$ref": "monomer2"
             },
             {
-                "$ref": "variantMonomer-3"
+                "$ref": "ambiguousMonomer-3"
             },
             {
                 "$ref": "monomer4"
@@ -25,7 +25,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-1",
+                    "monomerId": "ambiguousMonomer-1",
                     "attachmentPointId": "R1"
                 }
             },
@@ -36,7 +36,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-3",
+                    "monomerId": "ambiguousMonomer-3",
                     "attachmentPointId": "R1"
                 }
             },
@@ -83,10 +83,10 @@
                 "$ref": "monomerTemplate-P___Phosphate"
             },
             {
-                "$ref": "variantMonomerTemplate-K"
+                "$ref": "ambiguousMonomerTemplate-K"
             },
             {
-                "$ref": "variantMonomerTemplate-N"
+                "$ref": "ambiguousMonomerTemplate-N"
             }
         ]
     },
@@ -101,7 +101,7 @@
         "alias": "R",
         "templateId": "R___Ribose"
     },
-    "variantMonomer-1": {
+    "ambiguousMonomer-1": {
         "type": "ambiguousMonomer",
         "id": "1",
         "position": {
@@ -122,7 +122,7 @@
         "alias": "R",
         "templateId": "R___Ribose"
     },
-    "variantMonomer-3": {
+    "ambiguousMonomer-3": {
         "type": "ambiguousMonomer",
         "id": "3",
         "position": {
@@ -1214,7 +1214,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-K": {
+    "ambiguousMonomerTemplate-K": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "K",
@@ -1228,7 +1228,7 @@
             }
         ]
     },
-    "variantMonomerTemplate-N": {
+    "ambiguousMonomerTemplate-N": {
         "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",

--- a/api/tests/integration/tests/formats/ref/rna_variants.ket
+++ b/api/tests/integration/tests/formats/ref/rna_variants.ket
@@ -102,7 +102,7 @@
         "templateId": "R___Ribose"
     },
     "variantMonomer-1": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "1",
         "position": {
             "x": 0.000000,
@@ -123,7 +123,7 @@
         "templateId": "R___Ribose"
     },
     "variantMonomer-3": {
-        "type": "variantMonomer",
+        "type": "ambiguousMonomer",
         "id": "3",
         "position": {
             "x": 3.200000,
@@ -1215,7 +1215,7 @@
         ]
     },
     "variantMonomerTemplate-K": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "K",
         "name": "K",
@@ -1229,7 +1229,7 @@
         ]
     },
     "variantMonomerTemplate-N": {
-        "type": "variantMonomerTemplate",
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "N",
         "name": "N",

--- a/core/indigo-core/molecule/ket_objects.h
+++ b/core/indigo-core/molecule/ket_objects.h
@@ -942,7 +942,7 @@ namespace indigo
     public:
         DECL_ERROR;
 
-        inline static std::string ref_prefix = "variantMonomerTemplate-";
+        inline static std::string ref_prefix = "ambiguousMonomerTemplate-";
 
         KetVariantMonomerTemplate(const std::string& subtype, const std::string& id, const std::string& name, IdtAlias idt_alias,
                                   const std::vector<KetVariantMonomerOption>& options)
@@ -975,7 +975,7 @@ namespace indigo
     public:
         DECL_ERROR;
 
-        inline static std::string ref_prefix = "variantMonomer-";
+        inline static std::string ref_prefix = "ambiguousMonomer-";
 
         KetVariantMonomer(const std::string& id, const std::string& alias, const std::string& template_id)
             : KetBaseMonomer(MonomerType::VarianMonomer, id, alias, template_id)

--- a/core/indigo-core/molecule/src/ket_document_json_loader.cpp
+++ b/core/indigo-core/molecule/src/ket_document_json_loader.cpp
@@ -53,7 +53,7 @@ void KetDocumentJsonLoader::parseJson(const std::string& json_str, KetDocument& 
                 {
                     parseMonomerTemplate(templ, document);
                 }
-                else if (templ_type == "variantMonomerTemplate")
+                else if (templ_type == "ambiguousMonomerTemplate")
                 {
                     parseVariantMonomerTemplate(templ, document);
                 }
@@ -87,7 +87,7 @@ void KetDocumentJsonLoader::parseJson(const std::string& json_str, KetDocument& 
                 {
                     parseKetMonomer(ref, node, document);
                 }
-                else if (node_type == "variantMonomer")
+                else if (node_type == "ambiguousMonomer")
                 {
                     parseKetVariantMonomer(ref, node, document);
                 }

--- a/core/indigo-core/molecule/src/ket_document_json_saver.cpp
+++ b/core/indigo-core/molecule/src/ket_document_json_saver.cpp
@@ -292,7 +292,7 @@ void KetDocumentJsonSaver::saveVariantMonomer(JsonWriter& writer, const KetVaria
 {
     writer.Key(monomer.ref());
     writer.StartObject();
-    saveStr(writer, "type", "variantMonomer");
+    saveStr(writer, "type", "ambiguousMonomer");
     saveStr(writer, "id", monomer.id());
     auto& pos = monomer.position();
     if (pos.has_value())
@@ -314,7 +314,7 @@ void KetDocumentJsonSaver::saveVariantMonomerTemplate(JsonWriter& writer, const 
 {
     writer.Key(get_ref(monomer_template));
     writer.StartObject();
-    saveStr(writer, "type", "variantMonomerTemplate");
+    saveStr(writer, "type", "ambiguousMonomerTemplate");
     saveStr(writer, "subtype", monomer_template.subtype());
     saveStr(writer, "id", monomer_template.id());
     saveStr(writer, "name", monomer_template.name());

--- a/data/molecules/basic/idt_mixed_std.ket
+++ b/data/molecules/basic/idt_mixed_std.ket
@@ -14,7 +14,7 @@
                 "$ref": "monomer3"
             },
             {
-                "$ref": "variantMonomer-4"
+                "$ref": "ambiguousMonomer-4"
             },
             {
                 "$ref": "monomer5"
@@ -32,7 +32,7 @@
                 "$ref": "monomer9"
             },
             {
-                "$ref": "variantMonomer-10"
+                "$ref": "ambiguousMonomer-10"
             }
         ],
         "connections": [
@@ -65,7 +65,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-4",
+                    "monomerId": "ambiguousMonomer-4",
                     "attachmentPointId": "R1"
                 }
             },
@@ -131,7 +131,7 @@
                     "attachmentPointId": "R3"
                 },
                 "endpoint2": {
-                    "monomerId": "variantMonomer-10",
+                    "monomerId": "ambiguousMonomer-10",
                     "attachmentPointId": "R1"
                 }
             },
@@ -164,10 +164,10 @@
                 "$ref": "monomerTemplate-C___Cytosine"
             },
             {
-                "$ref": "variantMonomerTemplate-R"
+                "$ref": "ambiguousMonomerTemplate-R"
             },
             {
-                "$ref": "variantMonomerTemplate-S"
+                "$ref": "ambiguousMonomerTemplate-S"
             }
         ]
     },
@@ -215,8 +215,8 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-4": {
-        "type": "variantMonomer",
+    "ambiguousMonomer-4": {
+        "type": "ambiguousMonomer",
         "id": "4",
         "position": {
             "x": 3.200000,
@@ -280,8 +280,8 @@
         "alias": "dR",
         "templateId": "dR___Deoxy-Ribose"
     },
-    "variantMonomer-10": {
-        "type": "variantMonomer",
+    "ambiguousMonomer-10": {
+        "type": "ambiguousMonomer",
         "id": "10",
         "position": {
             "x": 9.600000,
@@ -1170,8 +1170,8 @@
             }
         ]
     },
-    "variantMonomerTemplate-R": {
-        "type": "variantMonomerTemplate",
+    "ambiguousMonomerTemplate-R": {
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "R",
         "name": "R",
@@ -1184,8 +1184,8 @@
             }
         ]
     },
-    "variantMonomerTemplate-S": {
-        "type": "variantMonomerTemplate",
+    "ambiguousMonomerTemplate-S": {
+        "type": "ambiguousMonomerTemplate",
         "subtype": "mixture",
         "id": "S",
         "name": "S",


### PR DESCRIPTION
According to ket format changes change variant to ambiguous in ket loader/writer


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
