### PR TITLE
 #2313 - Indigo functions doesn't work if ambiguous monomer present on the canvas

### DIFF
--- a/api/tests/integration/ref/formats/ket_to_ket.py.out
+++ b/api/tests/integration/ref/formats/ket_to_ket.py.out
@@ -1,4 +1,6 @@
 *** KET to KET ***
 images.ket:SUCCEED
-monomer_shape.ket molecule: SUCCEED
-monomer_shape.ket molecule: SUCCEED
+ambiguous_monomer.ket mol: SUCCEED
+ambiguous_monomer.ket doc: SUCCEED
+monomer_shape.ket mol: SUCCEED
+monomer_shape.ket doc: SUCCEED

--- a/api/tests/integration/ref/formats/ket_to_ket.py.out
+++ b/api/tests/integration/ref/formats/ket_to_ket.py.out
@@ -1,6 +1,6 @@
 *** KET to KET ***
 images.ket:SUCCEED
-ambiguous_monomer.ket mol: SUCCEED
 ambiguous_monomer.ket doc: SUCCEED
-monomer_shape.ket mol: SUCCEED
+ambiguous_monomer.ket mol: SUCCEED
 monomer_shape.ket doc: SUCCEED
+monomer_shape.ket mol: SUCCEED

--- a/api/tests/integration/tests/formats/ket_to_ket.py
+++ b/api/tests/integration/tests/formats/ket_to_ket.py
@@ -56,6 +56,7 @@ def check_res(filename, format, ket_ref, ket):
 indigo.setOption("json-use-native-precision", True)
 files = [
     "monomer_shape",
+    "ambiguous_monomer",
 ]
 formats = {
     "mol": indigo.loadMolecule,
@@ -70,4 +71,4 @@ for filename in sorted(files):
         # with open("{}_{}.ket".format(file_path, format), "w") as file:
         #     file.write(mol.json())
         ket = mol.json()
-        check_res(filename, "molecule", ket_ref, ket)
+        check_res(filename, format, ket_ref, ket)

--- a/api/tests/integration/tests/formats/ket_to_ket.py
+++ b/api/tests/integration/tests/formats/ket_to_ket.py
@@ -59,15 +59,15 @@ files = [
     "ambiguous_monomer",
 ]
 formats = {
-    "mol": indigo.loadMolecule,
     "doc": indigo.loadKetDocument,
+    "mol": indigo.loadMolecule,
 }
 for filename in sorted(files):
-    for format, loader in formats.items():
+    for format in sorted(formats.keys()):
         file_path = os.path.join(ref_path, filename)
         with open("{}_{}.ket".format(file_path, format), "r") as file:
             ket_ref = file.read()
-        mol = loader(ket_ref)
+        mol = formats[format](ket_ref)
         # with open("{}_{}.ket".format(file_path, format), "w") as file:
         #     file.write(mol.json())
         ket = mol.json()

--- a/api/tests/integration/tests/formats/ref/ambiguous_monomer_doc.ket
+++ b/api/tests/integration/tests/formats/ref/ambiguous_monomer_doc.ket
@@ -1,0 +1,548 @@
+{
+    "root": {
+        "nodes": [
+            {
+                "$ref": "mol0"
+            },
+            {
+                "$ref": "monomer0"
+            }
+        ],
+        "templates": [
+            {
+                "$ref": "monomerTemplate-D___Aspartic acid"
+            },
+            {
+                "$ref": "monomerTemplate-N___Asparagine"
+            },
+            {
+                "$ref": "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_"
+            }
+        ]
+    },
+    "mol0": {
+        "type": "molecule",
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    8.15647994229502,
+                    -12.083532606254808,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    9.613664416935088,
+                    -12.0831242081336,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.886451125631235,
+                    -11.662364112725957,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    9.613664416935088,
+                    -12.926074394730222,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.15647994229502,
+                    -12.929853984815562,
+                    0
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.88828992110518,
+                    -13.346732491000417,
+                    0
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 4,
+                "atoms": [
+                    2,
+                    0
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    0,
+                    4
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    4,
+                    5
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    5,
+                    3
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    3,
+                    1
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    1,
+                    2
+                ]
+            }
+        ],
+        "stereoFlagPosition": {
+            "x": 9.613664416935088,
+            "y": 10.662364112725957,
+            "z": 0
+        }
+    },
+    "monomer0": {
+        "type": "ambiguousMonomer",
+        "id": "0",
+        "position": {
+            "x": 12.909951,
+            "y": -11.775532
+        },
+        "alias": "B",
+        "alias": "B",
+        "templateId": "alternatives__D___Aspartic acid__N___Asparagine_"
+    },
+    "monomerTemplate-D___Aspartic acid": {
+        "type": "monomerTemplate",
+        "id": "D___Aspartic acid",
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "fullName": "Aspartic acid",
+        "alias": "D",
+        "naturalAnalogShort": "D",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 8,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.631000,
+                    -1.557800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.632700,
+                    -2.739200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.350700,
+                    -0.820100,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.929500,
+                    -1.557800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.952500,
+                    -0.966900,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.348500,
+                    0.657500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.931700,
+                    1.395200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.954200,
+                    0.803200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.933500,
+                    2.576600,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.653400,
+                    -0.965800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    0.085100,
+                    3.175100,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    10
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-N___Asparagine": {
+        "type": "monomerTemplate",
+        "id": "N___Asparagine",
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "fullName": "Asparagine",
+        "alias": "N",
+        "naturalAnalogShort": "N",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 7,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.892900,
+                    -1.417500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.894700,
+                    -2.598900,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.612700,
+                    -0.679900,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.667600,
+                    -1.417500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.690700,
+                    -0.826600,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.610400,
+                    0.797800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.669800,
+                    1.535400,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.692200,
+                    0.943400,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.671600,
+                    2.716800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.915300,
+                    -0.825500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -2.534100,
+                    1.772400,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    10
+                ]
+            }
+        ]
+    },
+    "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_": {
+        "type": "ambiguousMonomerTemplate",
+        "subtype": "alternatives",
+        "id": "alternatives__D___Aspartic acid__N___Asparagine_",
+        "alias": "B",
+        "options": [
+            {
+                "templateId": "D___Aspartic acid"
+            },
+            {
+                "templateId": "N___Asparagine"
+            }
+        ]
+    }
+}

