### PR TITLE
 #3045 Adding substituents to reactants breaks chemical property calculations

### DIFF
--- a/api/c/indigo/indigo.h
+++ b/api/c/indigo/indigo.h
@@ -751,6 +751,9 @@ CEXPORT int indigoUnselect(int item);
 // Access atoms and bonds
 CEXPORT int indigoIsSelected(int item);
 
+// Molecule or reaction
+CEXPORT int indigoHasSelection(int item);
+
 /* Connected components of molecules */
 
 CEXPORT int indigoCountComponents(int molecule);

--- a/api/c/indigo/src/indigo_calc.cpp
+++ b/api/c/indigo/src/indigo_calc.cpp
@@ -117,7 +117,7 @@ CEXPORT double indigoMolecularWeight(int molecule)
         MoleculeMass mass;
         auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
         mass.mass_options = self.mass_options;
-        return mass.molecularWeight(mol.asMolecule());
+        return mass.molecularWeight(mol);
     }
     INDIGO_END(-1);
 }
@@ -129,7 +129,7 @@ CEXPORT double indigoMostAbundantMass(int molecule)
         MoleculeMass mass;
         auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
         mass.mass_options = self.mass_options;
-        return mass.mostAbundantMass(mol.asMolecule());
+        return mass.mostAbundantMass(mol);
     }
     INDIGO_END(-1);
 }
@@ -141,7 +141,7 @@ CEXPORT double indigoMonoisotopicMass(int molecule)
         MoleculeMass mass;
         auto& mol = _indigoPrepareMass(self.getObject(molecule), mass);
         mass.mass_options = self.mass_options;
-        return mass.monoisotopicMass(mol.asMolecule());
+        return mass.monoisotopicMass(mol);
     }
     INDIGO_END(-1);
 }
@@ -155,7 +155,7 @@ CEXPORT const char* indigoMassComposition(int molecule)
         mass.mass_options = self.mass_options;
 
         auto& tmp = self.getThreadTmpData();
-        mass.massComposition(mol.asMolecule(), tmp.string);
+        mass.massComposition(mol, tmp.string);
 
         return tmp.string.ptr();
     }

--- a/api/c/indigo/src/indigo_calc.cpp
+++ b/api/c/indigo/src/indigo_calc.cpp
@@ -98,10 +98,6 @@ static BaseMolecule& _indigoPrepareMass(IndigoObject& obj, MoleculeMass mass)
     if (IndigoBaseMolecule::is(obj))
     {
         auto& mol = obj.getBaseMolecule();
-        if (mol.isQueryMolecule())
-        {
-            throw IndigoError("can not calculate mass for query molecule");
-        }
         return mol;
     }
     else

--- a/api/c/indigo/src/indigo_misc.cpp
+++ b/api/c/indigo/src/indigo_misc.cpp
@@ -1124,6 +1124,28 @@ CEXPORT int indigoIsSelected(int item)
     INDIGO_END(-1);
 }
 
