### PR TITLE
#3120 bingo-elastic-python reaction exact search do not use postproce…

### DIFF
--- a/bingo/bingo-elastic/python/README.md
+++ b/bingo/bingo-elastic/python/README.md
@@ -199,11 +199,25 @@ target = IndigoRecordMolecule(indigo_object=molecule)
 exact_records = repo.filter(exact=target, indigo_session=indigo, limit=20)
 ```
 
+```
+indigo = Indigo()
+records = indigo.loadReaction("C=C.BrBr>>C(CBr)Br")
+target = IndigoRecordReaction(indigo_object=molecule)
+exact_records = repo.filter(exact=target, indigo_session=indigo, limit=20)
+```
+
 Async:
 ```
 indigo = Indigo()
 molecule = indigo.loadMolecule("CCO")
 target = IndigoRecordMolecule(indigo_object=molecule)
+exact_records = await repo.filter(exact=target, indigo_session=indigo, limit=20)
+```
+
+```
+indigo = Indigo()
+records = indigo.loadReaction("C=C.BrBr>>C(CBr)Br")
+target = IndigoRecordReaction(indigo_object=molecule)
 exact_records = await repo.filter(exact=target, indigo_session=indigo, limit=20)
 ```
 
@@ -218,10 +232,22 @@ target = indigo.loadQueryMolecule("CCO")
 submatch_records = repo.filter(substructure=target, indigo_session=indigo, limit=20)
 ```
 
+```
+indigo = Indigo()
+target = indigo.loadQueryReaction("C=C>>")
+submatch_records = repo.filter(substructure=target, indigo_session=indigo, limit=20)
+```
+
 Async:
 ```
 indigo = Indigo()
 target = indigo.loadQueryMolecule("CCO")
+submatch_records = await repo.filter(substructure=target, indigo_session=indigo, limit=20)
+```
+
+```
+indigo = Indigo()
+target = indigo.loadQueryReaction("C=C>>")
 submatch_records = await repo.filter(substructure=target, indigo_session=indigo, limit=20)
 ```
 

--- a/bingo/bingo-elastic/python/bingo_elastic/queries.py
+++ b/bingo/bingo-elastic/python/bingo_elastic/queries.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from indigo import Indigo, IndigoObject  # type: ignore
 
-from bingo_elastic.model.record import IndigoRecord, IndigoRecordMolecule
+from bingo_elastic.model.record import IndigoRecord
 from bingo_elastic.utils import PostprocessType, head_by_path
 
 
@@ -288,10 +288,6 @@ class ExactMatch(CompilableQuery):
     def postprocess(
         self, record: IndigoRecord, indigo: Indigo, options: str
     ) -> Optional[IndigoRecord]:
-        # postprocess only on molecule search
-        if not isinstance(record, IndigoRecordMolecule):
-            return record
-
         if not record.cmf:
             return None
 


### PR DESCRIPTION
…ss actions

Fixes #3120
- Put back postprocess actions for exact reaction search
- Fix tests
- Add tests for reactions search

## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [ ] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated
### Optional
- [x] unit-tests written
- [x] documentation updated