--- a/api/tests/integration/tests/formats/ref/ambiguous_monomer_mol.ket
+++ b/api/tests/integration/tests/formats/ref/ambiguous_monomer_mol.ket
@@ -1,0 +1,552 @@
+{
+    "root": {
+        "nodes": [
+            {
+                "$ref": "mol0"
+            },
+            {
+                "$ref": "monomer0"
+            }
+        ],
+        "connections": [],
+        "templates": [
+            {
+                "$ref": "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_"
+            },
+            {
+                "$ref": "monomerTemplate-D___Aspartic acid"
+            },
+            {
+                "$ref": "monomerTemplate-N___Asparagine"
+            }
+        ]
+    },
+    "monomer0": {
+        "type": "ambiguousMonomer",
+        "id": "0",
+        "position": {
+            "x": 12.909951,
+            "y": -11.775532
+        },
+        "alias": "B",
+        "templateId": "alternatives__D___Aspartic acid__N___Asparagine_"
+    },
+    "ambiguousMonomerTemplate-alternatives__D___Aspartic acid__N___Asparagine_": {
+        "type": "ambiguousMonomerTemplate",
+        "subtype": "alternatives",
+        "id": "alternatives__D___Aspartic acid__N___Asparagine_",
+        "alias": "B",
+        "options": [
+            {
+                "templateId": "D___Aspartic acid"
+            },
+            {
+                "templateId": "N___Asparagine"
+            }
+        ]
+    },
+    "monomerTemplate-D___Aspartic acid": {
+        "type": "monomerTemplate",
+        "id": "D___Aspartic acid",
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "alias": "D",
+        "name": "Asp",
+        "fullName": "Aspartic acid",
+        "naturalAnalogShort": "D",
+        "naturalAnalog": "Asp",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 8,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.631000,
+                    -1.557800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.632700,
+                    -2.739200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.350700,
+                    -0.820100,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.929500,
+                    -1.557800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.952500,
+                    -0.966900,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.348500,
+                    0.657500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.931700,
+                    1.395200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.954200,
+                    0.803200,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.933500,
+                    2.576600,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.653400,
+                    -0.965800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    0.085100,
+                    3.175100,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    10
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-N___Asparagine": {
+        "type": "monomerTemplate",
+        "id": "N___Asparagine",
+        "class": "AminoAcid",
+        "classHELM": "PEPTIDE",
+        "alias": "N",
+        "name": "Asn",
+        "fullName": "Asparagine",
+        "naturalAnalogShort": "N",
+        "naturalAnalog": "Asn",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 3,
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 7,
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.892900,
+                    -1.417500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.894700,
+                    -2.598900,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.612700,
+                    -0.679900,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.667600,
+                    -1.417500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -1.690700,
+                    -0.826600,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.610400,
+                    0.797800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.669800,
+                    1.535400,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.692200,
+                    0.943400,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.671600,
+                    2.716800,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.915300,
+                    -0.825500,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -2.534100,
+                    1.772400,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    10
+                ]
+            }
+        ]
+    },
+    "mol0": {
+        "type": "molecule",
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    8.156480,
+                    -12.083532,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    9.613665,
+                    -12.083124,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.886451,
+                    -11.662364,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    9.613665,
+                    -12.926074,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.156480,
+                    -12.929854,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    8.888289,
+                    -13.346732,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 4,
+                "atoms": [
+                    2,
+                    0
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    0,
+                    4
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    4,
+                    5
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    5,
+                    3
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    3,
+                    1
+                ]
+            },
+            {
+                "type": 4,
+                "atoms": [
+                    1,
+                    2
+                ]
+            }
+        ],
+        "stereoFlagPosition": {
+            "x": 9.613665,
+            "y": 10.662364,
+            "z": 0.000000
+        }
+    }
+}

--- a/core/indigo-core/molecule/src/molecule_json_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_saver.cpp
@@ -1578,7 +1578,7 @@ void MoleculeJsonSaver::saveRoot(BaseMolecule& mol, JsonWriter& writer)
         for (int i = mol.tgroups.begin(); i != mol.tgroups.end(); i = mol.tgroups.next(i))
         {
             TGroup& tg = mol.tgroups.getTGroup(i);
-            auto template_name = std::string("monomerTemplate-") + monomerId(tg);
+            auto template_name = std::string(tg.ambiguous ? "ambiguousMonomerTemplate-" : "monomerTemplate-") + monomerId(tg);
             writer.StartObject();
             writer.Key("$ref");
             writer.String(template_name.c_str());


### PR DESCRIPTION
Fix molecule_json_saver. Add UT.


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
