### PR TITLE
 #2266 Error message is wrong for missing ratio number (PEPTIDE1{(A:+C:0.1)}$$$$V2.0)

### DIFF
--- a/api/tests/integration/ref/formats/helm_to_ket.py.out
+++ b/api/tests/integration/ref/formats/helm_to_ket.py.out
@@ -15,6 +15,7 @@ Test 'CHEM1{[A6OH]}|PEPTIDE1{A}$CHEM1,PEPTIDE1,1:R4-1:R1$$$V2.0': got expected e
 Test 'CHEM1{[A6OH]}|PEPTIDE1{A}$CHEM10,PEPTIDE1,1:R2-1:R1$$$V2.0': got expected error 'Polymer 'CHEM10' not found.'
 Test 'CHEM1{[MCC]}|RNA1{R(A)P.R(C)P.R(G)P.R(T)P.R(U)P}$RNA1,PEPTIDE1,15:R2-1:R1$$$V2.0': got expected error 'Polymer 'PEPTIDE1' not found.'
 Test 'CHEM1{[MCC]}|RNA1{R(U)P}$CHEM1,RNA1,1:R1-1:R2$$$V2.0': got expected error 'Monomer 'R' attachment point 'R2' already connected to monomer'monomer3' attachment point 'R1''
+Test 'PEPTIDE1{(A:+C:0.1)}$$$$V2.0': got expected error 'Unexpected symbol. Expected digit but found '+''
 Test 'PEPTIDE1{(A:1.5+C:aaaa)}$$$$V2.0': got expected error 'Unexpected symbol. Expected '+' or ',' but found '.''
 Test 'PEPTIDE1{A'2'}$$$$V2.0': got expected error 'Repeating not supported now.'
 Test 'PEPTIDE1{D-gGlu}$$$$V2.0': got expected error 'Unexpected symbol. Expected '.' or '}' but found '-'.'

--- a/api/tests/integration/tests/formats/helm_to_ket.py
+++ b/api/tests/integration/tests/formats/helm_to_ket.py
@@ -70,6 +70,7 @@ helm_errors = {
     "PEPTIDE1{(A:1.5+C:aaaa)}$$$$V2.0": "Unexpected symbol. Expected '+' or ',' but found '.'",
     "RNA1{R(bla-bla-bla)p}$$$$V2.0": "Unexpected symbol. Expected ')' but found 'l'.",
     "PEPTIDE1{D-gGlu}$$$$V2.0": "Unexpected symbol. Expected '.' or '}' but found '-'.",
+    "PEPTIDE1{(A:+C:0.1)}$$$$V2.0": "Unexpected symbol. Expected digit but found '+'",
 }
 for helm_seq in sorted(helm_errors.keys()):
     error = helm_errors[helm_seq]

--- a/core/indigo-core/molecule/src/sequence_loader.cpp
+++ b/core/indigo-core/molecule/src/sequence_loader.cpp
@@ -1424,7 +1424,7 @@ int SequenceLoader::readCount(std::string& count, Scanner& _scanner)
             ch = _scanner.lookNext();
         }
         if (count.size() == 0)
-            throw Error("Invalid number.");
+            throw Error("Unexpected symbol. Expected digit but found '%c'", ch);
     }
     return ch;
 }


### PR DESCRIPTION
Fix error message. Add UT


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
