### PR TITLE
#3105 bingo-elastic-python filter broken for exact/substructure

### DIFF
--- a/bingo/bingo-elastic/python/README.md
+++ b/bingo/bingo-elastic/python/README.md
@@ -132,7 +132,7 @@ Full usage example sync:
 
 ```
 from bingo_elastic.model import helpers
-from bingo_elastic.elastic import, ElasticRepository IndexName
+from bingo_elastic.elastic import ElasticRepository, IndexName
 from pathlib import Path
 
 repository = ElasticRepository(IndexName.BINGO_MOLECULE, host="127.0.0.1", port=9200)
@@ -189,40 +189,41 @@ Supported similarity algorithms:
 
 #### Find exact records from Elasticsearch
 
-Bingo Elasticsearch decides on the strategy to find, based on the query_object type
+To run exact match, your target must be either IndigoRecordMolecule or IndigoRecordReaction
+
 Sync:
 ```
-target = indigo.loadMolecule("<your molecule here>")
-record = IndigoRecord(indigo_object = target)
-exact_records = repo.filter(query_subject=record, indigo_session=indigo, limit=20)
+indigo = Indigo()
+molecule = indigo.loadMolecule("CCO")
+target = IndigoRecordMolecule(indigo_object=molecule)
+exact_records = repo.filter(exact=target, indigo_session=indigo, limit=20)
 ```
 
 Async:
 ```
-target = indigo.loadMolecule("<your molecule here>")
-record = IndigoRecord(indigo_object = target)
-exact_records = await repo.filter(query_subject=record, indigo_session=indigo, limit=20)
+indigo = Indigo()
+molecule = indigo.loadMolecule("CCO")
+target = IndigoRecordMolecule(indigo_object=molecule)
+exact_records = await repo.filter(exact=target, indigo_session=indigo, limit=20)
 ```
-
-In this case we requested top-20 candidate molecules with exact same fingerprint to `target`.
-`target` should be an instance of `IndigoRecord` class.
-
 
 #### Subsctructure match of the records from Elasticsearch
 
+To run substructure search, your target must be query molecule
+
 Sync:
 ```
-target = indigo.loadQueryMolecule("<your substructure here>")
-submatch_records = repo.filter(query_subject=target, indigo_session=indigo, limit=20)
+indigo = Indigo()
+target = indigo.loadQueryMolecule("CCO")
+submatch_records = repo.filter(substructure=target, indigo_session=indigo, limit=20)
 ```
 
 Async:
 ```
-target = indigo.loadQueryMolecule("<your substructure here>")
-submatch_records = await repo.filter(query_subject=target, indigo_session=indigo, limit=20)
+indigo = Indigo()
+target = indigo.loadQueryMolecule("CCO")
+submatch_records = await repo.filter(substructure=target, indigo_session=indigo, limit=20)
 ```
-
-In this case we requested top-10 candidate molecules with exact same fingerprint to `target`.
 
 Note: 
 Bingo is requesting data from Elasticsearch with batches. You can control it with page_size argument

--- a/bingo/bingo-elastic/python/bingo_elastic/model/record.py
+++ b/bingo/bingo-elastic/python/bingo_elastic/model/record.py
@@ -116,6 +116,14 @@ class IndigoRecord:
     record_id: Optional[str] = None
     error_handler: Optional[Callable[[object, BaseException], None]] = None
 
+    def __new__(cls, *args, **kwargs):
+        if cls is IndigoRecord:
+            raise TypeError(
+                "Cannot instantiate IndigoRecord directly. "
+                "Use IndigoRecordMolecule or IndigoRecordReaction instead."
+            )
+        return super().__new__(cls)
+
     def __init__(self, **kwargs) -> None:
         """
         Constructor accepts only keyword arguments

--- a/bingo/bingo-elastic/python/bingo_elastic/queries.py
+++ b/bingo/bingo-elastic/python/bingo_elastic/queries.py
@@ -322,6 +322,12 @@ class SimilarityMatch:
 
 def query_factory(key: str, value: Any) -> CompilableQuery:
     if key == "exact":
+        if not isinstance(value, IndigoRecord):
+            raise TypeError(
+                "Exact search requires the query object to be "
+                "a subclass of IndigoRecord "
+                "(IndigoRecordMolecule or IndigoRecordReaction)"
+            )
         return ExactMatch(value)
     if key == "substructure":
         return SubstructureQuery(key, value)

--- a/bingo/bingo-elastic/python/tests/conftest.py
+++ b/bingo/bingo-elastic/python/tests/conftest.py
@@ -11,7 +11,7 @@ from bingo_elastic.elastic import (
     IndexName,
 )
 from bingo_elastic.model.helpers import iterate_file, load_reaction
-from bingo_elastic.model.record import IndigoRecord, IndigoRecordMolecule
+from bingo_elastic.model.record import IndigoRecordMolecule
 
 
 @pytest.fixture()
@@ -91,12 +91,12 @@ def loaded_sdf(
 
 
 @pytest.fixture
-def pagination_fixture(
+def fixture_molecules_20_10_5_1(
     elastic_repository_molecule: ElasticRepository, indigo_fixture: Indigo
 ) -> None:
     def generator_records(molecules):
         for x in molecules:
-            yield IndigoRecord(indigo_object=x)
+            yield IndigoRecordMolecule(indigo_object=x)
 
     mol1 = [indigo_fixture.loadMolecule("CCO") for _ in range(20)]
     elastic_repository_molecule.index_records(generator_records(mol1))
@@ -104,6 +104,16 @@ def pagination_fixture(
     elastic_repository_molecule.index_records(generator_records(mol2))
     mol3 = [indigo_fixture.loadMolecule("CO") for _ in range(5)]
     elastic_repository_molecule.index_records(generator_records(mol3))
+    # We will add one molecule and fake fingerprints and hash to get collisions
+    # in order to test postprocess actions
+    ccco_mol = IndigoRecordMolecule(
+        indigo_object=indigo_fixture.loadMolecule("CCCO")
+    )
+    mol4 = IndigoRecordMolecule(indigo_object=indigo_fixture.loadMolecule("S"))
+    mol4.sub_fingerprint = ccco_mol.sub_fingerprint
+    mol4.sim_fingerprint = ccco_mol.sim_fingerprint
+    setattr(mol4, "hash", getattr(ccco_mol, "hash"))
+    elastic_repository_molecule.index_record(mol4)
     elastic_repository_molecule.el_client.indices.refresh(
         index=IndexName.BINGO_MOLECULE.value
     )


### PR DESCRIPTION
fixes #3105

- Added postprocess actions to compile query
- Added verbose error messages, when wrong IndigoObjects are used for exact and substructure searches
- Added tests for exact= and substructure= searches
- Added IndigoObjectType enum to get internal type without magic strings


## Remove-me-section
* Notify reviewers about the pull request
* Keep only necessary sections below for the review

## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [ ] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated
- [x] unit-tests written
- [x] documentation updated