+CEXPORT int indigoHasSelection(int item)
+{
+    INDIGO_BEGIN
+    {
+        IndigoObject& obj = self.getObject(item);
+
+        if (IndigoBaseMolecule::is(obj))
+        {
+            return obj.getBaseMolecule().hasSelection() ? 1 : 0;
+        }
+        else if (IndigoBaseReaction::is(obj))
+        {
+            return obj.getBaseReaction().hasSelection() ? 1 : 0;
+        }
+        else
+            throw IndigoError("indigoHasSelection(): expected molecule or reaction, got %s", obj.debugInfo());
+
+        return 1;
+    }
+    INDIGO_END(-1);
+}
+
 CEXPORT int indigoOptimize(int query, const char* options)
 {
     INDIGO_BEGIN

--- a/api/dotnet/src/IndigoLib.cs
+++ b/api/dotnet/src/IndigoLib.cs
@@ -895,6 +895,12 @@ namespace com.epam.indigo
         public static extern int indigoIsHighlighted(int item);
 
         [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
+        public static extern int indigoIsSelected(int item);
+
+        [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
+        public static extern int indigoHasSelection(int item);
+
+        [DllImport("indigo"), SuppressUnmanagedCodeSecurity]
         public static extern int indigoCountComponents(int molecule);
 
         [DllImport("indigo"), SuppressUnmanagedCodeSecurity]

--- a/api/dotnet/src/IndigoObject.cs
+++ b/api/dotnet/src/IndigoObject.cs
@@ -1401,6 +1401,18 @@ namespace com.epam.indigo
             return (dispatcher.checkResult(IndigoLib.indigoIsHighlighted(self)) == 1);
         }
 
+        public bool isSelected()
+        {
+            dispatcher.setSessionID();
+            return (dispatcher.checkResult(IndigoLib.indigoIsSelected(self)) == 1);
+        }
+
+        public bool hasSelection()
+        {
+            dispatcher.setSessionID();
+            return (dispatcher.checkResult(IndigoLib.indigoHasSelection(self)) == 1);
+        }
+
         public int countComponents()
         {
             dispatcher.setSessionID();

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoLib.java
@@ -674,6 +674,10 @@ public interface IndigoLib extends Library {
     int indigoUnhighlight(int item);
 
     int indigoIsHighlighted(int item);
+    
+    int indigoIsSelected(int item);
+
+    int indigoHasSelection(int item);
 
     int indigoCountComponents(int molecule);
 

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -821,6 +821,16 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
         return Indigo.checkResult(this, lib.indigoIsHighlighted(self)) == 1;
     }
 
+    public boolean isSelected() {
+        dispatcher.setSessionID();
+        return Indigo.checkResult(this, lib.indigoIsSelected(self)) == 1;
+    }
+
+    public boolean hasSelection() {
+        dispatcher.setSessionID();
+        return Indigo.checkResult(this, lib.indigoHasSelection(self)) == 1;
+    }
+
     public int countComponents() {
         dispatcher.setSessionID();
         return Indigo.checkResult(this, lib.indigoCountComponents(self));

--- a/api/python/indigo/indigo/indigo_lib.py
+++ b/api/python/indigo/indigo/indigo_lib.py
@@ -835,6 +835,10 @@ class IndigoLib:
         IndigoLib.lib.indigoUnhighlight.argtypes = [c_int]
         IndigoLib.lib.indigoIsHighlighted.restype = c_int
         IndigoLib.lib.indigoIsHighlighted.argtypes = [c_int]
+        IndigoLib.lib.indigoIsSelected.restype = c_int
+        IndigoLib.lib.indigoIsSelected.argtypes = [c_int]
+        IndigoLib.lib.indigoHasSelection.restype = c_int
+        IndigoLib.lib.indigoHasSelection.argtypes = [c_int]
         IndigoLib.lib.indigoCountComponents.restype = c_int
         IndigoLib.lib.indigoCountComponents.argtypes = [c_int]
         IndigoLib.lib.indigoComponentIndex.restype = c_int

--- a/api/python/indigo/indigo/indigo_object.py
+++ b/api/python/indigo/indigo/indigo_object.py
@@ -2980,6 +2980,28 @@ class IndigoObject:
             IndigoLib.checkResult(self._lib().indigoIsHighlighted(self.id))
         )
 
+    def isSelected(self):
+        """Atom or bond method returns True if selected
+
+        Returns:
+            bool: True if selected, False otherwise
+        """
+
+        return bool(
+            IndigoLib.checkResult(self._lib().indigoIsSelected(self.id))
+        )
+
+    def hasSelection(self):
+        """Molecule or reaction method returns True if has selection
+
+        Returns:
+            bool: True if has selection, False otherwise
+        """
+
+        return bool(
+            IndigoLib.checkResult(self._lib().indigoHasSelection(self.id))
+        )
+
     def countComponents(self):
         """Molecule method returns the number of components
 

--- a/api/wasm/indigo-ketcher/indigo-ketcher.cpp
+++ b/api/wasm/indigo-ketcher/indigo-ketcher.cpp
@@ -964,7 +964,7 @@ namespace indigo
         case IndigoKetcherObject::EKETMoleculeQuery:
         case IndigoKetcherObject::EKETMolecule:
             calculate_molecule(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream,
-                            indigoHasSelection(iko.id()));
+                               indigoHasSelection(iko.id()));
             break;
         case IndigoKetcherObject::EKETReactionQuery:
         case IndigoKetcherObject::EKETReaction:

--- a/api/wasm/indigo-ketcher/indigo-ketcher.cpp
+++ b/api/wasm/indigo-ketcher/indigo-ketcher.cpp
@@ -719,33 +719,6 @@ namespace indigo
         return iko.toString(options, outputFormat.size() ? outputFormat : "ket");
     }
 
-    void qmol2mol(IndigoKetcherObject& iko, const std::set<int>& selected_set)
-    {
-        IndigoObject qc(_checkResult(indigoClone(iko.id()))); // create query copy
-        const auto atoms_iterator = IndigoObject(_checkResult(indigoIterateAtoms(qc.id)));
-        while (const auto atom_id = _checkResult(indigoNext(atoms_iterator.id)))
-        {
-            int aix = _checkResult(indigoIndex(atom_id));
-            if (selected_set.size() && selected_set.find(aix) == selected_set.end())
-                _checkResult(indigoResetAtom(atom_id, "C")); // replace not selected atoms with C
-        }
-
-        const auto bonds_iterator = IndigoObject(_checkResult(indigoIterateBonds(qc.id)));
-        while (const auto bond_id = _checkResult(indigoNext(bonds_iterator.id)))
-        {
-            int bix = _checkResult(indigoIndex(bond_id));
-            const auto beg = _checkResult(indigoIndex(_checkResult(indigoSource(bond_id))));
-            const auto end = _checkResult(indigoIndex(_checkResult(indigoDestination(bond_id))));
-            if (selected_set.size() && selected_set.find(beg) == selected_set.end() && selected_set.find(end) == selected_set.end())
-                _checkResult(indigoRemoveBonds(qc.id, 1, &bix));
-        }
-
-        auto mid = indigoLoadMoleculeFromString(indigoMolfile(qc.id));
-        if (mid < 0)
-            jsThrow("Cannot calculate properties for structures with query features!");
-        iko.set(mid, IndigoKetcherObject::EKETMolecule);
-    }
-
     class VectorStringSemicoloned
     {
         const std::vector<std::string>& vec;
@@ -832,14 +805,8 @@ namespace indigo
 
     void calculate_molecule(IndigoKetcherObject iko, std::stringstream& molecularWeightStream, std::stringstream& mostAbundantMassStream,
                             std::stringstream& monoisotopicMassStream, std::stringstream& massCompositionStream, std::stringstream& grossFormulaStream,
-                            const std::vector<int>& selected_atoms)
+                            bool has_selection)
     {
-
-        const std::set<int> selected_set(selected_atoms.begin(), selected_atoms.end());
-
-        if (iko.objtype == IndigoKetcherObject::EKETMoleculeQuery)
-            qmol2mol(iko, selected_set);
-
         const auto componentsCount = _checkResult(indigoCountComponents(iko.id()));
 
         if (indigoCountRGroups(iko.id()) || indigoCountAttachmentPoints(iko.id()))
@@ -849,40 +816,25 @@ namespace indigo
 
         for (auto i = 0; i < componentsCount; i++)
         {
-            const auto component = IndigoObject(_checkResult(indigoComponent(iko.id(), i)));
-            std::vector<int> component_atoms;
-            const auto component_atoms_iterator = IndigoObject(_checkResult(indigoIterateAtoms(component.id)));
-            indigoUnselect(iko.id());
-            while (const auto atom_id = _checkResult(indigoNext(component_atoms_iterator.id)))
-            {
-                const auto atom = IndigoObject(atom_id);
-                int aix = _checkResult(indigoIndex(atom.id));
-                if (selected_set.size() && selected_set.find(aix) == selected_set.end())
-                    continue;
-                component_atoms.push_back(aix);
-                indigoSelect(atom_id);
-            }
+            auto& component = IndigoObject(_checkResult(indigoComponent(iko.id(), i)));
+            if (has_selection && !indigoHasSelection(component))
+                continue;
+            pushDoubleAsStr(indigoMolecularWeight(component.id()), molWeights);
+            pushDoubleAsStr(indigoMostAbundantMass(component.id()), mamMasses);
+            pushDoubleAsStr(indigoMonoisotopicMass(component.id()), misoMasses);
 
-            if (component_atoms.size())
-            {
+            const auto* massComposition = indigoMassComposition(component.id());
+            if (massComposition == nullptr)
+                massCompositions.push_back(indigoGetLastError());
+            else
+                massCompositions.push_back(std::string(massComposition));
 
-                pushDoubleAsStr(indigoMolecularWeight(iko.id()), molWeights);
-                pushDoubleAsStr(indigoMostAbundantMass(iko.id()), mamMasses);
-                pushDoubleAsStr(indigoMonoisotopicMass(iko.id()), misoMasses);
-
-                const auto* massComposition = indigoMassComposition(iko.id());
-                if (massComposition == nullptr)
-                    massCompositions.push_back(indigoGetLastError());
-                else
-                    massCompositions.push_back(std::string(massComposition));
-
-                const auto grossFormulaObject = IndigoObject(_checkResult(indigoGrossFormula(iko.id())));
-                const auto* grossFormula = indigoToString(grossFormulaObject.id);
-                if (grossFormula == nullptr)
-                    grossFormulas.push_back(indigoGetLastError());
-                else
-                    grossFormulas.push_back(std::string(grossFormula));
-            }
+            const auto grossFormulaObject = IndigoObject(_checkResult(indigoGrossFormula(component.id())));
+            const auto* grossFormula = indigoToString(grossFormulaObject.id);
+            if (grossFormula == nullptr)
+                grossFormulas.push_back(indigoGetLastError());
+            else
+                grossFormulas.push_back(std::string(grossFormula));
         }
 
         molecularWeightStream << VectorStringSemicoloned(molWeights);
@@ -894,43 +846,29 @@ namespace indigo
 
     void calculate_iteration_object(const IndigoObject& iterator, std::vector<std::string>& molWeights, std::vector<std::string>& mamMasses,
                                     std::vector<std::string>& misoMasses, std::vector<std::string>& massCompositions, std::vector<std::string>& grossFormulas,
-                                    const std::vector<int>& selected_atoms, int& base)
+                                    bool has_selection)
     {
         while (const auto id = _checkResult(indigoNext(iterator.id)))
         {
             auto mol = IndigoKetcherObject(id, _checkResult(indigoCheckQuery(id)) ? IndigoKetcherObject::EKETMoleculeQuery : IndigoKetcherObject::EKETMolecule);
-            std::vector<int> subselect;
-            if (selected_atoms.size())
-            {
-                for (int i = 0; i < selected_atoms.size(); ++i)
-                {
-                    int atom_id = selected_atoms[i] - base;
-                    if (atom_id >= 0)
-                        subselect.push_back(atom_id);
-                }
-            }
+            if (has_selection && !indigoHasSelection(mol))
+                continue;
 
-            if (!selected_atoms.size() || subselect.size())
+            std::stringstream mws, mams, misos, mcs, gfs;
+            calculate_molecule(mol, mws, mams, misos, mcs, gfs, has_selection);
+            if (gfs.str().size()) // If we have a gross formula, we also have everything else
             {
-                std::stringstream mws, mams, misos, mcs, gfs;
-                calculate_molecule(mol, mws, mams, misos, mcs, gfs, subselect);
-                if (gfs.str().size()) // If we have a gross formula, we also have everything else
-                {
-                    molWeights.push_back(mws.str());
-                    mamMasses.push_back(mams.str());
-                    misoMasses.push_back(misos.str());
-                    massCompositions.push_back(mcs.str());
-                    grossFormulas.push_back(gfs.str());
-                }
+                molWeights.push_back(mws.str());
+                mamMasses.push_back(mams.str());
+                misoMasses.push_back(misos.str());
+                massCompositions.push_back(mcs.str());
+                grossFormulas.push_back(gfs.str());
             }
-            if (selected_atoms.size())
-                base += indigoCountAtoms(id);
         }
     }
 
     void calculate_reaction(const IndigoKetcherObject& iko, std::stringstream& molecularWeightStream, std::stringstream& mostAbundantMassStream,
-                            std::stringstream& monoisotopicMassStream, std::stringstream& massCompositionStream, std::stringstream& grossFormulaStream,
-                            const std::vector<int>& selected_atoms)
+                            std::stringstream& monoisotopicMassStream, std::stringstream& massCompositionStream, std::stringstream& grossFormulaStream)
     {
         enum
         {
@@ -939,6 +877,7 @@ namespace indigo
             IDX_UNDEFINED = 2
         };
         std::vector<std::string> molWeights[3], mamMasses[3], misoMasses[3], massCompositions[3], grossFormulas[3];
+        bool has_selection = indigoHasSelection(iko);
 
         const auto mol_iterator = IndigoObject(_checkResult(indigoIterateMolecules(iko.id())));
         while (const auto mol_id = _checkResult(indigoNext(mol_iterator.id)))
@@ -950,10 +889,10 @@ namespace indigo
         if (_checkResult(indigoCountReactants(iko.id())) || _checkResult(indigoCountProducts(iko.id())))
         {
             calculate_iteration_object(IndigoObject(_checkResult(indigoIterateReactants(iko.id()))), molWeights[IDX_REACTANTS], mamMasses[IDX_REACTANTS],
-                                       misoMasses[IDX_REACTANTS], massCompositions[IDX_REACTANTS], grossFormulas[IDX_REACTANTS], selected_atoms, base);
+                                       misoMasses[IDX_REACTANTS], massCompositions[IDX_REACTANTS], grossFormulas[IDX_REACTANTS], has_selection);
 
             calculate_iteration_object(IndigoObject(_checkResult(indigoIterateProducts(iko.id()))), molWeights[IDX_PRODUCTS], mamMasses[IDX_PRODUCTS],
-                                       misoMasses[IDX_PRODUCTS], massCompositions[IDX_PRODUCTS], grossFormulas[IDX_PRODUCTS], selected_atoms, base);
+                                       misoMasses[IDX_PRODUCTS], massCompositions[IDX_PRODUCTS], grossFormulas[IDX_PRODUCTS], has_selection);
 
             molecularWeightStream << VectorStringBracketed(molWeights[IDX_REACTANTS], molWeights[IDX_PRODUCTS]);
             mostAbundantMassStream << VectorStringBracketed(mamMasses[IDX_REACTANTS], mamMasses[IDX_PRODUCTS]);
@@ -964,7 +903,7 @@ namespace indigo
         else
         {
             calculate_iteration_object(IndigoObject(_checkResult(indigoIterateMolecules(iko.id()))), molWeights[IDX_UNDEFINED], mamMasses[IDX_UNDEFINED],
-                                       misoMasses[IDX_UNDEFINED], massCompositions[IDX_UNDEFINED], grossFormulas[IDX_UNDEFINED], selected_atoms, base);
+                                       misoMasses[IDX_UNDEFINED], massCompositions[IDX_UNDEFINED], grossFormulas[IDX_UNDEFINED], has_selection);
 
             molecularWeightStream << VectorStringSemicoloned(molWeights[IDX_UNDEFINED]);
             mostAbundantMassStream << VectorStringSemicoloned(mamMasses[IDX_UNDEFINED]);
@@ -1025,12 +964,11 @@ namespace indigo
         case IndigoKetcherObject::EKETMoleculeQuery:
         case IndigoKetcherObject::EKETMolecule:
             calculate_molecule(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream,
-                               selected_atoms);
+                               indigoHasSelection(iko));
             break;
         case IndigoKetcherObject::EKETReactionQuery:
         case IndigoKetcherObject::EKETReaction:
-            calculate_reaction(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream,
-                               selected_atoms);
+            calculate_reaction(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream);
             break;
         }
         result.AddMember("molecular-weight", molecularWeightStream.str(), allocator);

--- a/api/wasm/indigo-ketcher/indigo-ketcher.cpp
+++ b/api/wasm/indigo-ketcher/indigo-ketcher.cpp
@@ -816,20 +816,20 @@ namespace indigo
 
         for (auto i = 0; i < componentsCount; i++)
         {
-            auto& component = IndigoObject(_checkResult(indigoComponent(iko.id(), i)));
-            if (has_selection && !indigoHasSelection(component.id()))
+            auto component = IndigoObject(indigoClone(_checkResult(indigoComponent(iko.id(), i))));
+            if (has_selection && !indigoHasSelection(component.id))
                 continue;
-            pushDoubleAsStr(indigoMolecularWeight(component.id()), molWeights);
-            pushDoubleAsStr(indigoMostAbundantMass(component.id()), mamMasses);
-            pushDoubleAsStr(indigoMonoisotopicMass(component.id()), misoMasses);
+            pushDoubleAsStr(indigoMolecularWeight(component.id), molWeights);
+            pushDoubleAsStr(indigoMostAbundantMass(component.id), mamMasses);
+            pushDoubleAsStr(indigoMonoisotopicMass(component.id), misoMasses);
 
-            const auto* massComposition = indigoMassComposition(component.id());
+            const auto* massComposition = indigoMassComposition(component.id);
             if (massComposition == nullptr)
                 massCompositions.push_back(indigoGetLastError());
             else
                 massCompositions.push_back(std::string(massComposition));
 
-            const auto grossFormulaObject = IndigoObject(_checkResult(indigoGrossFormula(component.id())));
+            const auto grossFormulaObject = IndigoObject(_checkResult(indigoGrossFormula(component.id)));
             const auto* grossFormula = indigoToString(grossFormulaObject.id);
             if (grossFormula == nullptr)
                 grossFormulas.push_back(indigoGetLastError());
@@ -964,7 +964,7 @@ namespace indigo
         case IndigoKetcherObject::EKETMoleculeQuery:
         case IndigoKetcherObject::EKETMolecule:
             calculate_molecule(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream,
-                               indigoHasSelection(iko.id()));
+                            indigoHasSelection(iko.id()));
             break;
         case IndigoKetcherObject::EKETReactionQuery:
         case IndigoKetcherObject::EKETReaction:

--- a/api/wasm/indigo-ketcher/indigo-ketcher.cpp
+++ b/api/wasm/indigo-ketcher/indigo-ketcher.cpp
@@ -817,7 +817,7 @@ namespace indigo
         for (auto i = 0; i < componentsCount; i++)
         {
             auto& component = IndigoObject(_checkResult(indigoComponent(iko.id(), i)));
-            if (has_selection && !indigoHasSelection(component))
+            if (has_selection && !indigoHasSelection(component.id()))
                 continue;
             pushDoubleAsStr(indigoMolecularWeight(component.id()), molWeights);
             pushDoubleAsStr(indigoMostAbundantMass(component.id()), mamMasses);
@@ -851,7 +851,7 @@ namespace indigo
         while (const auto id = _checkResult(indigoNext(iterator.id)))
         {
             auto mol = IndigoKetcherObject(id, _checkResult(indigoCheckQuery(id)) ? IndigoKetcherObject::EKETMoleculeQuery : IndigoKetcherObject::EKETMolecule);
-            if (has_selection && !indigoHasSelection(mol))
+            if (has_selection && !indigoHasSelection(mol.id()))
                 continue;
 
             std::stringstream mws, mams, misos, mcs, gfs;
@@ -877,7 +877,7 @@ namespace indigo
             IDX_UNDEFINED = 2
         };
         std::vector<std::string> molWeights[3], mamMasses[3], misoMasses[3], massCompositions[3], grossFormulas[3];
-        bool has_selection = indigoHasSelection(iko);
+        bool has_selection = indigoHasSelection(iko.id());
 
         const auto mol_iterator = IndigoObject(_checkResult(indigoIterateMolecules(iko.id())));
         while (const auto mol_id = _checkResult(indigoNext(mol_iterator.id)))
@@ -964,7 +964,7 @@ namespace indigo
         case IndigoKetcherObject::EKETMoleculeQuery:
         case IndigoKetcherObject::EKETMolecule:
             calculate_molecule(iko, molecularWeightStream, mostAbundantMassStream, monoisotopicMassStream, massCompositionStream, grossFormulaStream,
-                               indigoHasSelection(iko));
+                               indigoHasSelection(iko.id()));
             break;
         case IndigoKetcherObject::EKETReactionQuery:
         case IndigoKetcherObject::EKETReaction:

--- a/api/wasm/indigo-ketcher/test/test.js
+++ b/api/wasm/indigo-ketcher/test/test.js
@@ -84,9 +84,12 @@ indigoModuleFn().then(indigo => {
         test("calculate", "selected", () => {
             let options = new indigo.MapStringString();
             selected = new indigo.VectorInt();
-            selected.push_back(1);
-            selected.push_back(2);
-            const values = JSON.parse(indigo.calculate("C.N.P.O", options, selected));
+            let ketfile = `{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},{"$ref":"mol3"}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[28,-21,0]}],"stereoFlagPosition":{"x":28,"y":20,"z":0}},
+"mol1":{"type":"molecule","atoms":[{"label":"N","location":[30,-21,0],"selected":true}],"stereoFlagPosition":{"x":30,"y":20,"z":0}},
+"mol2":{"type":"molecule","atoms":[{"label":"P","location":[28,-19,0],"selected":true}],"stereoFlagPosition":{"x":28,"y":18,"z":0}},
+"mol3":{"type":"molecule","atoms":[{"label":"O","location":[31,-19,0]}],"stereoFlagPosition":{"x":31,"y":18,"z":0}}}`
+            const values = JSON.parse(indigo.calculate(ketfile, options, selected));
             assert.equal(values['gross-formula'], "H3 N; H3 P");
             selected.delete();
             options.delete();
@@ -95,36 +98,13 @@ indigoModuleFn().then(indigo => {
         test("calculate", "complex", () => {
             let options = new indigo.MapStringString();
             selected = new indigo.VectorInt();
-            let molfile = `$RXN
-
-
-
-  1  1  0
-$MOL
-
-  Ketcher  3262115472D 1   1.00000     0.00000     0
-
-  5  4  0     0  0            999 V2000
-    2.3000   -4.4330    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    3.3000   -4.4330    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    2.8000   -3.5670    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    2.9000   -6.9001    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
-    2.9000   -5.9001    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
-  1  2  1  0     0  0
-  2  3  1  0     0  0
-  1  3  1  0     0  0
-  4  5  1  0     0  0
-M  END
-$MOL
-
-  Ketcher  3262115472D 1   1.00000     0.00000     0
-
-  1  0  0     0  0            999 V2000
-    6.3501   -4.1500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-M  END
-`
+            let ketfile1 = `{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":31,"y":-21,"z":0},{"x":34,"y":-21,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[29,-21,0]},{"label":"C","location":[30,-19,0]},{"label":"C","location":[30,-20,0]}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[0,2]}],"stereoFlagPosition":{"x":29,"y":17,"z":0}},
+"mol1":{"type":"molecule","atoms":[{"label":"S","location":[28,-22,0]},{"label":"S","location":[28,-20,0]}],"bonds":[{"type":1,"atoms":[0,1]}],"stereoFlagPosition":{"x":29,"y":20,"z":0}},
+"mol2":{"type":"molecule","atoms":[{"label":"C","location":[35,-21,0]}]}}`
             assert.deepStrictEqual(
-                JSON.parse(indigo.calculate(molfile, options, selected)),
+                JSON.parse(indigo.calculate(ketfile1, options, selected)),
                 {
                     "molecular-weight": "[42.0809991; 66.1360028] > [16.0429997]",
                     "most-abundant-mass": "[42.0469501; 65.9597914] > [16.0313001]",
@@ -134,9 +114,13 @@ M  END
                 }
             );
 
-            selected.push_back(5); // select CH4
+            let ketfile2 = `{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":31,"y":-21,"z":0},{"x":34,"y":-21,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[29,-21,0]},{"label":"C","location":[30,-19,0]},{"label":"C","location":[30,-20,0]}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[0,2]}],"stereoFlagPosition":{"x":29,"y":17,"z":0}},
+"mol1":{"type":"molecule","atoms":[{"label":"S","location":[28,-22,0]},{"label":"S","location":[28,-20,0]}],"bonds":[{"type":1,"atoms":[0,1]}],"stereoFlagPosition":{"x":29,"y":20,"z":0}},
+"mol2":{"type":"molecule","atoms":[{"label":"C","location":[35,-21,0],"selected": true}]}}`
             assert.deepStrictEqual(
-                JSON.parse(indigo.calculate(molfile, options, selected)),
+                JSON.parse(indigo.calculate(ketfile2, options, selected)),
                 {
                     "molecular-weight": "16.0429997",
                     "most-abundant-mass": "16.0313001",
@@ -146,16 +130,13 @@ M  END
                 }
             );
 
-            selected.delete();
-            selected = new indigo.VectorInt();
-
-            selected.push_back(0);
-            selected.push_back(1);
-            selected.push_back(2);
-            selected.push_back(3);
-            selected.push_back(4); // select two-components reagent
+            let ketfile3 = `{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":31,"y":-21,"z":0},{"x":34,"y":-21,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[29,-21,0],"selected": true},{"label":"C","location":[30,-19,0],"selected": true},{"label":"C","location":[30,-20,0],"selected": true}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[0,2]}],"stereoFlagPosition":{"x":29,"y":17,"z":0}},
+"mol1":{"type":"molecule","atoms":[{"label":"S","location":[28,-22,0],"selected": true},{"label":"S","location":[28,-20,0],"selected": true}],"bonds":[{"type":1,"atoms":[0,1]}],"stereoFlagPosition":{"x":29,"y":20,"z":0}},
+"mol2":{"type":"molecule","atoms":[{"label":"C","location":[35,-21,0]}]}}`
             assert.deepStrictEqual(
-                JSON.parse(indigo.calculate(molfile, options, selected)),
+                JSON.parse(indigo.calculate(ketfile3, options, selected)),
                 {
                     "molecular-weight": "42.0809991; 66.1360028",
                     "most-abundant-mass": "42.0469501; 65.9597914",
@@ -165,15 +146,14 @@ M  END
                 }
             );
 
-            selected.delete();
-            selected = new indigo.VectorInt();
-
-            selected.push_back(0);
-            selected.push_back(1);
-            selected.push_back(2);
-            selected.push_back(5); // select product and partial reagent
+            // select product and partial reagent
+            let ketfile4 = `{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":31,"y":-21,"z":0},{"x":34,"y":-21,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[29,-21,0],"selected": true},{"label":"C","location":[30,-19,0],"selected": true},{"label":"C","location":[30,-20,0],"selected": true}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[0,2]}],"stereoFlagPosition":{"x":29,"y":17,"z":0}},
+"mol1":{"type":"molecule","atoms":[{"label":"S","location":[28,-22,0]},{"label":"S","location":[28,-20,0]}],"bonds":[{"type":1,"atoms":[0,1]}],"stereoFlagPosition":{"x":29,"y":20,"z":0}},
+"mol2":{"type":"molecule","atoms":[{"label":"C","location":[35,-21,0],"selected": true}]}}`
             assert.deepStrictEqual(
-                JSON.parse(indigo.calculate(molfile, options, selected)),
+                JSON.parse(indigo.calculate(ketfile4, options, selected)),
                 {
                     "molecular-weight": "[42.0809991] > [16.0429997]",
                     "most-abundant-mass": "[42.0469501] > [16.0313001]",
@@ -1175,7 +1155,7 @@ M  END
             options.set('mass-skip-error-on-pseudoatoms', 'false');
             options.set('output-content-type', "application/json");
             options.set('smart-layout', 'true');
-            let ket = JSON.parse(indigo.layout(pathway, "ket", options)).struct;            
+            let ket = JSON.parse(indigo.layout(pathway, "ket", options)).struct;
             // fs.writeFileSync("pathway_layout.ket", ket);
             const ket_ref = fs.readFileSync("pathway_layout.ket");
             assert.equal(ket, ket_ref.toString().trim());
@@ -1191,7 +1171,7 @@ M  END
             let options = new indigo.MapStringString();
             options.set('json-saving-pretty', 'true');
             options.set('nac', '0.2');
-            let json = JSON.parse(indigo.calculateMacroProperties(double_dna, options)).properties;            
+            let json = JSON.parse(indigo.calculateMacroProperties(double_dna, options)).properties;
             // fs.writeFileSync("props_double_dna.json", json);
             const json_ref = fs.readFileSync("props_double_dna.json");
             assert.equal(json, json_ref.toString().trim());
@@ -1207,7 +1187,7 @@ M  END
             let options = new indigo.MapStringString();
             options.set('json-saving-pretty', 'true');
             options.set('nac', '0.2');
-            let json = JSON.parse(indigo.calculateMacroProperties(peptides_micro, options)).properties;            
+            let json = JSON.parse(indigo.calculateMacroProperties(peptides_micro, options)).properties;
             // fs.writeFileSync("props_peptides_micro.json", json);
             const json_ref = fs.readFileSync("props_peptides_micro.json");
             assert.equal(json, json_ref.toString().trim());
@@ -1223,7 +1203,7 @@ M  END
             let options = new indigo.MapStringString();
             options.set('json-saving-pretty', 'true');
             options.set('nac', '0.2');
-            let json = JSON.parse(indigo.calculateMacroProperties(peptides, options)).properties;            
+            let json = JSON.parse(indigo.calculateMacroProperties(peptides, options)).properties;
             // fs.writeFileSync("props_peptides.json", json);
             const json_ref = fs.readFileSync("props_peptides.json");
             assert.equal(json, json_ref.toString().trim());
@@ -1239,7 +1219,7 @@ M  END
             let options = new indigo.MapStringString();
             options.set('json-saving-pretty', 'true');
             options.set('nac', '0.2');
-            let json = JSON.parse(indigo.calculateMacroProperties(chems, options)).properties;            
+            let json = JSON.parse(indigo.calculateMacroProperties(chems, options)).properties;
             // fs.writeFileSync("props_chems.json", json);
             const json_ref = fs.readFileSync("props_chems.json");
             assert.equal(json, json_ref.toString().trim());
@@ -1254,7 +1234,7 @@ M  END
             const ket = fs.readFileSync("pathway.ket");
             let options = new indigo.MapStringString();
             options.set('molfile-saving-skip-date', 'true')
-            let sdf = indigo.convert(ket, "sdf", options);            
+            let sdf = indigo.convert(ket, "sdf", options);
             // fs.writeFileSync("pathway.sdf", sdf);
             const sdf_ref = fs.readFileSync("pathway.sdf");
             assert.equal(sdf, sdf_ref.toString());
@@ -1266,7 +1246,7 @@ M  END
     {
         test("calculate pka", "PKa", () => {
             let options = new indigo.MapStringString();
-            let pka = indigo.pka('C([C@@H](C(=O)O)N)S', options);            
+            let pka = indigo.pka('C([C@@H](C(=O)O)N)S', options);
             assert.equal(pka.toString(), '8.493334');
             options.delete();
             assert(true);
@@ -1276,7 +1256,7 @@ M  END
     {
         test("calculate pka values", "PKa", () => {
             let options = new indigo.MapStringString();
-            let pka = indigo.pkaValues('C([C@@H](C(=O)O)N)S', options);            
+            let pka = indigo.pkaValues('C([C@@H](C(=O)O)N)S', options);
             assert.equal(pka.toString(), '2.390000,8.493334,9.530001');
             options.delete();
             assert(true);
@@ -1286,7 +1266,7 @@ M  END
     {
         test("calculate LogP", "LogP", () => {
             let options = new indigo.MapStringString();
-            let pka = indigo.logp('C([C@@H](C(=O)O)N)S', options);            
+            let pka = indigo.logp('C([C@@H](C(=O)O)N)S', options);
             assert.equal(pka.toString(), '-0.671900');
             options.delete();
             assert(true);
@@ -1296,7 +1276,7 @@ M  END
     {
         test("molar refractivity", "molarRefractivity", () => {
             let options = new indigo.MapStringString();
-            let pka = indigo.molarRefractivity('C([C@@H](C(=O)O)N)S', options);            
+            let pka = indigo.molarRefractivity('C([C@@H](C(=O)O)N)S', options);
             assert.equal(pka.toString(), '29.464200');
             options.delete();
             assert(true);

--- a/core/indigo-core/molecule/base_molecule.h
+++ b/core/indigo-core/molecule/base_molecule.h
@@ -389,6 +389,8 @@ namespace indigo
         void setShowAtomCIP(const int atomIndex, const bool display);
         void setBondCIP(int bond_idx, CIPDesc cip);
 
+        bool restoreAromaticHydrogens(bool unambiguous_only = true);
+
         Vec3f& getAtomXyz(int idx);
         bool getMiddlePoint(int idx1, int idx2, Vec3f& vec);
 

--- a/core/indigo-core/molecule/molecule.h
+++ b/core/indigo-core/molecule/molecule.h
@@ -153,8 +153,6 @@ namespace indigo
 
         void invalidateAtom(int index, int mask) override;
 
-        bool restoreAromaticHydrogens(bool unambiguous_only = true);
-
         bool standardize(const StandardizeOptions& options);
 
         bool ionize(float ph, float ph_toll, const IonizeOptions& options);

--- a/core/indigo-core/molecule/molecule_mass.h
+++ b/core/indigo-core/molecule/molecule_mass.h
@@ -27,7 +27,7 @@
 namespace indigo
 {
 
-    class Molecule;
+    class BaseMolecule;
 
     // Molecular mass calculation
     class MoleculeMass
@@ -54,27 +54,27 @@ namespace indigo
         /* Mass of a molecule calculated using the average mass of each
          * element weighted for its natural isotopic abundance
          */
-        double molecularWeight(Molecule& mol);
+        double molecularWeight(BaseMolecule& mol);
 
         /* Mass of a molecule containing most likely
          * isotopic composition for a single random molecule.
          * Notes: in PubChem search engine it is called Exact Mass
          */
-        double mostAbundantMass(Molecule& mol);
+        double mostAbundantMass(BaseMolecule& mol);
 
         /* Mass of a molecule calculated using the mass of
          * the most abundant isotope of each element.
          * Notes: in Marvin it is called Exact Mass
          */
-        double monoisotopicMass(Molecule& mol);
+        double monoisotopicMass(BaseMolecule& mol);
 
         /* Sum of the mass numbers of all constituent atoms.
          */
-        int nominalMass(Molecule& mol);
+        int nominalMass(BaseMolecule& mol);
 
         /* Atom weight percentage like "C 77% H 13%"
          */
-        void massComposition(Molecule& molecule, Array<char>& str);
+        void massComposition(BaseMolecule& molecule, Array<char>& str);
     };
 
 } // namespace indigo

--- a/core/indigo-core/molecule/src/base_molecule.cpp
+++ b/core/indigo-core/molecule/src/base_molecule.cpp
@@ -29,6 +29,7 @@
 #include "molecule/ket_document.h"
 #include "molecule/ket_document_json_loader.h"
 #include "molecule/molecule_arom_match.h"
+#include "molecule/molecule_dearom.h"
 #include "molecule/molecule_exact_matcher.h"
 #include "molecule/molecule_exact_substructure_matcher.h"
 #include "molecule/molecule_inchi.h"
@@ -38,6 +39,7 @@
 #include "molecule/monomers_template_library.h"
 #include "molecule/query_molecule.h"
 #include "molecule/smiles_loader.h"
+
 
 #ifdef _MSC_VER
 #pragma warning(push, 4)
@@ -5883,6 +5885,11 @@ bool BaseMolecule::convertTemplateAtomsToSuperatoms(bool only_transformed)
         }
     }
     return modified;
+}
+
+bool BaseMolecule::restoreAromaticHydrogens(bool unambiguous_only)
+{
+    return MoleculeDearomatizer::restoreHydrogens(*this, unambiguous_only);
 }
 
 #ifdef _MSC_VER

--- a/core/indigo-core/molecule/src/base_molecule.cpp
+++ b/core/indigo-core/molecule/src/base_molecule.cpp
@@ -40,7 +40,6 @@
 #include "molecule/query_molecule.h"
 #include "molecule/smiles_loader.h"
 
-
 #ifdef _MSC_VER
 #pragma warning(push, 4)
 #pragma warning(error : 4100 4101 4189 4244 4456 4458 4715)

--- a/core/indigo-core/molecule/src/molecule.cpp
+++ b/core/indigo-core/molecule/src/molecule.cpp
@@ -1566,11 +1566,6 @@ void Molecule::invalidateAtom(int index, int mask)
     BaseMolecule::invalidateAtom(index, mask);
 }
 
-bool Molecule::restoreAromaticHydrogens(bool unambiguous_only)
-{
-    return MoleculeDearomatizer::restoreHydrogens(*this, unambiguous_only);
-}
-
 bool Molecule::standardize(const StandardizeOptions& options)
 {
     updateEditRevision();

--- a/core/indigo-core/molecule/src/molecule_gross_formula.cpp
+++ b/core/indigo-core/molecule/src/molecule_gross_formula.cpp
@@ -25,6 +25,7 @@
 #include "molecule/elements.h"
 #include "molecule/molecule.h"
 #include "molecule/molecule_gross_formula.h"
+#include "molecule/query_molecule.h"
 
 using namespace indigo;
 
@@ -132,10 +133,7 @@ std::unique_ptr<GROSS_UNITS> MoleculeGrossFormula::collect(BaseMolecule& mol, bo
     std::set<int> selected_atoms;
     mol.getAtomSelection(selected_atoms);
 
-    if (!mol.isQueryMolecule())
-    {
-        mol.asMolecule().restoreAromaticHydrogens();
-    }
+    mol.restoreAromaticHydrogens();
 
     std::unique_ptr<GROSS_UNITS> result = std::make_unique<GROSS_UNITS>();
     auto& gross = *result;
@@ -211,9 +209,13 @@ std::unique_ptr<GROSS_UNITS> MoleculeGrossFormula::collect(BaseMolecule& mol, bo
             else
                 *val += 1;
 
-            if (!mol.isQueryMolecule() && !mol.isRSite(filters[i][j]))
+            if (!mol.isRSite(filters[i][j]))
             {
-                int implicit_h = mol.asMolecule().getImplicitH_NoThrow(filters[i][j], -1);
+                int implicit_h = -1;
+                if (mol.isQueryMolecule())
+                    implicit_h = mol.asQueryMolecule().getImplicitH(filters[i][j], true);
+                else
+                    implicit_h = mol.asMolecule().getImplicitH_NoThrow(filters[i][j], -1);
 
                 if (implicit_h >= 0)
                 {

--- a/core/indigo-core/molecule/src/molecule_mass.cpp
+++ b/core/indigo-core/molecule/src/molecule_mass.cpp
@@ -32,7 +32,7 @@ MoleculeMass::MoleculeMass()
     relative_atomic_mass_map = nullptr;
 }
 
-double MoleculeMass::molecularWeight(Molecule& mol)
+double MoleculeMass::molecularWeight(BaseMolecule& mol)
 {
     std::set<int> selected_atoms;
     mol.getAtomSelection(selected_atoms);
@@ -87,7 +87,7 @@ double MoleculeMass::molecularWeight(Molecule& mol)
         }
 
         // Add hydrogens
-        impl_h += mol.getImplicitH_NoThrow(v, 0);
+        impl_h += mol.getImplicitH(v, true);
     }
 
     for (int i = ELEM_MIN; i < ELEM_MAX; i++)
@@ -116,7 +116,7 @@ static int _isotopesCmp(int i1, int i2, void* context)
     return 0;
 }
 
-double MoleculeMass::mostAbundantMass(Molecule& mol)
+double MoleculeMass::mostAbundantMass(BaseMolecule& mol)
 {
     std::set<int> selected_atoms;
     mol.getAtomSelection(selected_atoms);
@@ -152,7 +152,7 @@ double MoleculeMass::mostAbundantMass(Molecule& mol)
 
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
-        int impl_h = mol.getImplicitH(v);
+        int impl_h = mol.getImplicitH(v, false);
 
         if (isotope == 0)
             elements_counts[number]++;
@@ -215,7 +215,7 @@ double MoleculeMass::mostAbundantMass(Molecule& mol)
     return molmass;
 }
 
-double MoleculeMass::monoisotopicMass(Molecule& mol)
+double MoleculeMass::monoisotopicMass(BaseMolecule& mol)
 {
     std::set<int> selected_atoms;
     mol.getAtomSelection(selected_atoms);
@@ -248,7 +248,7 @@ double MoleculeMass::monoisotopicMass(Molecule& mol)
 
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
-        int impl_h = mol.getImplicitH(v);
+        int impl_h = mol.getImplicitH(v, false);
 
         if (isotope == 0)
             isotope = Element::getMostAbundantIsotope(number);
@@ -262,7 +262,7 @@ double MoleculeMass::monoisotopicMass(Molecule& mol)
     return molmass;
 }
 
-int MoleculeMass::nominalMass(Molecule& mol)
+int MoleculeMass::nominalMass(BaseMolecule& mol)
 {
     if (mol.sgroups.getSGroupCount(SGroup::SG_TYPE_SRU) > 0)
     {
@@ -280,7 +280,7 @@ int MoleculeMass::nominalMass(Molecule& mol)
 
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
-        int impl_h = mol.getImplicitH(v);
+        int impl_h = mol.getImplicitH(v, false);
 
         if (isotope == 0)
             molmass += Element::getDefaultIsotope(number);
@@ -317,7 +317,7 @@ int MoleculeMass::_cmp(_ElemCounter& ec1, _ElemCounter& ec2, void* /*context*/)
     return strncmp(Element::toString(ec1.elem), Element::toString(ec2.elem), 3);
 }
 
-void MoleculeMass::massComposition(Molecule& mol, Array<char>& str)
+void MoleculeMass::massComposition(BaseMolecule& mol, Array<char>& str)
 {
     std::set<int> selected_atoms;
     mol.getAtomSelection(selected_atoms);
@@ -352,7 +352,7 @@ void MoleculeMass::massComposition(Molecule& mol, Array<char>& str)
 
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
-        impl_h += mol.getImplicitH(v);
+        impl_h += mol.getImplicitH(v, false);
 
         if (isotope)
         {

--- a/core/indigo-core/molecule/src/molecule_mass.cpp
+++ b/core/indigo-core/molecule/src/molecule_mass.cpp
@@ -67,6 +67,8 @@ double MoleculeMass::molecularWeight(BaseMolecule& mol)
 
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
+        if (number < 0) // Query molecule unsure atom
+            continue;
 
         if (isotope == 0)
         {
@@ -153,6 +155,8 @@ double MoleculeMass::mostAbundantMass(BaseMolecule& mol)
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
         int impl_h = mol.getImplicitH(v, false);
+        if (number < 0) // Query molecule unsure atom
+            continue;
 
         if (isotope == 0)
             elements_counts[number]++;
@@ -249,6 +253,8 @@ double MoleculeMass::monoisotopicMass(BaseMolecule& mol)
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
         int impl_h = mol.getImplicitH(v, false);
+        if (number < 0) // Query molecule unsure atom
+            continue;
 
         if (isotope == 0)
             isotope = Element::getMostAbundantIsotope(number);
@@ -281,6 +287,8 @@ int MoleculeMass::nominalMass(BaseMolecule& mol)
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
         int impl_h = mol.getImplicitH(v, false);
+        if (number < 0) // Query molecule unsure atom
+            continue;
 
         if (isotope == 0)
             molmass += Element::getDefaultIsotope(number);
@@ -353,6 +361,8 @@ void MoleculeMass::massComposition(BaseMolecule& mol, Array<char>& str)
         int number = mol.getAtomNumber(v);
         int isotope = mol.getAtomIsotope(v);
         impl_h += mol.getImplicitH(v, false);
+        if (number < 0) // Query molecule unsure atom
+            continue;
 
         if (isotope)
         {

--- a/core/indigo-core/reaction/base_reaction.h
+++ b/core/indigo-core/reaction/base_reaction.h
@@ -372,6 +372,8 @@ namespace indigo
 
         KetDocument& getKetDocument();
 
+        bool hasSelection();
+
         DECL_ERROR;
 
     protected:

--- a/core/indigo-core/reaction/src/base_reaction.cpp
+++ b/core/indigo-core/reaction/src/base_reaction.cpp
@@ -258,6 +258,14 @@ bool BaseReaction::haveCoord(BaseReaction& reaction)
     return true;
 }
 
+bool BaseReaction::hasSelection()
+{
+    for (int i = begin(); i < end(); i = next(i))
+        if (getBaseMolecule(i).hasSelection())
+            return true;
+    return false;
+}
+
 int BaseReaction::_nextElement(int type, int index)
 {
     if (index == -1)

--- a/utils/indigo-service/backend/service/tests/api/indigo_test.py
+++ b/utils/indigo-service/backend/service/tests/api/indigo_test.py
@@ -2398,13 +2398,13 @@ M  END
                 self.assertEqual(result_json.text, ref_json)
 
     def test_calculate_selected(self):
+        ketdata = """{"root":{"nodes":[{"$ref":"mol0"}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[9,7,0],"selected":true},{"label":"C","location":[9,6,0]}],"bonds":[{"type":1,"atoms":[0,1]}]}}"""
         headers, data = self.get_headers(
             {
-                "struct": "CC",
-                "input_format": "chemical/x-mdl-molfile",
-                "selected": [
-                    0,
-                ],
+                "struct": ketdata,
+                "input_format": "chemical/x-indigo-ket",
+                "selected": [],
                 "properties": (
                     "molecular-weight",
                     "gross",
@@ -2422,10 +2422,14 @@ M  END
         self.assertEqual("C 79.89 H 20.11", result_data["mass-composition"])
 
     def test_calculate_selected_benzene(self):
+        ketdata = """{"root":{"nodes":[{"$ref":"mol0"}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[8,7,0],"selected":true},{"label":"N","location":[7,7,0]},{"label":"C","location":[8,6,0],"selected":true},
+{"label":"C","location":[9,6,0],"selected":true},{"label":"C","location":[10,7,0],"selected":true},{"label":"C","location":[9,8,0],"selected":true},{"label":"C","location":[8,8,0],"selected":true}],
+"bonds":[{"type":1,"atoms":[0,1]},{"type":2,"atoms":[0,2]},{"type":1,"atoms":[2,3]},{"type":2,"atoms":[3,4]},{"type":1,"atoms":[4,5]},{"type":2,"atoms":[5,6]},{"type":1,"atoms":[6,0]}]}}"""
         headers, data = self.get_headers(
             {
-                "struct": "C1(N)=CC=CC=C1",
-                "selected": [0, 2, 3, 4, 5, 6],
+                "struct": ketdata,
+                "selected": [],
                 "properties": [
                     "molecular-weight",
                     "most-abundant-mass",
@@ -2447,12 +2451,7 @@ M  END
     def test_calculate_empty(self):
         headers, data = self.get_headers(
             {
-                "struct": """
-  Ketcher 10211616132D 1   1.00000     0.00000     0
-
-  0  0  0     0  0            999 V2000
-M  END
-""",
+                "struct": """{"root":{"nodes":[],"connections":[],"templates":[]}}""",
                 "properties": [
                     "molecular-weight",
                     "most-abundant-mass",
@@ -2476,7 +2475,10 @@ M  END
     def test_calculate_selected_benzene_2(self):
         headers, data = self.get_headers(
             {
-                "struct": "C1=CC=CC=C1",
+                "struct": """{"root":{"nodes":[{"$ref":"mol0"}],"connections":[],"templates":[]},"mol0":{"type":"molecule","atoms":[
+{"label":"C","location":[0,1,0],"selected":true},{"label":"C","location":[1,2,0]},{"label":"C","location":[2,2,0]},
+{"label":"C","location":[3,1,0]},{"label":"C","location":[2,0,0]},{"label":"C","location":[1,0,0]}],
+"bonds":[{"type":2,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":2,"atoms":[2,3]},{"type":1,"atoms":[3,4]},{"type":2,"atoms":[4,5]},{"type":1,"atoms":[5,0]}]}}""",
                 "properties": [
                     "molecular-weight",
                     "most-abundant-mass",
@@ -2484,9 +2486,7 @@ M  END
                     "gross",
                     "mass-composition",
                 ],
-                "selected": [
-                    0,
-                ],
+                "selected": [],
             }
         )
         result = requests.post(
@@ -2528,39 +2528,15 @@ M  END
         )
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["gross"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["molecular-weight"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["most-abundant-mass"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["monoisotopic-mass"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["mass-composition"],
-        )
+        self.assertEqual("C2 H3", result_data["gross"])
+        self.assertEqual("27.0459994", result_data["molecular-weight"])
+        self.assertEqual("27.0454744", result_data["most-abundant-mass"])
+        self.assertEqual("27.0454744", result_data["monoisotopic-mass"])
+        self.assertEqual("C 88.82 H 11.18", result_data["mass-composition"])
 
     def test_calculate_query_mol_selected(self):
-        mol = """
-  Ketcher 11081614252D 1   1.00000     0.00000     0
-
-  3  2  0     0  0            999 V2000
-    6.4500   -4.5500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    7.4500   -4.5500    0.0000 Q   0  0  0  0  0  0  0  0  0  0  0  0
-    7.9500   -5.4160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  1  2  8  0     0  0
-  2  3  1  0     0  0
-M  END
-"""
+        mol = """{"root":{"nodes":[{"$ref":"mol0"}],"connections":[],"templates":[]},"mol0":{"type":"molecule","atoms":[
+{"label":"C","location":[0,0,0],"selected":true},{"label":"Q","location":[1,0,0]},{"label":"C","location":[2,0,0]}],"bonds":[{"type":8,"atoms":[0,1]},{"type":1,"atoms":[1,2]}]}}"""
         headers, data = self.get_headers(
             {
                 "struct": mol,
@@ -2571,9 +2547,7 @@ M  END
                     "gross",
                     "mass-composition",
                 ],
-                "selected": [
-                    0,
-                ],
+                "selected": [],
             }
         )
         result = requests.post(
@@ -2581,26 +2555,14 @@ M  END
         )
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["gross"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["molecular-weight"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["most-abundant-mass"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["monoisotopic-mass"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["mass-composition"],
-        )
+        self.assertEqual("C", result_data["gross"])
+        self.assertEqual("12.0109997", result_data["molecular-weight"])
+        self.assertEqual("12.0109997", result_data["most-abundant-mass"])
+        self.assertEqual("12.0109997", result_data["monoisotopic-mass"])
+        self.assertEqual("C 100.00", result_data["mass-composition"])
+
+        mol = """{"root":{"nodes":[{"$ref":"mol0"}],"connections":[],"templates":[]},"mol0":{"type":"molecule","atoms":[
+{"label":"C","location":[0,0,0]},{"label":"Q","location":[1,0,0]},{"label":"C","location":[2,0,0],"selected":true}],"bonds":[{"type":8,"atoms":[0,1]},{"type":1,"atoms":[1,2]}]}}"""
         headers, data = self.get_headers(
             {
                 "struct": mol,
@@ -2611,9 +2573,7 @@ M  END
                     "gross",
                     "mass-composition",
                 ],
-                "selected": [
-                    2,
-                ],
+                "selected": [],
                 "options": {
                     "molfile-saving-add-mrv-sma": False,
                 },
@@ -2626,8 +2586,8 @@ M  END
         result_data = json.loads(result.text)
         self.assertEqual("C H3", result_data["gross"])
         self.assertEqual("15.0349997", result_data["molecular-weight"])
-        self.assertEqual("15.0234751", result_data["most-abundant-mass"])
-        self.assertEqual("15.0234751", result_data["monoisotopic-mass"])
+        self.assertEqual("15.0344747", result_data["most-abundant-mass"])
+        self.assertEqual("15.0344747", result_data["monoisotopic-mass"])
         self.assertEqual("C 79.89 H 20.11", result_data["mass-composition"])
 
     def test_calculate_query_rxn(self):
@@ -2676,58 +2636,26 @@ M  END
         )
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
+        self.assertEqual("[C2 H3] > [C2 H7 N]", result_data["gross"])
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["gross"],
+            "[27.0459994] > [45.0849994]", result_data["molecular-weight"]
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["molecular-weight"],
+            "[27.0454744] > [45.0837744]", result_data["most-abundant-mass"]
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["most-abundant-mass"],
+            "[27.0454744] > [45.0837744]", result_data["monoisotopic-mass"]
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
-            result_data["monoisotopic-mass"],
-        )
-        self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[C 88.82 H 11.18] > [C 53.28 H 15.65 N 31.07]",
             result_data["mass-composition"],
         )
 
     def test_calculate_query_rxn_selected(self):
-        rxn = """$RXN
-
-
-
-  1  1  0
-$MOL
-
-  Ketcher 11081614532D 1   1.00000     0.00000     0
-
-  3  2  0     0  0            999 V2000
-    0.0000    0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.8660   -0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    1.7321    0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  2  3  1  0     0  0
-  1  2  8  0     0  0
-M  END
-$MOL
-
-  Ketcher 11081614532D 1   1.00000     0.00000     0
-
-  4  3  0     0  0            999 V2000
-    7.7321    0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    8.5980   -0.2500    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
-    9.4641    0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   10.3301   -0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  1  2  1  0     0  0
-  2  3  1  0     0  0
-  3  4  1  0     0  0
-M  END
-"""
+        rxn = """{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":4,"y":3,"z":0},{"x":8,"y":3,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[2,4,0],"selected":true},{"label":"C","location":[2,3,0]},{"label":"C","location":[3,4,0]}],"bonds":[{"type":1,"atoms":[1,2]},{"type":8,"atoms":[0,1]}]},
+"mol1":{"type":"molecule","atoms":[{"label":"C","location":[9,4,0]},{"label":"N","location":[10,3,0]},{"label":"C","location":[11,4,0]},{"label":"C","location":[12,3,0]}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[2,3]}]}}"""
         headers, data = self.get_headers(
             {
                 "struct": rxn,
@@ -2738,9 +2666,7 @@ M  END
                     "gross",
                     "mass-composition",
                 ],
-                "selected": [
-                    0,
-                ],
+                "selected": [],
             }
         )
         result = requests.post(
@@ -2749,25 +2675,29 @@ M  END
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[C] > ",
             result_data["gross"],
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[12.0109997] > ",
             result_data["molecular-weight"],
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[12.0109997] > ",
             result_data["most-abundant-mass"],
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[12.0109997] > ",
             result_data["monoisotopic-mass"],
         )
         self.assertEqual(
-            "Cannot calculate properties for structures with query features",
+            "[C 100.00] > ",
             result_data["mass-composition"],
         )
+        rxn = """{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":4,"y":3,"z":0},{"x":8,"y":3,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[2,4,0]},{"label":"C","location":[2,3,0]},{"label":"C","location":[3,4,0],"selected":true}],"bonds":[{"type":1,"atoms":[1,2]},{"type":8,"atoms":[0,1]}]},
+"mol1":{"type":"molecule","atoms":[{"label":"C","location":[9,4,0]},{"label":"N","location":[10,3,0]},{"label":"C","location":[11,4,0]},{"label":"C","location":[12,3,0]}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[2,3]}]}}"""
         headers, data = self.get_headers(
             {
                 "struct": rxn,
@@ -2791,11 +2721,17 @@ M  END
         )
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
-        self.assertEqual("C H3", result_data["gross"])
-        self.assertEqual("15.0349997", result_data["molecular-weight"])
-        self.assertEqual("15.0234751", result_data["most-abundant-mass"])
-        self.assertEqual("15.0234751", result_data["monoisotopic-mass"])
-        self.assertEqual("C 79.89 H 20.11", result_data["mass-composition"])
+        self.assertEqual("[C H3] > ", result_data["gross"])
+        self.assertEqual("[15.0349997] > ", result_data["molecular-weight"])
+        self.assertEqual("[15.0344747] > ", result_data["most-abundant-mass"])
+        self.assertEqual("[15.0344747] > ", result_data["monoisotopic-mass"])
+        self.assertEqual(
+            "[C 79.89 H 20.11] > ", result_data["mass-composition"]
+        )
+        rxn = """{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":4,"y":3,"z":0},{"x":8,"y":3,"z":0}]}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[2,4,0]},{"label":"C","location":[2,3,0]},{"label":"C","location":[3,4,0],"selected":true}],"bonds":[{"type":1,"atoms":[1,2]},{"type":8,"atoms":[0,1]}]},
+"mol1":{"type":"molecule","atoms":[{"label":"C","location":[9,4,0],"selected":true},{"label":"N","location":[10,3,0],"selected":true},{"label":"C","location":[11,4,0],"selected":true},{"label":"C","location":[12,3,0]}],"bonds":[{"type":1,"atoms":[0,1]},{"type":1,"atoms":[1,2]},{"type":1,"atoms":[2,3]}]}}"""
         headers, data = self.get_headers(
             {
                 "struct": rxn,
@@ -2806,7 +2742,7 @@ M  END
                     "gross",
                     "mass-composition",
                 ],
-                "selected": [2, 3, 4, 5],
+                "selected": [],
                 "options": {
                     "molfile-saving-add-mrv-sma": False,
                 },
@@ -2817,27 +2753,28 @@ M  END
         )
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
-        self.assertEqual("C H3; C2 H6 N", result_data["gross"])
+        self.assertEqual("[C H3] > [C2 H6 N]", result_data["gross"])
         self.assertEqual(
-            "15.0349997; 44.0769994", result_data["molecular-weight"]
+            "[15.0349997] > [44.0769994]", result_data["molecular-weight"]
         )
         self.assertEqual(
-            "15.0234751; 44.0500238", result_data["most-abundant-mass"]
+            "[15.0344747] > [44.0759494]", result_data["most-abundant-mass"]
         )
         self.assertEqual(
-            "15.0234751; 44.0500238", result_data["monoisotopic-mass"]
+            "[15.0344747] > [44.0759494]", result_data["monoisotopic-mass"]
         )
         self.assertEqual(
-            "C 79.89 H 20.11; C 54.50 H 13.72 N 31.78",
+            "[C 79.89 H 20.11] > [C 54.50 H 13.72 N 31.78]",
             result_data["mass-composition"],
         )
 
     def test_calculate_selected_components_mol(self):
         headers, data = self.get_headers(
             {
-                "struct": "CC.CC",
-                "input_format": "chemical/x-mdl-molfile",
-                "selected": [0, 2, 3],
+                "struct": """{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[5,8,0],"selected":true},{"label":"C","location":[6,8,0]}],"bonds":[{"type":1,"atoms":[0,1]}]},
+"mol1":{"type":"molecule","atoms":[{"label":"C","location":[9,8,0],"selected":true},{"label":"C","location":[10,8,0],"selected":true}],"bonds":[{"type":1,"atoms":[0,1]}]}}""",
+                "input_format": "chemical/x-indigo-ket",
                 "properties": (
                     "molecular-weight",
                     "gross",
@@ -2861,9 +2798,14 @@ M  END
     def test_calculate_selected_components_rxn(self):
         headers, data = self.get_headers(
             {
-                "struct": "CC>>CC.CC",
-                "input_format": "chemical/x-mdl-rxnfile",
-                "selected": [0, 2, 3],
+                "struct": """{"root":{"nodes":[{"$ref":"mol0"},{"$ref":"mol1"},{"$ref":"mol2"},
+{"type":"arrow","data":{"mode":"open-angle","pos":[{"x":7,"y":8,"z":0},{"x":8,"y":8,"z":0}]}},
+{"type":"plus","location":[11,8,0],"prop":{}}],"connections":[],"templates":[]},
+"mol0":{"type":"molecule","atoms":[{"label":"C","location":[5,8,0],"selected":true},{"label":"C","location":[6,8,0]}],"bonds":[{"type":1,"atoms":[0,1]}]},
+"mol1":{"type":"molecule","atoms":[{"label":"C","location":[9,8,0],"selected":true},{"label":"C","location":[10,8,0],"selected":true}],"bonds":[{"type":1,"atoms":[0,1]}]},
+"mol2":{"type":"molecule","atoms":[{"label":"C","location":[12,8,0]},{"label":"C","location":[13,8,0]}],"bonds":[{"type":1,"atoms":[0,1]}]}}""",
+                "input_format": "chemical/x-indigo-ket",
+                "selected": [],
                 "properties": (
                     "molecular-weight",
                     "gross",
@@ -2877,11 +2819,12 @@ M  END
         self.assertEqual(200, result.status_code)
         result_data = json.loads(result.text)
         self.assertEqual(
-            "16.0429997; 30.0699995", result_data["molecular-weight"]
+            "[15.0349997] > [30.0699995]", result_data["molecular-weight"]
         )
-        self.assertEqual("C H4; C2 H6", result_data["gross"])
+        self.assertEqual("[C H3] > [C2 H6]", result_data["gross"])
         self.assertEqual(
-            "C 74.87 H 25.13; C 79.89 H 20.11", result_data["mass-composition"]
+            "[C 79.89 H 20.11] > [C 79.89 H 20.11]",
+            result_data["mass-composition"],
         )
 
     def test_convert_inchi_aux(self):

--- a/utils/indigo-service/backend/service/v2/indigo_api.py
+++ b/utils/indigo-service/backend/service/v2/indigo_api.py
@@ -207,24 +207,16 @@ def do_calc(m, func_name, precision):
 
 
 def molecule_calc(m, func_name, precision=None):
-    if m.dbgInternalType() == "#03: <query molecule>":
-        return "Cannot calculate properties for structures with query features"
-    if m.countRGroups() or m.countAttachmentPoints():
-        return "Cannot calculate properties for RGroups"
     results = []
     has_selection = m.hasSelection()
-    for c in m.iterateComponents():
+    for component in m.iterateComponents():
+        c = component.clone()
         if not has_selection or c.hasSelection():
             results.append(do_calc(c.clone(), func_name, precision))
     return "; ".join(results)
 
 
 def reaction_calc(rxn, func_name, precision=None):
-    if rxn.dbgInternalType() == "#05: <query reaction>":
-        return "Cannot calculate properties for structures with query features"
-    for m in rxn.iterateMolecules():
-        if m.countRGroups() or m.countAttachmentPoints():
-            return "Cannot calculate properties for RGroups"
     reactants_results = []
     has_selection = rxn.hasSelection()
     if rxn.countReactants() > 0 or rxn.countProducts() > 0:
@@ -1558,7 +1550,7 @@ def calculate():
         selected=data["selected"],
         indigo=indigo,
     )
-    if data.struct.hasSelection():
+    if md.struct.hasSelection():
         if md.is_rxn:
             remove_unselected_repeating_units_r(md.struct)
         else:

--- a/utils/indigo-service/backend/service/v2/indigo_api.py
+++ b/utils/indigo-service/backend/service/v2/indigo_api.py
@@ -196,14 +196,6 @@ def iterate_selected_submolecules(r, selected, indigo):
             yield m.getSubmolecule(moleculeAtoms).clone()
 
 
-def iterate_selected_components(m, selected):
-    for c in m.iterateComponents():
-        for atom in c.iterateAtoms():
-            if atom.index() in selected:
-                yield c
-                break
-
-
 def do_calc(m, func_name, precision):
     try:
         value = getattr(m, func_name)()
@@ -220,8 +212,10 @@ def molecule_calc(m, func_name, precision=None):
     if m.countRGroups() or m.countAttachmentPoints():
         return "Cannot calculate properties for RGroups"
     results = []
+    has_selection = m.hasSelection()
     for c in m.iterateComponents():
-        results.append(do_calc(c.clone(), func_name, precision))
+        if not has_selection or c.hasSelection():
+            results.append(do_calc(c.clone(), func_name, precision))
     return "; ".join(results)
 
 
@@ -232,87 +226,41 @@ def reaction_calc(rxn, func_name, precision=None):
         if m.countRGroups() or m.countAttachmentPoints():
             return "Cannot calculate properties for RGroups"
     reactants_results = []
+    has_selection = rxn.hasSelection()
     if rxn.countReactants() > 0 or rxn.countProducts() > 0:
         for r in rxn.iterateReactants():
-            reactants_results.append(
-                "[{0}]".format(molecule_calc(r, func_name, precision))
-            )
+            if not has_selection or r.hasSelection():
+                reactants_results.append(
+                    "[{0}]".format(molecule_calc(r, func_name, precision))
+                )
         product_results = []
         for p in rxn.iterateProducts():
-            product_results.append(
-                "[{0}]".format(molecule_calc(p, func_name, precision))
-            )
+            if not has_selection or p.hasSelection():
+                product_results.append(
+                    "[{0}]".format(molecule_calc(p, func_name, precision))
+                )
         return "{0} > {1}".format(
             " + ".join(reactants_results), " + ".join(product_results)
         )
     else:
         results = []
         for m in rxn.iterateMolecules():
-            results.append(do_calc(m, func_name, precision))
+            if not has_selection or m.hasSelection():
+                results.append(do_calc(m, func_name, precision))
         return "; ".join(results)
 
 
-def selected_molecule_calc(
-    m, selected, func_name, precision=None, indigo=None
-):
-    if m.dbgInternalType() == "#03: <query molecule>":
-        try:
-            m = qmol_to_mol(m, selected, indigo)
-        except IndigoException:
-            return "Cannot calculate properties for structures with query features"
-    if m.countRGroups() and max(selected) >= m.countAtoms():
-        return "Cannot calculate properties for RGroups"
-    try:
-        m = remove_implicit_h_in_selected_components(m, selected)
-    except ImplicitHCalcExpection as e:
-        return str(e.value)
-    results = []
-    for c in iterate_selected_components(m, selected):
-        cc = c.clone()
-        if cc.countRSites() or cc.countAttachmentPoints():
-            return "Cannot calculate properties for RGroups"
-        results.append(do_calc(cc, func_name, precision))
-    return "; ".join(results)
-
-
-def selected_reaction_calc(
-    r, selected, func_name, precision=None, indigo=None
-):
-    results = []
-    total_atoms_count = sum([m.countAtoms() for m in r.iterateMolecules()])
-    total_rgroups_count = sum([m.countRGroups() for m in r.iterateMolecules()])
-    if total_rgroups_count and max(selected) >= total_atoms_count:
-        return "Cannot calculate properties for RGroups"
-    try:
-        for csm in iterate_selected_submolecules(r, selected, indigo):
-            if csm.countRSites() or csm.countAttachmentPoints():
-                return "Cannot calculate properties for RGroups"
-            results.append(do_calc(csm, func_name, precision))
-    except ImplicitHCalcExpection as e:
-        return str(e.value)
-    except IndigoException:
-        return "Cannot calculate properties for structures with query features"
-    return "; ".join(results)
-
-
-def remove_unselected_repeating_units_m(m, selected):
+def remove_unselected_repeating_units_m(m):
     for ru in m.iterateRepeatingUnits():
         for atom in ru.iterateAtoms():
-            if atom.index() not in selected:
+            if not atom.isSelected():
                 ru.remove()
                 break
 
 
-def remove_unselected_repeating_units_r(r, selected):
-    atomCounter = 0
+def remove_unselected_repeating_units_r(r):
     for m in r.iterateMolecules():
-        moleculeAtoms = []
-        for atom in selected:
-            if atomCounter <= atom < atomCounter + m.countAtoms():
-                moleculeAtoms.append(atom - atomCounter)
-        atomCounter += m.countAtoms()
-        if moleculeAtoms:
-            remove_unselected_repeating_units_m(m, moleculeAtoms)
+        remove_unselected_repeating_units_m(m)
 
 
 def try_load_seq(indigo, md, molstr, library, seq_type):
@@ -1610,11 +1558,11 @@ def calculate():
         selected=data["selected"],
         indigo=indigo,
     )
-    if data["selected"]:
+    if data.struct.hasSelection():
         if md.is_rxn:
-            remove_unselected_repeating_units_r(md.struct, data["selected"])
+            remove_unselected_repeating_units_r(md.struct)
         else:
-            remove_unselected_repeating_units_m(md.struct, data["selected"])
+            remove_unselected_repeating_units_m(md.struct)
     calculate_properties = data["properties"]
     result = {}
     precision = data["precision"]
@@ -1627,31 +1575,13 @@ def calculate():
     }
     for p in calculate_properties:
         if md.is_rxn:
-            if data["selected"]:
-                result[p] = selected_reaction_calc(
-                    md.struct,
-                    data["selected"],
-                    func_name_dict[p],
-                    precision=precision,
-                    indigo=indigo,
-                )
-            else:
-                result[p] = reaction_calc(
-                    md.struct, func_name_dict[p], precision=precision
-                )
+            result[p] = reaction_calc(
+                md.struct, func_name_dict[p], precision=precision
+            )
         else:
-            if data["selected"]:
-                result[p] = selected_molecule_calc(
-                    md.struct,
-                    data["selected"],
-                    func_name_dict[p],
-                    precision=precision,
-                    indigo=indigo,
-                )
-            else:
-                result[p] = molecule_calc(
-                    md.struct, func_name_dict[p], precision=precision
-                )
+            result[p] = molecule_calc(
+                md.struct, func_name_dict[p], precision=precision
+            )
     if data["json_output"]:
         return jsonify(result), 200, {"Content-Type": "application/json"}
     else:


### PR DESCRIPTION
Remove selection indexes. Use "selected" in ket instead.


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
