### PR TITLE
Backmerge: #2312 - Export of ambiguous monomers doesn't work (error appears) to any export format (even to SVG/PNG) except KET

### DIFF
--- a/api/tests/integration/ref/formats/ket_ambiguous_export.py.out
+++ b/api/tests/integration/ref/formats/ket_ambiguous_export.py.out
@@ -1,0 +1,10 @@
+Test mol v2000
+molecule: Ambiguous monomer cannot be transform to SGroup.
+Test mol v3000
+molfile saver: Ambiguous monomer cannot be saved to molfile.
+Test cdxml
+molecule: Ambiguous monomer cannot be transform to SGroup.
+Test cml
+molecule: Ambiguous monomer cannot be transform to SGroup.
+Test smiles
+*

--- a/api/tests/integration/tests/formats/ket_ambiguous_export.py
+++ b/api/tests/integration/tests/formats/ket_ambiguous_export.py
@@ -1,0 +1,53 @@
+﻿import difflib
+import os
+import sys
+
+
+def find_diff(a, b):
+    return "\n".join(difflib.unified_diff(a.splitlines(), b.splitlines()))
+
+
+sys.path.append(
+    os.path.normpath(
+        os.path.join(os.path.abspath(__file__), "..", "..", "..", "common")
+    )
+)
+from env_indigo import (  # noqa
+    Indigo,
+    IndigoException,
+    getIndigoExceptionText,
+    joinPathPy,
+)
+
+indigo = Indigo()
+
+root = joinPathPy("molecules/macro/", __file__)
+
+mol = indigo.loadMoleculeFromFile(os.path.join(root, "ambiguous.ket"))
+print("Test mol v2000")
+try:
+    indigo.setOption("molfile-saving-mode", "2000")
+    print(mol.molfile())
+except IndigoException as e:
+    print(getIndigoExceptionText(e))
+print("Test mol v3000")
+try:
+    indigo.setOption("molfile-saving-mode", "3000")
+    print(mol.molfile())
+except IndigoException as e:
+    print(getIndigoExceptionText(e))
+print("Test cdxml")
+try:
+    print(mol.cdxml())
+except IndigoException as e:
+    print(getIndigoExceptionText(e))
+print("Test cml")
+try:
+    print(mol.cml())
+except IndigoException as e:
+    print(getIndigoExceptionText(e))
+print("Test smiles")
+try:
+    print(mol.smiles())
+except IndigoException as e:
+    print(getIndigoExceptionText(e))

--- a/api/tests/integration/tests/formats/molecules/macro/ambiguous.ket
+++ b/api/tests/integration/tests/formats/molecules/macro/ambiguous.ket
@@ -1,0 +1,449 @@
+{
+    "root": {
+        "nodes": [
+            {
+                "$ref": "monomer4"
+            }
+        ],
+        "connections": [],
+        "templates": [
+            {
+                "$ref": "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_"
+            },
+            {
+                "$ref": "monomerTemplate-D___Aspartic acid"
+            },
+            {
+                "$ref": "monomerTemplate-N___Asparagine"
+            }
+        ]
+    },
+    "monomer4": {
+        "type": "ambiguousMonomer",
+        "id": "4",
+        "position": {
+            "x": 7.966666686534882,
+            "y": -6.075
+        },
+        "alias": "B",
+        "templateId": "alternatives__D___Aspartic acid__N___Asparagine_"
+    },
+    "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_": {
+        "type": "ambiguousMonomerTemplate",
+        "id": "alternatives__D___Aspartic acid__N___Asparagine_",
+        "alias": "B",
+        "subtype": "alternatives",
+        "options": [
+            {
+                "templateId": "D___Aspartic acid"
+            },
+            {
+                "templateId": "N___Asparagine"
+            }
+        ]
+    },
+    "monomerTemplate-D___Aspartic acid": {
+        "type": "monomerTemplate",
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.631,
+                    -1.5578,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.6327,
+                    -2.7392,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.3507,
+                    -0.8201,
+                    0
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.9295,
+                    -1.5578,
+                    0
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.9525,
+                    -0.9669,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.3485,
+                    0.6575,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.9317,
+                    1.3952,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.9542,
+                    0.8032,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.9335,
+                    2.5766,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.6534,
+                    -0.9658,
+                    0
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    0.0851,
+                    3.1751,
+                    0
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    10
+                ]
+            }
+        ],
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "id": "D___Aspartic acid",
+        "fullName": "Aspartic acid",
+        "alias": "D",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                },
+                "type": "left"
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                },
+                "type": "right"
+            },
+            {
+                "attachmentAtom": 8,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                },
+                "type": "side"
+            }
+        ],
+        "naturalAnalogShort": "D"
+    },
+    "monomerTemplate-N___Asparagine": {
+        "type": "monomerTemplate",
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.8929,
+                    -1.4175,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.8947,
+                    -2.5989,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.6127,
+                    -0.6799,
+                    0
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.6676,
+                    -1.4175,
+                    0
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.6907,
+                    -0.8266,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.6104,
+                    0.7978,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.6698,
+                    1.5354,
+                    0
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.6922,
+                    0.9434,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.6716,
+                    2.7168,
+                    0
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.9153,
+                    -0.8255,
+                    0
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -2.5341,
+                    1.7724,
+                    0
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    10
+                ]
+            }
+        ],
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "id": "N___Asparagine",
+        "fullName": "Asparagine",
+        "alias": "N",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                },
+                "type": "left"
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                },
+                "type": "right"
+            },
+            {
+                "attachmentAtom": 7,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                },
+                "type": "side"
+            }
+        ],
+        "naturalAnalogShort": "N"
+    }
+}

