### PR TITLE
Backmerge: #2337 - Export of HELM with inline SMILES contains "Mod0" instead of SMILES

### DIFF
--- a/api/tests/integration/ref/formats/ket_to_helm.py.out
+++ b/api/tests/integration/ref/formats/ket_to_helm.py.out
@@ -14,4 +14,6 @@ helm_multi_char_rna.ket:SUCCEED
 helm_peptide.ket:SUCCEED
 helm_rna_without_base.ket:SUCCEED
 helm_simple_rna.ket:SUCCEED
+helm_smiles.ket:SUCCEED
+helm_smiles_sugar.ket:SUCCEED
 rna_variants.ket:SUCCEED

--- a/api/tests/integration/tests/formats/ket_to_helm.py
+++ b/api/tests/integration/tests/formats/ket_to_helm.py
@@ -49,6 +49,8 @@ helm_data = {
     "rna_variants": "RNA1{R(A,G)P.R(G,T)P.R(A,C,G,T)}$$$$V2.0",
     "helm_monomer_molecule": "PEPTIDE1{A}|PEPTIDE2{G}|CHEM1{[C(N[*:2])=C[*:1] |$;;_R2;;_R1$|]}$CHEM1,PEPTIDE1,1:R2-1:R1|PEPTIDE2,CHEM1,1:R2-1:R1$$$V2.0",
     "helm_fractional_ratio": "PEPTIDE1{(A:1.5+C:.1+G:3.)}$$$$V2.0",
+    "helm_smiles": "PEPTIDE1{G.[[*:1]NC(C(=O)[*:2])C=O |$_R1;;;;;_R2;;$|].C}|PEPTIDE2{G.[[*:1]NC(C(=O)[*:2])C=O |$_R1;;;;;_R2;;$|].C}$$$$V2.0",
+    "helm_smiles_sugar": "RNA1{[C(C(CO[*:1])O[*:2])[*:3] |$;;;;_R1;;_R2;_R3$|](A)P}$$$$V2.0",
 }
 
 for filename in sorted(helm_data.keys()):

--- a/core/indigo-core/molecule/ket_objects.h
+++ b/core/indigo-core/molecule/ket_objects.h
@@ -656,7 +656,7 @@ namespace indigo
         enum class MonomerType
         {
             Monomer,
-            VarianMonomer,
+            AmbiguousMonomer,
         };
 
         KetBaseMonomer(MonomerType monomer_type, const std::string& id, const std::string& alias, const std::string& template_id)
@@ -980,7 +980,7 @@ namespace indigo
         inline static std::string ref_prefix = "ambiguousMonomer-";
 
         KetVariantMonomer(const std::string& id, const std::string& alias, const std::string& template_id)
-            : KetBaseMonomer(MonomerType::VarianMonomer, id, alias, template_id)
+            : KetBaseMonomer(MonomerType::AmbiguousMonomer, id, alias, template_id)
         {
             _ref = ref_prefix + _id;
         };

--- a/core/indigo-core/molecule/monomers_template_library.h
+++ b/core/indigo-core/molecule/monomers_template_library.h
@@ -258,6 +258,11 @@ namespace indigo
         const std::string& getIdtAliasByModification(IdtModification modification, const std::string sugar_id, const std::string base_id,
                                                      const std::string phosphate_id);
 
+        const std::map<std::string, MonomerTemplate>& monomerTemplates()
+        {
+            return _monomer_templates;
+        };
+
     private:
         std::map<std::string, MonomerTemplate> _monomer_templates;
         std::map<std::string, MonomerGroupTemplate> _monomer_group_templates;

--- a/core/indigo-core/molecule/sequence_saver.h
+++ b/core/indigo-core/molecule/sequence_saver.h
@@ -34,6 +34,7 @@ namespace indigo
     class Output;
     class BaseMolecule;
     class KetDocument;
+    class KetBaseMonomer;
 
     class DLLEXPORT SequenceSaver
     {
@@ -68,6 +69,7 @@ namespace indigo
     private:
         std::string getMonomerAlias(BaseMolecule& mol, int atom_idx);
         std::string getHelmPolymerClass(BaseMolecule& mol, int atom_idx);
+        void add_monomer(KetDocument& document, const std::unique_ptr<KetBaseMonomer>& monomer, std::string& helm_string);
         SequenceSaver(const SequenceSaver&); // no implicit copy
         Output& _output;
         const MonomerTemplates& _mon_lib;

--- a/core/indigo-core/molecule/src/ket_document.cpp
+++ b/core/indigo-core/molecule/src/ket_document.cpp
@@ -22,6 +22,10 @@
 #include "molecule/molecule.h"
 #include "molecule/molecule_json_loader.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#endif
+
 using namespace indigo;
 
 IMPL_ERROR(KetDocument, "Ket Document")
@@ -330,7 +334,7 @@ MonomerClass KetDocument::getMonomerClass(const KetBaseMonomer& monomer) const
 {
     if (monomer.monomerType() == KetBaseMonomer::MonomerType::Monomer)
         return _templates.at(monomer.templateId()).monomerClass();
-    else if (monomer.monomerType() == KetBaseMonomer::MonomerType::VarianMonomer)
+    else if (monomer.monomerType() == KetBaseMonomer::MonomerType::AmbiguousMonomer)
         return _variant_templates.at(monomer.templateId()).monomerClass();
     else
         throw Error("Unknonwn monomer type");
@@ -489,3 +493,7 @@ const std::string& KetDocument::monomerIdByRef(const std::string& ref)
         throw Error("Monomer with ref %s not found", ref.c_str());
     return it->second;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/indigo-core/molecule/src/ket_document_json_saver.cpp
+++ b/core/indigo-core/molecule/src/ket_document_json_saver.cpp
@@ -458,7 +458,7 @@ void KetDocumentJsonSaver::saveKetDocument(JsonWriter& writer, const KetDocument
         auto& monomer = monomers.at(it);
         if (monomer->monomerType() == KetBaseMonomer::MonomerType::Monomer)
             saveMonomer(writer, *static_cast<KetMonomer*>(monomer.get()));
-        else if (monomer->monomerType() == KetBaseMonomer::MonomerType::VarianMonomer)
+        else if (monomer->monomerType() == KetBaseMonomer::MonomerType::AmbiguousMonomer)
             saveVariantMonomer(writer, *static_cast<KetVariantMonomer*>(monomer.get()));
         else
             throw Error("Unknown monomer type");


### PR DESCRIPTION
Backmerge ti master


## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes
