### PR TITLE
#2732 - V2000 Mol file loader skips essential SGroup line in certain cases

### DIFF
--- a/core/indigo-core/molecule/src/molfile_loader.cpp
+++ b/core/indigo-core/molecule/src/molfile_loader.cpp
@@ -1411,14 +1411,14 @@ void MolfileLoader::_readCtab2000()
                             id[3] = 0;
                             throw Error("Undefined Sgroup connectivity: '%s'", id);
                         }
-                        if (id[2] == '\n')
-                        {
-                            if (n != 0)
-                                throw Error("Unexpected end of M SCN");
-                            else
-                                // In some molfiles last space is not written
-                                need_skip_line = false;
-                        }
+                    }
+                    if (id[2] == '\n')
+                    {
+                        if (n != 0)
+                            throw Error("Unexpected end of M SCN");
+                        else
+                            // In some molfiles last space is not written
+                            need_skip_line = false;
                     }
                 }
                 if (need_skip_line)

--- a/core/indigo-core/tests/tests/formats.cpp
+++ b/core/indigo-core/tests/tests/formats.cpp
@@ -340,6 +340,44 @@ M  END
     ASSERT_EQ(t_mol.sgroups.getSGroupCount(), 0);
 }
 
+TEST_F(IndigoCoreFormatsTest, mol_loader_issue_2732)
+{
+    Molecule t_mol;
+    
+
+    const char* mol = R"(
+  ACCLDraw01172516572D
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+    4.4375   -4.3750    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1538   -4.7885    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.8700   -4.3750    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1538   -4.7885    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.1538   -4.7885    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  3  1  0  0  0  0
+  4  5  1  0  0  0  0
+  2  5  1  0  0  0  0
+  4  1  1  0  0  0  0
+M  STY  1   1 MUL
+M  SLB  1   1   1
+M  SCN  1   1 HT
+M  SAL   1  3   2   4   5
+M  SBL   1  2   1   4
+M  SPA   1  1   2
+M  SDI   1  4    4.7956   -4.9953    4.7956   -4.1682
+M  SDI   1  4    5.5119   -4.1682    5.5119   -4.9953
+M  SMT   1 3
+M  END
+)";
+    loadMolecule(mol, t_mol);
+    ASSERT_EQ(t_mol.sgroups.getSGroupCount(), 1);
+    SGroup& sg = t_mol.sgroups.getSGroup(0);
+    ASSERT_EQ(sg.atoms.size(), 3);
+    ASSERT_EQ(sg.atoms.at(0), 1);
+    ASSERT_EQ(sg.atoms.at(1), 3);
+    ASSERT_EQ(sg.atoms.at(2), 4);
+}
+
 TEST_F(IndigoCoreFormatsTest, smarts_load_save)
 {
     QueryMolecule q_mol;

--- a/core/indigo-core/tests/tests/formats.cpp
+++ b/core/indigo-core/tests/tests/formats.cpp
@@ -344,7 +344,6 @@ M  END
 TEST_F(IndigoCoreFormatsTest, mol_loader_issue_2732)
 {
     Molecule t_mol;
-    
 
     const char* mol = R"(
   ACCLDraw01172516572D


### PR DESCRIPTION
## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated

### Optional
- [ ] unit-tests written
- [ ] documentation updated
