### PR TITLE
bugfix: indentation errors in docstring description.

### DIFF
--- a/utils/indigo-service/backend/service/v2/imago_api.py
+++ b/utils/indigo-service/backend/service/v2/imago_api.py
@@ -177,30 +177,30 @@ def imago_upload_post():
         - image/tiff,
         - image/bmp,
         - image/cmu-raster,
-        - image/x-portable-bitmap'
+        - image/x-portable-bitmap,
     parameters:
         - name: image_request
-            in: body
-            description: 'Image to process in Imago'
-            required: true
-            type: string
-            format: binary
+          in: body
+          description: 'Image to process in Imago'
+          required: true
+          type: string
+          format: binary
         - name: version
-            in: json_request
-            description: 'Version of Imago'
-            type: string
+          in: json_request
+          description: 'Version of Imago'
+          type: string
         - name: settings
-            in: json_request
-            description: 'Settings for Imago'
-            type: json
+          in: json_request
+          description: 'Settings for Imago'
+          type: json
         - name: action
-            in: json_request
-            description: "Determines logic of POST request: send image or wait until settings passed"
-            type: string
+          in: json_request
+          description: "Determines logic of POST request: send image or wait until settings passed"
+          type: string
         - name: expire
-            in: json_request
-            description: "Time for image POST requeust to expire during waiting for settings"
-            type: float
+          in: json_request
+          description: "Time for image POST requeust to expire during waiting for settings"
+          type: float
     responses:
         200:
             description: 'Task id for obtaining molecule'
@@ -416,14 +416,14 @@ def upload_status_post(upload_id):
     description: 'Pass settings to Imago and proccess uploaded image'
     parameters:
         - name: action
-            in: json_request
-            required: true
-            type: string
-            description: 'Parameter to run Imago with passed properties'
+          in: json_request
+          required: true
+          type: string
+          description: 'Parameter to run Imago with passed properties'
         - name: settings
-            in: json_request
-            type: object
-            description: 'Parameters for Imago in JSON'
+          in: json_request
+          type: object
+          description: 'Parameters for Imago in JSON'
     responses:
         200:
             description: 'Image processed'

--- a/utils/indigo-service/backend/service/v2/imago_api.py
+++ b/utils/indigo-service/backend/service/v2/imago_api.py
@@ -214,7 +214,7 @@ def imago_upload_post():
                 - error
                 properties:
                     error:
-                    type: string
+                        type: string
         400:
             description: A problem with supplied client data
             schema:
@@ -223,7 +223,7 @@ def imago_upload_post():
                 - error
                 properties:
                     error:
-                    type: string
+                        type: string
         415:
             description: Supplied image format are not supported
             schema:
@@ -232,7 +232,7 @@ def imago_upload_post():
                 - error
                 properties:
                     error:
-                    type: string
+                        type: string
         5XX:
             description: 'Internal service error'
             schema:
@@ -241,7 +241,7 @@ def imago_upload_post():
                 - error
                 properties:
                     error:
-                    type: string
+                        type: string
     """
     args = []
     full_mime_type = request.headers.get("Content-Type")
@@ -363,14 +363,14 @@ def upload_status_get(upload_id):
                 id: UploadResponce
                 properties:
                     state:
-                    type: string
-                    example: SUCCESS
+                        type: string
+                        example: SUCCESS
                     metadata:
-                    type: object
-                    properties:
-                        mol_str:
-                            type: string
-                            description: "Mol file in string format"
+                        type: object
+                        properties:
+                            mol_str:
+                                type: string
+                                description: "Mol file in string format"
         400:
             schema:
                 $ref: "#/definitions/imago_imagoupload_post_Error"

--- a/utils/indigo-service/backend/service/v2/libraries_api.py
+++ b/utils/indigo-service/backend/service/v2/libraries_api.py
@@ -109,7 +109,7 @@ def search_post():
         - bingo
     responses:
         200:
-        description: search results
+            description: search results
     """
     libraries_api_logger.info(
         "[REQUEST] POST /search {0}".format(request.data)


### PR DESCRIPTION
bugfix: indentation errors in docstring description.

When accessing to Swagger(http://host:port/apidocs/), it throws an exception - "Failed to load API definition" .
Due to indentation errors in the two files.

