### PR TITLE
#3150 Exception during molecules loading in test fixture

### DIFF
--- a/bingo/bingo-elastic/python/tests/conftest.py
+++ b/bingo/bingo-elastic/python/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import time
 from pathlib import Path
 from typing import Callable
@@ -30,7 +31,10 @@ def resource_loader() -> Callable[[str], str]:
 
 @pytest.fixture
 def indigo_fixture() -> Indigo:
-    return Indigo()
+    indigo = Indigo()
+    yield indigo
+    del indigo
+    gc.collect()
 
 
 @pytest.fixture

--- a/bingo/tests/conftest.py
+++ b/bingo/tests/conftest.py
@@ -1,5 +1,8 @@
+import gc
+
 import pytest
 from indigo import Indigo
+
 from .constants import (
     DATA_TYPES,
     DB_BINGO,
@@ -17,9 +20,10 @@ from .logger import logger
 
 @pytest.fixture(scope="class")
 def indigo():
-    # TODO: uncomment this:
     indigo = Indigo()
-    return indigo
+    yield indigo
+    del indigo
+    gc.collect()
 
 
 @pytest.fixture(scope="class")
@@ -48,6 +52,7 @@ def db(request, indigo):
         db.import_data(meta["import_no_sql"], data_type)
     elif db_str == DB_BINGO_ELASTIC:
         from bingo_elastic.elastic import IndexName
+
         from .dbc.BingoElastic import BingoElastic
 
         if data_type == EntitiesType.MOLECULES:


### PR DESCRIPTION
Fixes #3150

- Found that problem arise when python garbage collector startging to clean up fixtures from the previous test. It switches indigo session id and race condition may happen (between session ids). Force to clean up indigo instance before running next step

## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [ ] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated
