### PR TITLE
#3065 Indigo build fails when trying to build indigo-depict

### DIFF
--- a/utils/indigo-depict/main.c
+++ b/utils/indigo-depict/main.c
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -869,7 +870,7 @@ int main(int argc, char* argv[])
     indigoSetOption("ignore-bad-valence", "on");
     indigoSetOption("molfile-saving-mode", "2000");
     indigoSetOption("ket-saving-version", "1.0.0");
-    indigoSetOptionBool("json-saving-pretty", "on");
+    indigoSetOptionBool("json-saving-pretty", true);
     indigoSetOptionFloat("reaction-component-margin-size", 0.0f);
 
     if (parseParams(&p, argc, argv) < 0)


### PR DESCRIPTION
Found a typo, IndigoSetOption awaits int, but receieves "on". This one wasn't catched by CI/CD pipelines, because it doesn't build depict.


## Remove-me-section
* Notify reviewers about the pull request
* Keep only necessary sections below for the review

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
### Optional
- [ ] unit-tests written
- [ ] documentation updated

## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes

## Bump request
- [ ] PR name follows the pattern `Bump version to ...`
- [ ] add brackets \[ \] for 'skip ci' and put it into the body
- [ ] milestone is linked to PR
- [ ] all tickets are closed inside the relevant milestone

