### PR TITLE
Backmerge: #2987 - Melting temperature value missed if UPC or NAC value set to zero

### DIFF
--- a/api/tests/integration/ref/formats/macromol_props.py.out
+++ b/api/tests/integration/ref/formats/macromol_props.py.out
@@ -20,3 +20,5 @@ props_only_micro.json: SUCCEED
 props_peptides.json: SUCCEED
 props_peptides_micro.json: SUCCEED
 props_rna_with_mol.json: SUCCEED
+UPC=0: SUCCEED
+NAC=0: SUCCEED

--- a/api/tests/integration/tests/formats/macromol_props.py
+++ b/api/tests/integration/tests/formats/macromol_props.py
@@ -78,3 +78,25 @@ for filename in sorted(macro_data):
     else:
         print(filename + ".json: FAILED")
         print(diff)
+
+filename = "props_double_dna_gc"
+mol = indigo.loadKetDocumentFromFile(os.path.join(root, filename + ".ket"))
+with open(os.path.join(ref, filename) + "_zero.json", "r") as file:
+    props_ref = file.read()
+    props = mol.macroProperties(upc, nac)
+# test UPC=0
+props = mol.macroProperties(0, nac)
+diff = find_diff(props_ref, props)
+if not diff:
+    print("UPC=0: SUCCEED")
+else:
+    print("UPC=0: FAILED")
+    print(diff)
+# test NAC=0
+props = mol.macroProperties(upc, 0)
+diff = find_diff(props_ref, props)
+if not diff:
+    print("NAC=0: SUCCEED")
+else:
+    print("NAC=0: FAILED")
+    print(diff)

--- a/api/tests/integration/tests/formats/ref/props_double_dna_gc_zero.json
+++ b/api/tests/integration/tests/formats/ref/props_double_dna_gc_zero.json
@@ -1,0 +1,13 @@
+[
+    {
+        "grossFormula": "C38 N16 O24 P2 H50",
+        "mass": 1176.843928,
+        "monomerCount": {
+            "peptides": {},
+            "nucleotides": {
+                "C": 2,
+                "G": 2
+            }
+        }
+    }
+]

--- a/api/tests/integration/tests/formats/ref/props_double_dna_gc_zero.json
+++ b/api/tests/integration/tests/formats/ref/props_double_dna_gc_zero.json
@@ -1,6 +1,6 @@
 [
     {
-        "grossFormula": "C38 N16 O24 P2 H50",
+        "grossFormula": "C38 H50 N16 O24 P2",
         "mass": 1176.843928,
         "monomerCount": {
             "peptides": {},

--- a/core/indigo-core/molecule/src/macro_properties_calculator.cpp
+++ b/core/indigo-core/molecule/src/macro_properties_calculator.cpp
@@ -558,7 +558,7 @@ void MacroPropertiesCalculator::CalculateMacroProps(KetDocument& document, Outpu
                 bases.emplace_back(monomer_template.getStringProp("naturalAnalogShort"));
                 move_to_next_base(it, sequence.end());
             }
-            if (bases.size() > 0)
+            if (bases.size() > 0 && upc > 0 && nac > 0)
             {
                 std::string left = bases.front();
                 bases.pop_front();


### PR DESCRIPTION
backmerge to 1.33


## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes

