### PR TITLE
#3099 - Support dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:12
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    git \
+    curl \
+    wget \
+    build-essential \
+    vim \
+    htop \
+    # Add your extra tools here
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m vscode && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER vscode
+WORKDIR /workspaces

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,66 @@
+# Debian 12 base
 FROM debian:12
 
+# Avoid prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Install base tools and languages
 RUN apt-get update && apt-get install -y \
-    sudo \
-    git \
-    curl \
-    wget \
-    build-essential \
-    vim \
-    htop \
-    # Add your extra tools here
-    && rm -rf /var/lib/apt/lists/*
+    sudo git curl wget \
+    build-essential gcc g++ clang gdb \
+    cmake ninja-build unzip zip \
+    python3 python3-pip python3-venv \
+    libfreetype6-dev \
+    libfontconfig1-dev \
+    postgresql-server-dev-15 \
+    libpq-dev \
+    openjdk-17-jdk \
+    apt-transport-https gnupg \
+ && rm -rf /var/lib/apt/lists/*
 
+# Install latest .NET 8 LTS SDK
+RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
+ && rm packages-microsoft-prod.deb \
+ && apt-get update && apt-get install -y dotnet-sdk-6.0 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user (same as VS Code default)
 RUN useradd -m vscode && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-USER vscode
+# Create Python virtual environment for user
+RUN python3 -m venv /opt/venv \
+ && /opt/venv/bin/pip install --upgrade pip \
+ && /opt/venv/bin/pip install \
+        wheel \
+        setuptools \
+        waitress \
+        flasgger \
+        psycopg2 \
+        sqlalchemy \
+        numpy \
+        celery \
+        marshmallow \
+        redis \
+        flask_httpauth \
+        pyparsing \
+        requests
+
+# Install PowerShell
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https software-properties-common && \
+    wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y powershell && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/pwsh /usr/bin/powershell
+
+# Ensure venv is used by default for all users
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Set work directory
 WORKDIR /workspaces
+
+# Default to non-root user
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "Debian 12 Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  // Optional: run after container creation
+  "postCreateCommand": "echo 'Container is ready!'",
+
+  "forwardPorts": [3000, 8000],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,58 @@
 {
-  "name": "Debian 12 Dev Container",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
-
-  // Optional: run after container creation
-  "postCreateCommand": "echo 'Container is ready!'",
-
-  "forwardPorts": [3000, 8000],
-
-  "customizations": {
-    "vscode": {
-      "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash"
-      },
-      "extensions": [
-        "ms-azuretools.vscode-docker"
-      ]
-    }
-  },
-
-  "remoteUser": "vscode"
+    "name": "Debian 12 Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceFolder": "/workspaces/Indigo",
+    "remoteUser": "root",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                // Use the Python inside the venv
+                "typescript.tsc.autoDetect": "off",
+                "python.defaultInterpreterPath": "/opt/venv/bin/python",
+                "python.terminal.activateEnvironment": true,
+                "python.analysis.autoImportCompletions": true,
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true,
+                "python.formatting.provider": "black",
+                "editor.formatOnSave": true,
+                "files.trimTrailingWhitespace": true,
+                "files.insertFinalNewline": true,
+                "taskExplorer.enabledTasks": {
+                    "ant": false,
+                    "appPublisher": false,
+                    "batch": false,
+                    "bash": false,
+                    "composer": false,
+                    "gradle": false,
+                    "grunt": false,
+                    "gulp": false,
+                    "make": false,
+                    "maven": false,
+                    "npm": false,
+                    "nsis": false,
+                    "perl": false,
+                    "pipenv": false,
+                    "powershell": false,
+                    "python": false,
+                    "ruby": false,
+                    "tsc": false,
+                    "workspace": true
+                }
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.debugpy",
+                "ms-toolsai.jupyter",
+                "ms-dotnettools.csharp",
+                "spmeesseman.vscode-taskexplorer",
+                "ms-vscode.cmake-tools",
+                "ms-vscode.cpptools"
+            ]
+        }
+    },
+    "postCreateCommand": "pip install --no-cache-dir debugpy",
+    "features": {},
+    "updateRemoteUserUID": true
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ Each project is placed in the corresponding directory with CMakeList.txt configu
 file, that does not include other projects. In order to build the whole project with the
 correct references you need to use CMake configurations from the build_scripts directory.
 
+## Develop using dev container
+
+This is an alternative setup solution next to have it on your PC directly. It builds on having the tools in a docker container and VSCode acts as a client.
+
+### Prerequisites
+
+1. Docker Desktop (or docker engine if you prefer)
+2. VSCode
+
+### Installation Steps
+
+1. Clone this repository
+2. Open in VSCode
+3. Follow recommendation to install the Dev Container Extension
+4. Open in Dev Container
+
+The first time takes some minutes but afterwards you can directly develop from VSCode.
+
+***Remark for Windows Users:*** Its a known limitation that on windows the overlay driver is super slow, so if you want to have
+a fast IDE, clone your container into a volume rather than natively on the client or in your WSL distribution.
+
 ## Preinstalled build tools ##
 
 To build the project from the sources, the following tools should be installed:
@@ -82,7 +103,7 @@ To build the project from the sources, the following tools should be installed:
 - flask_httpauth package installed (to run backend API test). Command: `python -m pip install flask_httpauth`
 - pyparsing package installed (to run backend API test). Command: `python -m pip install pyparsing`
 - requests package installed (to run backend API test). Command: `python -m pip install requests`
- 
+
 > On Linux use python3 insted of python. Using virtual environment might be required as well.
 
 
@@ -130,14 +151,14 @@ Befor running any test you have to build and install indigo-python
 
 
 > Package will be named like 'epam.indigo-*\<version-arch\>*.whl'. For instance: *epam.indigo-1.29.0.dev2-py3-none-win_amd64.whl*
-   
+
 2) Install package using pip
     > - If Indigo package has been already installed, uninstall it with the following command: `python -m pip uninstall <path-to-.whl-file> -y`
 
     ```
     python -m pip install <path-to-.whl-file>
     ```
-    
+
     > Replace _**\<path-to-.whl-file>**_ with the right path to .whl package. For instance: `python -m pip install ../api/python/dist/epam.indigo-1.29.0.dev2-py3-none-win_amd64.whl`
 
 3) Run integration test
@@ -147,7 +168,7 @@ Befor running any test you have to build and install indigo-python
     ```
     python api/tests/integration/test.py -t 1
     ```
-    
+
     >to run tests by mask use `test_name`
     ```
     python api/tests/integration/test.py -t 1 -p test_name
@@ -277,14 +298,14 @@ Change directory to ```recipe-conda``, set INDIGO_VERSION to existing Indigo ver
 Linux/Mac:
 ```
 >cd conda-recipe
->INDIGO_VERSION=1.29.0 conda build . 
+>INDIGO_VERSION=1.29.0 conda build .
 ```
 
 Windows(using cmd):
 ```
 >cd conda-recipe
->set INDIGO_VERSION=1.29.0 
->conda build . 
+>set INDIGO_VERSION=1.29.0
+>conda build .
 ```
 
 To upload packages: install anaconda-client, login, and upload packet using command provided by conda-build in output

--- a/utils/indigo-depict/main.c
+++ b/utils/indigo-depict/main.c
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -869,7 +870,7 @@ int main(int argc, char* argv[])
     indigoSetOption("ignore-bad-valence", "on");
     indigoSetOption("molfile-saving-mode", "2000");
     indigoSetOption("ket-saving-version", "1.0.0");
-    indigoSetOptionBool("json-saving-pretty", "on");
+    indigoSetOptionBool("json-saving-pretty", true);
     indigoSetOptionFloat("reaction-component-margin-size", 0.0f);
 
     if (parseParams(&p, argc, argv) < 0)


### PR DESCRIPTION
I was a bit bothered to setup so much stuff manually up, so I would like to provide my dev containers setup. That means if someone wants to start developing they can simply clone the repo and start as a dev container, having everything set up. The idea of this PR is that this is a basis which can be extended easily or merged/reused for the build agents.

Limitations:
1. Only linux working at the moment, cross compile not possible
2. WASM not included

Why merge now?

Have a basis :)

## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated
### Optional
- [x] unit-tests written
- [x] documentation updated
