### PR TITLE
Revert "#2657 - Add ES6 options for WASM build (#2658)"

### DIFF
--- a/api/wasm/indigo-ketcher/CMakeLists.txt
+++ b/api/wasm/indigo-ketcher/CMakeLists.txt
@@ -38,8 +38,6 @@ set(EMCC_COMMON_FLAGS
 set(EMCC_FLAGS_SEPARATE
         ${EMCC_COMMON_FLAGS}
         -s SINGLE_FILE=0
-        -s EXPORT_ES6=1
-        -s USE_ES6_IMPORT_META=1
         )
 
 set(EMCC_FLAGS


### PR DESCRIPTION
This reverts commit e79b727a83ee8123cc1b1754fccd0e2c09d5d95a.
