### PR TITLE
Add virtual destructors into CDX to avoid memory leak

### DIFF
--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -189,6 +189,7 @@ namespace indigo
     class BaseCDXProperty
     {
     public:
+        virtual ~BaseCDXProperty()=default;
         virtual bool hasContent() const = 0;
         virtual std::unique_ptr<BaseCDXProperty> copy() = 0;
         virtual std::unique_ptr<BaseCDXProperty> next() = 0;
@@ -375,6 +376,7 @@ namespace indigo
     class BaseCDXElement
     {
     public:
+        virtual ~BaseCDXElement()=default;
         virtual bool hasContent() = 0;
         virtual std::unique_ptr<BaseCDXElement> copy() = 0;
         virtual std::unique_ptr<BaseCDXProperty> firstProperty() = 0;

--- a/core/indigo-core/molecule/molecule_cdxml_loader.h
+++ b/core/indigo-core/molecule/molecule_cdxml_loader.h
@@ -189,7 +189,7 @@ namespace indigo
     class BaseCDXProperty
     {
     public:
-        virtual ~BaseCDXProperty()=default;
+        virtual ~BaseCDXProperty() = default;
         virtual bool hasContent() const = 0;
         virtual std::unique_ptr<BaseCDXProperty> copy() = 0;
         virtual std::unique_ptr<BaseCDXProperty> next() = 0;
@@ -376,7 +376,7 @@ namespace indigo
     class BaseCDXElement
     {
     public:
-        virtual ~BaseCDXElement()=default;
+        virtual ~BaseCDXElement() = default;
         virtual bool hasContent() = 0;
         virtual std::unique_ptr<BaseCDXElement> copy() = 0;
         virtual std::unique_ptr<BaseCDXProperty> firstProperty() = 0;

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -1146,7 +1146,7 @@ void MoleculeCdxmlLoader::_parseFragmentAttributes(BaseCDXProperty& prop)
 
 void MoleculeCdxmlLoader::applyDispatcher(BaseCDXProperty& prop, const std::unordered_map<std::string, std::function<void(const std::string&)>>& dispatcher)
 {
-    for (auto ptr = prop.copy(); ptr->hasContent(); ptr = ptr->next())
+    for (auto ptr = prop.copy(); ptr->hasContent(); ptr=ptr->next())
     {
         auto it = dispatcher.find(ptr->name());
         if (it != dispatcher.end())

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -1146,7 +1146,7 @@ void MoleculeCdxmlLoader::_parseFragmentAttributes(BaseCDXProperty& prop)
 
 void MoleculeCdxmlLoader::applyDispatcher(BaseCDXProperty& prop, const std::unordered_map<std::string, std::function<void(const std::string&)>>& dispatcher)
 {
-    for (auto ptr = prop.copy(); ptr->hasContent(); ptr=ptr->next())
+    for (auto ptr = prop.copy(); ptr->hasContent(); ptr = ptr->next())
     {
         auto it = dispatcher.find(ptr->name());
         if (it != dispatcher.end())


### PR DESCRIPTION
To correct destruct derived classes base class destructor should be virtual,


