### PR TITLE
 #2998 - Input fields for ion concentration and oligonucleotides become inactive after entering excessively long number

### DIFF
--- a/api/tests/integration/ref/formats/macromol_props.py.out
+++ b/api/tests/integration/ref/formats/macromol_props.py.out
@@ -22,4 +22,6 @@ props_peptides.json: SUCCEED
 props_peptides_micro.json: SUCCEED
 props_rna_with_mol.json: SUCCEED
 UPC=0: SUCCEED
+UPC=1e+41: SUCCEED
 NAC=0: SUCCEED
+NAC=1e+41: SUCCEED

--- a/api/tests/integration/tests/formats/macromol_props.py
+++ b/api/tests/integration/tests/formats/macromol_props.py
@@ -84,20 +84,21 @@ filename = "props_double_dna_gc"
 mol = indigo.loadKetDocumentFromFile(os.path.join(root, filename + ".ket"))
 with open(os.path.join(ref, filename) + "_zero.json", "r") as file:
     props_ref = file.read()
-    props = mol.macroProperties(upc, nac)
-# test UPC=0
-props = mol.macroProperties(0, nac)
-diff = find_diff(props_ref, props)
-if not diff:
-    print("UPC=0: SUCCEED")
-else:
-    print("UPC=0: FAILED")
-    print(diff)
-# test NAC=0
-props = mol.macroProperties(upc, 0)
-diff = find_diff(props_ref, props)
-if not diff:
-    print("NAC=0: SUCCEED")
-else:
-    print("NAC=0: FAILED")
-    print(diff)
+# test invalid UPC - 0 or too big value
+for invalid_upc in (0, 1e41):
+    props = mol.macroProperties(invalid_upc, nac)
+    diff = find_diff(props_ref, props)
+    if not diff:
+        print("UPC=%s: SUCCEED" % invalid_upc)
+    else:
+        print("UPC=%s: FAILED" % invalid_upc)
+        print(diff)
+# test invalid NAC - 0 or too big value
+for invalid_nac in (0, 1e41):
+    props = mol.macroProperties(upc, invalid_nac)
+    diff = find_diff(props_ref, props)
+    if not diff:
+        print("NAC=%s: SUCCEED" % invalid_nac)
+    else:
+        print("NAC=%s: FAILED" % invalid_nac)
+        print(diff)

--- a/core/indigo-core/molecule/src/macro_properties_calculator.cpp
+++ b/core/indigo-core/molecule/src/macro_properties_calculator.cpp
@@ -578,7 +578,7 @@ void MacroPropertiesCalculator::CalculateMacroProps(KetDocument& document, Outpu
                 bases.emplace_back(monomer_template.getStringProp("naturalAnalogShort"));
                 move_to_next_base(it, sequence.end());
             }
-            if (bases.size() > 1 && upc > 0 && nac > 0)
+            if (bases.size() > 1 && std::isfinite(upc) && std::isfinite(nac) && upc > 0 && nac > 0)
             {
                 std::string left = bases.front();
                 bases.pop_front();


### PR DESCRIPTION
Fix code. Add UT

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