--- a/core/indigo-core/molecule/molecule_json_loader.h
+++ b/core/indigo-core/molecule/molecule_json_loader.h
@@ -84,6 +84,7 @@ namespace indigo
 
         static void loadMetaObjects(rapidjson::Value& meta_objects, MetaDataStorage& meta);
         static int parseMonomerTemplate(const rapidjson::Value& monomer_template, BaseMolecule& mol, StereocentersOptions stereochemistry_options);
+        void parseAmbiguousMonomerTemplate(const rapidjson::Value& monomer_template, BaseMolecule& mol);
 
     protected:
         struct EnhancedStereoCenter

--- a/core/indigo-core/molecule/molecule_json_saver.h
+++ b/core/indigo-core/molecule/molecule_json_saver.h
@@ -71,6 +71,7 @@ namespace indigo
         void saveRGroup(PtrPool<BaseMolecule>& fragments, int rgnum, JsonWriter& writer);
         void saveFragment(BaseMolecule& fragment, JsonWriter& writer);
         void saveMonomerTemplate(TGroup& tg, JsonWriter& writer);
+        void saveAmbiguousMonomerTemplate(TGroup& tg, JsonWriter& writer);
         void saveMonomerAttachmentPoints(TGroup& tg, JsonWriter& writer);
         void saveSuperatomAttachmentPoints(Superatom& sa, JsonWriter& writer);
 

--- a/core/indigo-core/molecule/molecule_tgroups.h
+++ b/core/indigo-core/molecule/molecule_tgroups.h
@@ -48,6 +48,10 @@ namespace indigo
         int tgroup_id;
         bool unresolved;
         Array<char> idt_alias;
+        bool ambiguous;
+        bool mixture;
+        ObjArray<Array<char>> aliases;
+        Array<float> ratios;
 
         TGroup();
         ~TGroup();

--- a/core/indigo-core/molecule/src/base_molecule.cpp
+++ b/core/indigo-core/molecule/src/base_molecule.cpp
@@ -2996,6 +2996,8 @@ int BaseMolecule::_transformTGroupToSGroup(int idx, int t_idx)
         tg_idx = tgroups.findTGroup(getTemplateAtom(idx));
 
     TGroup& tgroup = tgroups.getTGroup(tg_idx);
+    if (tgroup.ambiguous)
+        throw Error("Ambiguous monomer cannot be transform to SGroup.");
     fragment.clear();
     fragment.clone(*tgroup.fragment.get());
 

--- a/core/indigo-core/molecule/src/molecule_tgroups.cpp
+++ b/core/indigo-core/molecule/src/molecule_tgroups.cpp
@@ -23,7 +23,7 @@
 
 using namespace indigo;
 
-TGroup::TGroup() : unresolved(false)
+TGroup::TGroup() : unresolved(false), ambiguous(false)
 {
 }
 
@@ -34,6 +34,7 @@ TGroup::~TGroup()
 void TGroup::clear()
 {
     unresolved = false;
+    ambiguous = false;
 }
 
 int TGroup::cmp(TGroup& tg1, TGroup& tg2, void* /*context*/)
@@ -49,6 +50,11 @@ int TGroup::cmp(TGroup& tg1, TGroup& tg2, void* /*context*/)
     if (tg1.unresolved && !tg2.unresolved)
         return 1;
     else if (!tg1.unresolved && tg2.unresolved)
+        return -1;
+
+    if (tg1.ambiguous && !tg2.ambiguous)
+        return 1;
+    else if (!tg1.ambiguous && tg2.ambiguous)
         return -1;
 
     lgrps.clear();
@@ -118,8 +124,18 @@ void TGroup::copy(const TGroup& other)
     tgroup_id = other.tgroup_id;
     unresolved = other.unresolved;
     idt_alias.copy(other.idt_alias);
-    fragment.reset(other.fragment->neu());
-    fragment->clone(*other.fragment.get(), 0, 0);
+    if (!other.ambiguous)
+    {
+        fragment.reset(other.fragment->neu());
+        fragment->clone(*other.fragment.get(), 0, 0);
+    }
+    ambiguous = other.ambiguous;
+    mixture = other.mixture;
+    for (int i = 0; i < other.aliases.size(); i++)
+    {
+        aliases.push().copy(other.aliases[i]);
+    }
+    ratios.copy(other.ratios);
 }
 
 IMPL_ERROR(MoleculeTGroups, "molecule tgroups");

--- a/core/indigo-core/molecule/src/molfile_saver.cpp
+++ b/core/indigo-core/molecule/src/molfile_saver.cpp
@@ -1168,6 +1168,8 @@ void MolfileSaver::_writeTGroup(Output& output, BaseMolecule& mol, int tg_idx)
     QS_DEF(Array<char>, buf);
     ArrayOutput out(buf);
     TGroup& tgroup = mol.tgroups.getTGroup(tg_idx);
+    if (tgroup.ambiguous)
+        throw Error("Ambiguous monomer cannot be saved to molfile.");
     std::string natreplace;
     if (tgroup.tgroup_natreplace.size() > 0)
         natreplace = tgroup.tgroup_natreplace.ptr();


### PR DESCRIPTION

backmerge to master

## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes
