### PR TITLE
 #3061, #3062 - System can't recognize single rebose or phosphate if loaded from HELM

### DIFF
--- a/api/tests/integration/ref/formats/helm_to_ket.py.out
+++ b/api/tests/integration/ref/formats/helm_to_ket.py.out
@@ -2,6 +2,8 @@
 helm_2818.ket:SUCCEED
 helm_2826.ket:SUCCEED
 helm_alias.ket:SUCCEED
+helm_alias_ambiguous.ket:SUCCEED
+helm_alias_single_r_p.ket:SUCCEED
 helm_aminoacids_variants.ket:SUCCEED
 helm_annotations.ket:SUCCEED
 helm_any_chem.ket:SUCCEED

--- a/api/tests/integration/ref/formats/ket_to_helm.py.out
+++ b/api/tests/integration/ref/formats/ket_to_helm.py.out
@@ -1,5 +1,7 @@
 *** KET to HELM ***
 dna_variants.ket:SUCCEED
+helm_alias_ambiguous.ket:SUCCEED
+helm_alias_single_r_p.ket:SUCCEED
 helm_aminoacids_variants.ket:SUCCEED
 helm_annotations.ket:SUCCEED
 helm_any_chem.ket:SUCCEED

--- a/api/tests/integration/tests/formats/helm_to_ket.py
+++ b/api/tests/integration/tests/formats/helm_to_ket.py
@@ -55,6 +55,8 @@ helm_data = {
     "helm_unresolved_rna": "RNA1{Sugar1(Base1)Phos3.Rna1.Rna2}$$$$V2.0",
     "helm_only_base": "RNA1{(A)}$$$$V2.0",
     "helm_nucleosides": "RNA1{[5R6Rm5](A).[5R6Rm5](A).[5R6Rm5](A)}$$$$V2.0",
+    "helm_alias_single_r_p": "RNA1{r.p}$$$$V2.0",
+    "helm_alias_ambiguous": "RNA1{[Sm5moe]([m2nprn2A]+[nobn6pur]+[nC6n2G]+[nC6n8A])[mepo2]}$$$$V2.0",
 }
 
 lib = indigo.loadMonomerLibraryFromFile(

--- a/api/tests/integration/tests/formats/ket_to_helm.py
+++ b/api/tests/integration/tests/formats/ket_to_helm.py
@@ -44,7 +44,7 @@ helm_data = {
     "helm_cycled_polymer": "PEPTIDE1{A.C.D.E.F}$PEPTIDE1,PEPTIDE1,5:R2-1:R1$$$V2.0",
     "helm_mixed_base": "RNA1{d(A)p.d(A+G)p.d(A)p.d(G+C)}$$$$V2.0",
     "helm_mixed_custom": "RNA1{d(A:10+[Xan]:20+G:30+T:50)p.d(A:10+C:20+G:30+T:50)p.d(A+C+G+T)}$$$$V2.0",
-    "helm_aminoacids_variants": "PEPTIDE1{([Dha]+N).(L+I).(E+Q).(A+C+D+E+F+G+H+I+K+L+M+N+O+P+Q+R+S+T+U+V+W+Y)}$$$$V2.0",
+    "helm_aminoacids_variants": "PEPTIDE1{([Dha]+N).(L+I).(E+Q).(A+C+D+E+F+G+H+I+K+L+M+N+[Pyl]+P+Q+R+S+T+[seC]+V+W+Y)}$$$$V2.0",
     "dna_variants": "RNA1{d(C,G,T)p.d(A,C,G,T)}$$$$V2.0",
     "rna_variants": "RNA1{r(A,G)p.r(G,U)p.r(A,C,G,U)}$$$$V2.0",
     "helm_monomer_molecule": "PEPTIDE1{A}|PEPTIDE2{G}|CHEM1{[C(N[*:2])=C[*:1] |$;;_R2;;_R1$|]}$CHEM1,PEPTIDE1,1:R2-1:R1|PEPTIDE2,CHEM1,1:R2-1:R1$$$V2.0",
@@ -60,6 +60,8 @@ helm_data = {
     "helm_unresolved": "PEPTIDE1{[Unres1].[Unres2].([Unres1]+[Unres2]+[Unres3])}|RNA1{[Unres1]([Unres2])}$$$$V2.0",
     "helm_unresolved_rna": "RNA1{[Sugar1]([Base1])[Phos3].[Rna1].[Rna2]}$$$$V2.0",
     "helm_nucleosides": "RNA1{[5R6Rm5cEt](A).[5R6Rm5cEt](A).[5R6Rm5cEt](A)}$$$$V2.0",
+    "helm_alias_single_r_p": "RNA1{r.p}$$$$V2.0",
+    "helm_alias_ambiguous": "RNA1{[Sm5moe]([m2nprn2A]+[nobn6pur]+[nC6n2G]+[nC6n8A])[mepo2]}$$$$V2.0",
 }
 
 for filename in sorted(helm_data.keys()):

--- a/api/tests/integration/tests/formats/ref/helm_alias_ambiguous.ket
+++ b/api/tests/integration/tests/formats/ref/helm_alias_ambiguous.ket
@@ -1,0 +1,1928 @@
+{
+    "root": {
+        "nodes": [
+            {
+                "$ref": "monomer0"
+            },
+            {
+                "$ref": "ambiguousMonomer-1"
+            },
+            {
+                "$ref": "monomer2"
+            }
+        ],
+        "connections": [
+            {
+                "connectionType": "single",
+                "endpoint1": {
+                    "monomerId": "monomer0",
+                    "attachmentPointId": "R3"
+                },
+                "endpoint2": {
+                    "monomerId": "ambiguousMonomer-1",
+                    "attachmentPointId": "R1"
+                }
+            },
+            {
+                "connectionType": "single",
+                "endpoint1": {
+                    "monomerId": "monomer0",
+                    "attachmentPointId": "R2"
+                },
+                "endpoint2": {
+                    "monomerId": "monomer2",
+                    "attachmentPointId": "R1"
+                }
+            }
+        ],
+        "templates": [
+            {
+                "$ref": "monomerTemplate-Sm5moe___(5S)-Methyl-2O-MOE"
+            },
+            {
+                "$ref": "monomerTemplate-m2nprn___N3-(dimethylamino)propylaminoadenine"
+            },
+            {
+                "$ref": "monomerTemplate-nobn6p___6-(p-Nitrobenzylthio)purine"
+            },
+            {
+                "$ref": "monomerTemplate-nC6n2G___6-Aminohexyl-2-aminoguanine"
+            },
+            {
+                "$ref": "monomerTemplate-nC6n8A___6-Aminohexyl-8-aminoadenine"
+            },
+            {
+                "$ref": "monomerTemplate-mepo2___Hydroxymethylphosphonic acid"
+            },
+            {
+                "$ref": "ambiguousMonomerTemplate-Var0"
+            }
+        ]
+    },
+    "monomer0": {
+        "type": "monomer",
+        "id": "0",
+        "seqid": 1,
+        "position": {
+            "x": 0.000000,
+            "y": -0.000000
+        },
+        "alias": "Sm5moe",
+        "templateId": "Sm5moe___(5S)-Methyl-2O-MOE"
+    },
+    "ambiguousMonomer-1": {
+        "type": "ambiguousMonomer",
+        "id": "1",
+        "position": {
+            "x": 0.000000,
+            "y": -1.500000
+        },
+        "seqid": 2,
+        "alias": "Var0",
+        "templateId": "Var0"
+    },
+    "monomer2": {
+        "type": "monomer",
+        "id": "2",
+        "seqid": 3,
+        "position": {
+            "x": 1.500000,
+            "y": -0.000000
+        },
+        "alias": "mepo2",
+        "templateId": "mepo2___Hydroxymethylphosphonic acid"
+    },
+    "monomerTemplate-Sm5moe___(5S)-Methyl-2O-MOE": {
+        "type": "monomerTemplate",
+        "id": "Sm5moe___(5S)-Methyl-2O-MOE",
+        "class": "Sugar",
+        "classHELM": "RNA",
+        "fullName": "(5S)-Methyl-2O-MOE",
+        "alias": "Sm5moe",
+        "naturalAnalogShort": "R",
+        "aliasHELM": "Sm5moe",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 9,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 6,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        7
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 3,
+                "type": "side",
+                "leavingGroup": {
+                    "atoms": [
+                        8
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    -1.708000,
+                    -0.052000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.821000,
+                    0.408000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.108000,
+                    -0.294000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.556000,
+                    -1.188000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.545000,
+                    -1.039000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -2.600000,
+                    0.397000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.673000,
+                    1.396000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    0.257000,
+                    1.763000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -0.096000,
+                    -2.076000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -2.658000,
+                    1.396000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -3.551000,
+                    1.845000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.877000,
+                    -0.129000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.228000,
+                    0.808000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.215000,
+                    0.973000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.564000,
+                    1.910000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    3.551000,
+                    2.076000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.436000,
+                    -0.152000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    4
+                ],
+                "stereo": 6
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    5
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    6
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    11
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    8
+                ],
+                "stereo": 6
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    9,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    11,
+                    12
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    12,
+                    13
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    13,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    14,
+                    15
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    16
+                ],
+                "stereo": 6
+            }
+        ]
+    },
+    "monomerTemplate-m2nprn___N3-(dimethylamino)propylaminoadenine": {
+        "type": "monomerTemplate",
+        "id": "m2nprn___N3-(dimethylamino)propylaminoadenine",
+        "class": "Base",
+        "classHELM": "RNA",
+        "fullName": "N3-(dimethylamino)propylaminoadenine",
+        "alias": "m2nprn",
+        "naturalAnalogShort": "A",
+        "aliasHELM": "m2nprn2A",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 10,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        15
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    0.769000,
+                    0.500000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.635000,
+                    1.002000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.633000,
+                    2.002000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    2.499000,
+                    2.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.095000,
+                    -2.003000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.095000,
+                    -1.003000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.961000,
+                    -0.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -1.827000,
+                    -1.003000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -1.827000,
+                    -2.003000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.961000,
+                    -2.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -2.778000,
+                    -0.694000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.365000,
+                    -1.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -2.778000,
+                    -2.313000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -0.961000,
+                    -3.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    0.770000,
+                    -0.502000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -3.086000,
+                    0.256000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.497000,
+                    3.503000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    3.365000,
+                    2.006000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    5
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    7,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    9
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    4,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    10,
+                    11
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    11,
+                    12
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    12
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    9,
+                    13
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    10,
+                    15
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    16
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    17
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-nobn6p___6-(p-Nitrobenzylthio)purine": {
+        "type": "monomerTemplate",
+        "id": "nobn6p___6-(p-Nitrobenzylthio)purine",
+        "class": "Base",
+        "classHELM": "RNA",
+        "fullName": "6-(p-Nitrobenzylthio)purine",
+        "alias": "nobn6p",
+        "naturalAnalogShort": "X",
+        "aliasHELM": "nobn6pur",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 8,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        9
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "N",
+                "location": [
+                    -3.384000,
+                    -0.962000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -2.641000,
+                    -1.632000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.690000,
+                    -1.324000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.176000,
+                    0.015000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -2.225000,
+                    0.324000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -1.482000,
+                    -0.346000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -2.225000,
+                    1.323000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.176000,
+                    1.632000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -3.763000,
+                    0.823000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -4.763000,
+                    0.823000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "S",
+                "location": [
+                    -0.529000,
+                    -0.038000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.213000,
+                    -0.709000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.165000,
+                    -0.402000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.909000,
+                    -1.071000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.861000,
+                    -0.762000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.373000,
+                    0.576000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.325000,
+                    0.885000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    3.068000,
+                    0.216000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    4.020000,
+                    0.523000,
+                    0.000000
+                ],
+                "charge": 1
+            },
+            {
+                "label": "O",
+                "location": [
+                    4.231000,
+                    1.501000,
+                    0.000000
+                ],
+                "charge": -1
+            },
+            {
+                "label": "O",
+                "location": [
+                    4.763000,
+                    -0.147000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    3
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    5
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    5,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    6
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    10,
+                    11
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    11,
+                    12
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    12,
+                    13
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    13,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    12,
+                    15
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    15,
+                    16
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    16,
+                    17
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    17,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    17,
+                    18
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    18,
+                    19
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    18,
+                    20
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-nC6n2G___6-Aminohexyl-2-aminoguanine": {
+        "type": "monomerTemplate",
+        "id": "nC6n2G___6-Aminohexyl-2-aminoguanine",
+        "class": "Base",
+        "classHELM": "RNA",
+        "fullName": "6-Aminohexyl-2-aminoguanine",
+        "alias": "nC6n2G",
+        "naturalAnalogShort": "G",
+        "aliasHELM": "nC6n2G",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 4,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        10
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 20,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        12
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 20,
+                "type": "side",
+                "leavingGroup": {
+                    "atoms": [
+                        13
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    -3.994000,
+                    -0.627000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.961000,
+                    0.374000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -4.900000,
+                    0.714000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -5.515000,
+                    -0.075000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -4.954000,
+                    -0.903000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -3.145000,
+                    -1.155000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -2.263000,
+                    -0.684000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -2.230000,
+                    0.316000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.079000,
+                    0.844000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -3.045000,
+                    1.844000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -5.295000,
+                    -1.844000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.413000,
+                    -1.211000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    5.515000,
+                    -1.430000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    4.698000,
+                    0.096000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.531000,
+                    -0.740000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.320000,
+                    -1.266000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.202000,
+                    -0.793000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.052000,
+                    -1.321000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.934000,
+                    -0.849000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    3.784000,
+                    -1.375000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    4.666000,
+                    -0.903000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    5
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    7,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    8,
+                    1
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    8,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    11
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    20,
+                    12
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    20,
+                    13
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    11,
+                    14
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    14,
+                    15
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    15,
+                    16
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    16,
+                    17
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    17,
+                    18
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    18,
+                    19
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    19,
+                    20
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-nC6n8A___6-Aminohexyl-8-aminoadenine": {
+        "type": "monomerTemplate",
+        "id": "nC6n8A___6-Aminohexyl-8-aminoadenine",
+        "class": "Base",
+        "classHELM": "RNA",
+        "fullName": "6-Aminohexyl-8-aminoadenine",
+        "alias": "nC6n8A",
+        "naturalAnalogShort": "A",
+        "aliasHELM": "nC6n8A",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 13,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        19
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 6,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        7
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 6,
+                "type": "side",
+                "leavingGroup": {
+                    "atoms": [
+                        8
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    -0.644000,
+                    -0.920000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.196000,
+                    -1.465000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.087000,
+                    -1.010000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.927000,
+                    -1.554000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    2.818000,
+                    -1.099000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    3.658000,
+                    -1.644000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    4.549000,
+                    -1.189000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    5.387000,
+                    -1.733000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    4.601000,
+                    -0.190000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.935000,
+                    -0.412000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.390000,
+                    0.427000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -2.425000,
+                    0.167000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -2.373000,
+                    -0.833000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -3.307000,
+                    -1.189000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -4.934000,
+                    -0.358000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -5.387000,
+                    0.533000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -4.841000,
+                    1.371000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -3.843000,
+                    1.318000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -3.297000,
+                    2.155000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -3.567000,
+                    -2.155000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "N",
+                "location": [
+                    -1.535000,
+                    -1.375000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 1,
+                "atoms": [
+                    20,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    5
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    5,
+                    6
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    7
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    9,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    10,
+                    11
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    11,
+                    12
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    12,
+                    13
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    13,
+                    9
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    9,
+                    14
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    14,
+                    15
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    15,
+                    16
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    16,
+                    17
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    17,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    17,
+                    18
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    13,
+                    19
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    12,
+                    20
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-mepo2___Hydroxymethylphosphonic acid": {
+        "type": "monomerTemplate",
+        "id": "mepo2___Hydroxymethylphosphonic acid",
+        "class": "Phosphate",
+        "classHELM": "RNA",
+        "fullName": "Hydroxymethylphosphonic acid",
+        "alias": "mepo2",
+        "naturalAnalogShort": "P",
+        "aliasHELM": "mepo2",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 0,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        5
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 1,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        2
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    -0.750000,
+                    0.000000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "P",
+                "location": [
+                    0.251000,
+                    0.000000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.750000,
+                    -0.866000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.751000,
+                    0.866000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.251000,
+                    0.000000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.251000,
+                    -0.865000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    2
+                ]
+            },
+            {
+                "type": 2,
+                "atoms": [
+                    1,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    5
+                ]
+            }
+        ]
+    },
+    "ambiguousMonomerTemplate-Var0": {
+        "type": "ambiguousMonomerTemplate",
+        "subtype": "mixture",
+        "id": "Var0",
+        "alias": "Var0",
+        "options": [
+            {
+                "templateId": "m2nprn___N3-(dimethylamino)propylaminoadenine"
+            },
+            {
+                "templateId": "nobn6p___6-(p-Nitrobenzylthio)purine"
+            },
+            {
+                "templateId": "nC6n2G___6-Aminohexyl-2-aminoguanine"
+            },
+            {
+                "templateId": "nC6n8A___6-Aminohexyl-8-aminoadenine"
+            }
+        ]
+    }
+}

--- a/api/tests/integration/tests/formats/ref/helm_alias_single_r_p.ket
+++ b/api/tests/integration/tests/formats/ref/helm_alias_single_r_p.ket
@@ -1,0 +1,388 @@
+{
+    "root": {
+        "nodes": [
+            {
+                "$ref": "monomer0"
+            },
+            {
+                "$ref": "monomer1"
+            }
+        ],
+        "connections": [
+            {
+                "connectionType": "single",
+                "endpoint1": {
+                    "monomerId": "monomer0",
+                    "attachmentPointId": "R2"
+                },
+                "endpoint2": {
+                    "monomerId": "monomer1",
+                    "attachmentPointId": "R1"
+                }
+            }
+        ],
+        "templates": [
+            {
+                "$ref": "monomerTemplate-R___Ribose"
+            },
+            {
+                "$ref": "monomerTemplate-P___Phosphate"
+            }
+        ]
+    },
+    "monomer0": {
+        "type": "monomer",
+        "id": "0",
+        "seqid": 1,
+        "position": {
+            "x": 0.000000,
+            "y": -0.000000
+        },
+        "alias": "r",
+        "templateId": "R___Ribose"
+    },
+    "monomer1": {
+        "type": "monomer",
+        "id": "1",
+        "seqid": 2,
+        "position": {
+            "x": 1.500000,
+            "y": -0.000000
+        },
+        "alias": "p",
+        "templateId": "P___Phosphate"
+    },
+    "monomerTemplate-R___Ribose": {
+        "type": "monomerTemplate",
+        "id": "R___Ribose",
+        "class": "Sugar",
+        "classHELM": "RNA",
+        "fullName": "Ribose",
+        "alias": "R",
+        "naturalAnalogShort": "R",
+        "aliasHELM": "r",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 10,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        11
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 6,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        8
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "type": "side",
+                "leavingGroup": {
+                    "atoms": [
+                        5
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "C",
+                "location": [
+                    1.499000,
+                    1.176000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    1.656000,
+                    0.188000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.765000,
+                    -0.266000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "C",
+                "location": [
+                    0.058000,
+                    0.441000,
+                    0.000000
+                ],
+                "stereoLabel": "abs"
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.512000,
+                    1.332000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.207000,
+                    1.883000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.608000,
+                    -1.254000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    2.547000,
+                    -0.266000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    1.386000,
+                    -1.883000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "C",
+                "location": [
+                    -0.930000,
+                    0.285000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.559000,
+                    1.062000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "H",
+                "location": [
+                    -2.547000,
+                    0.905000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    4
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    4,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    5
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    2,
+                    6
+                ],
+                "stereo": 6
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    1,
+                    7
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    6,
+                    8
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    3,
+                    9
+                ],
+                "stereo": 1
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    9,
+                    10
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    10,
+                    11
+                ]
+            }
+        ]
+    },
+    "monomerTemplate-P___Phosphate": {
+        "type": "monomerTemplate",
+        "id": "P___Phosphate",
+        "class": "Phosphate",
+        "classHELM": "RNA",
+        "fullName": "Phosphate",
+        "alias": "P",
+        "naturalAnalogShort": "P",
+        "aliasHELM": "p",
+        "attachmentPoints": [
+            {
+                "attachmentAtom": 0,
+                "type": "left",
+                "leavingGroup": {
+                    "atoms": [
+                        3
+                    ]
+                }
+            },
+            {
+                "attachmentAtom": 0,
+                "type": "right",
+                "leavingGroup": {
+                    "atoms": [
+                        4
+                    ]
+                }
+            }
+        ],
+        "atoms": [
+            {
+                "label": "P",
+                "location": [
+                    0.000000,
+                    0.000000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.500000,
+                    -0.866000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    0.500000,
+                    0.866000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    -1.000000,
+                    0.000000,
+                    0.000000
+                ]
+            },
+            {
+                "label": "O",
+                "location": [
+                    1.000000,
+                    0.000000,
+                    0.000000
+                ]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 2,
+                "atoms": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    3
+                ]
+            },
+            {
+                "type": 1,
+                "atoms": [
+                    0,
+                    4
+                ]
+            }
+        ]
+    }
+}

--- a/api/tests/integration/tests/formats/ref/helm_unresolved.ket
+++ b/api/tests/integration/tests/formats/ref/helm_unresolved.ket
@@ -189,7 +189,6 @@
         "id": "AminoAcidUnres3",
         "class": "AminoAcid",
         "alias": "Unres3",
-        "aliasHELM": "Var0",
         "unresolved": true,
         "attachmentPoints": [
             {

--- a/core/indigo-core/molecule/src/sequence_saver.cpp
+++ b/core/indigo-core/molecule/src/sequence_saver.cpp
@@ -1318,7 +1318,12 @@ std::string SequenceSaver::saveHELM(KetDocument& document, std::vector<std::dequ
                 {
                     if (variants.size() > 0)
                         variants += mixture ? '+' : ',';
-                    auto alias = templates.at(option.templateId()).getStringProp("alias");
+                    std::string alias;
+                    auto& mononomer_template = templates.at(option.templateId());
+                    if (mononomer_template.hasStringProp("aliasHELM"))
+                        alias = mononomer_template.getStringProp("aliasHELM");
+                    if (alias.size() == 0)
+                        alias = mononomer_template.getStringProp("alias");
                     if (alias.size() > 1)
                         variants += '[';
                     variants += alias;


### PR DESCRIPTION
Fix aliasHELM for ambiguous monomers and for single R and P

 #3061 System can't recognize single rebose or phosphate if loaded from HELM
 #3062 Mix of ketcher library aliases and HELM aliases inside ambigous monomer causes it wrong type on the canvas

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created

