### PR TITLE
#2732 - V2000 Mol file loader skips essential SGroup line in certain cases

### DIFF
--- a/core/indigo-core/molecule/src/molfile_loader.cpp
+++ b/core/indigo-core/molecule/src/molfile_loader.cpp
@@ -1411,14 +1411,14 @@ void MolfileLoader::_readCtab2000()
                             id[3] = 0;
                             throw Error("Undefined Sgroup connectivity: '%s'", id);
                         }
-                        if (id[2] == '\n')
-                        {
-                            if (n != 0)
-                                throw Error("Unexpected end of M SCN");
-                            else
-                                // In some molfiles last space is not written
-                                need_skip_line = false;
-                        }
+                    }
+                    if (id[2] == '\n')
+                    {
+                        if (n != 0)
+                            throw Error("Unexpected end of M SCN");
+                        else
+                            // In some molfiles last space is not written
+                            need_skip_line = false;
                     }
                 }
                 if (need_skip_line)


### PR DESCRIPTION
## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
