### PR TITLE
 #2332 - Error message should use "ambiguous monomer" instead of "variant monomer"

### DIFF
--- a/api/tests/integration/ref/formats/idt_to_ket.py.out
+++ b/api/tests/integration/ref/formats/idt_to_ket.py.out
@@ -30,6 +30,7 @@ idt_unresolved.ket:SUCCEED
 idt_unresolved_many.ket:SUCCEED
 idt_unsplit.ket:SUCCEED
 Test '!+A-$#12w12r23e32e33': got expected error 'Invalid symbols in the sequence: !,-,$,#,1,2,w,1,2,2,3,e,3,2,e,3,3'
+Test '(Y:)': got expected error 'Invalid IDT ambiguous monomer (Y:)'
 Test '(YY:00330067)': got expected error 'Invalid mixed base - only numerical index allowed.'
 Test '+/5Phos/A': got expected error 'Sugar prefix could not be used with modified monomer.'
 Test '/': got expected error 'Unexpected end of data'

--- a/api/tests/integration/tests/formats/idt_to_ket.py
+++ b/api/tests/integration/tests/formats/idt_to_ket.py
@@ -102,6 +102,7 @@ idt_errors = {
     "/3Phos/*": "Symbol '*' could be placed only between two nucleotides/nucleosides.",
     "r(B1:50003000)(B1)": "Unknown mixed base 'B1'",
     "(YY:00330067)": "Invalid mixed base - only numerical index allowed.",
+    "(Y:)": "Invalid IDT ambiguous monomer (Y:)",
 }
 for idt_seq in sorted(idt_errors.keys()):
     error = idt_errors[idt_seq]

--- a/core/indigo-core/molecule/src/ket_document.cpp
+++ b/core/indigo-core/molecule/src/ket_document.cpp
@@ -100,7 +100,7 @@ KetAmbiguousMonomerTemplate& KetDocument::addAmbiguousMonomerTemplate(const std:
                                                                       IdtAlias idt_alias, std::vector<KetAmbiguousMonomerOption>& options)
 {
     if (_ambiguous_templates.find(id) != _ambiguous_templates.end())
-        throw Error("Variant monomer template '%s' already exists.", id.c_str());
+        throw Error("Ambiguous monomer template '%s' already exists.", id.c_str());
     _ambiguous_templates_ids.emplace_back(id);
     auto it = _ambiguous_templates.try_emplace(id, subtype, id, name, idt_alias, options);
     _template_id_to_type.emplace(id, KetBaseMonomerTemplate::TemplateType::AmbiguousMonomerTemplate);
@@ -120,7 +120,7 @@ std::unique_ptr<KetBaseMonomer>& KetDocument::addAmbiguousMonomer(const std::str
 std::unique_ptr<KetBaseMonomer>& KetDocument::addAmbiguousMonomer(const std::string& id, const std::string& alias, const std::string& template_id)
 {
     if (_monomers.find(id) != _monomers.end())
-        throw Error("Variant monomer '%s' already exists.", id.c_str());
+        throw Error("Ambiguous monomer '%s' already exists.", id.c_str());
     auto it = _monomers.try_emplace(id, std::make_unique<KetAmbiguousMonomer>(id, alias, template_id));
     it.first->second->setAttachmentPoints(_ambiguous_templates.at(template_id).attachmentPoints());
     _monomer_ref_to_id.emplace(it.first->second->ref(), id);
@@ -222,7 +222,7 @@ void KetDocument::processAmbiguousMonomerTemplates()
                 has_probability = true;
         }
         if (has_ratio && has_probability)
-            throw Error("Variant monomer template '%s' has options with both ratio and probability set.", it.first.c_str());
+            throw Error("Ambiguous monomer template '%s' has options with both ratio and probability set.", it.first.c_str());
         MonomerClass monomer_class = _templates.at(options[0].templateId()).monomerClass();
         for (auto& opt_it : options)
         {

--- a/core/indigo-core/molecule/src/ket_objects.cpp
+++ b/core/indigo-core/molecule/src/ket_objects.cpp
@@ -655,7 +655,7 @@ const std::map<std::string, int>& KetConnection::getStringPropStrToIdx() const
     return str_to_idx;
 }
 
-IMPL_ERROR(KetAmbiguousMonomer, "Ket Variant Monomer")
+IMPL_ERROR(KetAmbiguousMonomer, "Ket Ambiguous Monomer")
 
 const std::map<std::string, int>& KetAmbiguousMonomer::getIntPropStrToIdx() const
 {


### PR DESCRIPTION
Fix code. Add UT


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
