### PR TITLE
#2922 Performing an exact match search results in PostgreSQL termination

### DIFF
--- a/bingo/postgres/src/pg_am/pg_bingo_search.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_search.cpp
@@ -131,7 +131,10 @@ Datum bingo_rescan(PG_FUNCTION_ARGS)
         so = (BingoPgSearch*)scan->opaque;
         if (so != NULL)
         {
-            so->prepareRescan(scan);
+            // We create here search engines, which can call SPI functions
+            // TODO: It doesn't look proper to run SPI from low level index functions
+            // It's better to utilize low level Postgre API
+            so->prepareRescan(scan, true);
         }
     }
     PG_BINGO_HANDLE(delete so; scan->opaque = NULL);

--- a/bingo/postgres/src/pg_common/bingo_pg_cursor.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_cursor.h
@@ -22,13 +22,24 @@ public:
     uintptr_t getDatum(int arg_idx);
     unsigned int getArgOid(int arg_idx);
 
+    /**
+     * Forces deferred SPI_finish at transaction end instead of immediately
+     * when the cursor is destroyed. This is needed to avoid invoking
+     * inside the index code. SPI_finish will be called once
+     * the transaction has fully ended.
+     */
+    void finishOnTransactionEnd()
+    {
+        _finishOnTransactionEnd = true;
+    }
+
     DECL_ERROR;
 
 private:
     BingoPgCursor(const BingoPgCursor&); // no implicit copy
 
     void _init(indigo::Array<char>& query_str);
-
+    bool _finishOnTransactionEnd;
     indigo::Array<char> _cursorName;
     PG_OBJECT _cursorPtr;
     bool _pushed;

--- a/bingo/postgres/src/pg_core/bingo_pg_search.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_search.cpp
@@ -65,12 +65,12 @@ bool BingoPgSearch::next(PG_OBJECT scan_desc_ptr, PG_OBJECT result_ptr)
     return _fpEngine->searchNext(result_ptr);
 }
 
-void BingoPgSearch::prepareRescan(PG_OBJECT scan_desc_ptr)
+void BingoPgSearch::prepareRescan(PG_OBJECT scan_desc_ptr, bool deferred_finish)
 {
     _indexScanDesc = scan_desc_ptr;
     if (_initSearch)
     {
-        _initScanSearch();
+        _initScanSearch(deferred_finish);
     }
     else
     {
@@ -81,7 +81,7 @@ void BingoPgSearch::prepareRescan(PG_OBJECT scan_desc_ptr)
     }
 }
 
-void BingoPgSearch::_initScanSearch()
+void BingoPgSearch::_initScanSearch(bool deferred_finish)
 {
     _initSearch = false;
 
@@ -102,6 +102,8 @@ void BingoPgSearch::_initScanSearch()
         _fpEngine = std::make_unique<RingoPgSearchEngine>(rel_name);
     else
         throw Error("unknown index type %d", index_type);
+
+    _fpEngine->setDeferredFinish(deferred_finish);
     /*
      * Read configuration from index tuple
      */

--- a/bingo/postgres/src/pg_core/bingo_pg_search.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_search.h
@@ -43,14 +43,14 @@ public:
         return _funcName.ptr();
     }
 
-    void prepareRescan(PG_OBJECT scan_desc_ptr);
+    void prepareRescan(PG_OBJECT scan_desc_ptr, bool deferred_finish);
 
     DECL_ERROR;
 
 private:
     BingoPgSearch(const BingoPgSearch&); // no implicit copy
 
-    void _initScanSearch();
+    void _initScanSearch(bool deferred_finish = false);
     //   void _defineQueryOptions();
 
     bool _initSearch;

--- a/bingo/postgres/src/pg_core/bingo_pg_search_engine.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_search_engine.h
@@ -134,6 +134,11 @@ public:
         return 0;
     }
 
+    void setDeferredFinish(bool deferred)
+    {
+        _deferred_finish = deferred;
+    }
+
     virtual void prepareQuerySearch(BingoPgIndex&, PG_OBJECT scan_desc);
     virtual bool searchNext(PG_OBJECT result_ptr)
     {
@@ -163,6 +168,8 @@ protected:
 
     int _blockBegin;
     int _blockEnd;
+
+    bool _deferred_finish = false;
 
     BingoPgIndex* _bufferIndexPtr;
 

--- a/bingo/postgres/src/pg_core/mango_pg_search_engine.cpp
+++ b/bingo/postgres/src/pg_core/mango_pg_search_engine.cpp
@@ -424,6 +424,10 @@ void MangoPgSearchEngine::_prepareExactSearch(PG_OBJECT scan_desc_ptr)
     }
     // profTimerStart(t4, "mango_pg.exact_search_cursor");
     _searchCursor = std::make_unique<BingoPgCursor>("SELECT %s FROM %s WHERE %s", what_clause.ptr(), from_clause.ptr(), where_clause.ptr());
+    if (_deferred_finish)
+    {
+        _searchCursor->finishOnTransactionEnd();
+    }
     // profTimerStop(t4);
     //   if(nanoHowManySeconds(profTimerGetTime(t4) )> 1)
     //      elog(WARNING, "select %s from %s where %s", what_clause.ptr(), from_clause.ptr(), where_clause.ptr());
@@ -466,6 +470,10 @@ void MangoPgSearchEngine::_prepareGrossSearch(PG_OBJECT scan_desc_ptr)
     {
         const char* gross_conditions = bingoCore.mangoGrossGetConditions();
         _searchCursor = std::make_unique<BingoPgCursor>("SELECT b_id, gross FROM %s WHERE %s", _shadowRelName.ptr(), gross_conditions);
+        if (_deferred_finish)
+        {
+            _searchCursor->finishOnTransactionEnd();
+        }
     }
     CORE_CATCH_ERROR("molecule search engine: can not get gross conditions")
 }
@@ -473,6 +481,10 @@ void MangoPgSearchEngine::_prepareGrossSearch(PG_OBJECT scan_desc_ptr)
 void MangoPgSearchEngine::_prepareSmartsSearch(PG_OBJECT scan_desc_ptr)
 {
     _prepareSubSearch(scan_desc_ptr);
+    if (_deferred_finish)
+    {
+        _searchCursor->finishOnTransactionEnd();
+    }
 }
 
 void MangoPgSearchEngine::_prepareMassSearch(PG_OBJECT scan_desc_ptr)
@@ -514,6 +526,10 @@ void MangoPgSearchEngine::_prepareMassSearch(PG_OBJECT scan_desc_ptr)
         where_clause.printf("AND mass < %f", max_mass);
     where_clause.writeChar(0);
     _searchCursor = std::make_unique<BingoPgCursor>("SELECT b_id FROM %s WHERE %s", _shadowRelName.ptr(), where_clause_str.ptr());
+    if (_deferred_finish)
+    {
+        _searchCursor->finishOnTransactionEnd();
+    }
 }
 
 void MangoPgSearchEngine::_prepareSimSearch(PG_OBJECT scan_desc_ptr)

--- a/bingo/postgres/src/pg_core/ringo_pg_search_engine.cpp
+++ b/bingo/postgres/src/pg_core/ringo_pg_search_engine.cpp
@@ -222,6 +222,10 @@ void RingoPgSearchEngine::_prepareExactSearch(PG_OBJECT scan_desc_ptr)
     _prepareExactQueryStrings(what_clause, from_clause, where_clause);
 
     _searchCursor = std::make_unique<BingoPgCursor>("SELECT %s FROM %s WHERE %s", what_clause.ptr(), from_clause.ptr(), where_clause.ptr());
+    if (_deferred_finish)
+    {
+        _searchCursor->finishOnTransactionEnd();
+    }
 }
 
 void RingoPgSearchEngine::_prepareSmartsSearch(PG_OBJECT scan_desc_ptr)

--- a/bingo/tests/conftest.py
+++ b/bingo/tests/conftest.py
@@ -34,6 +34,11 @@ def entities(request, indigo):
     del entities
 
 
+@pytest.fixture
+def db_backend(request):
+    return request.config.getoption("--db")
+
+
 @pytest.fixture(scope="class")
 def db(request, indigo):
     db_str = request.config.getoption("--db")
@@ -65,7 +70,6 @@ def db(request, indigo):
         pass
     elif db_str == DB_MSSQL:
         pass
-
     yield db
 
     logger.info("Dropping DB...")

--- a/bingo/tests/data/molecules/exact/import/targets/exact_join.sql
+++ b/bingo/tests/data/molecules/exact/import/targets/exact_join.sql
@@ -1,0 +1,144 @@
+/*
+Thanks to amhuhn2 for providing this test case
+This test case is almost blindly copied from 
+https://github.com/epam/Indigo/issues/2922
+to cover this particular issue
+*/
+
+/* Create a new schema */
+DROP SCHEMA IF EXISTS issue2922 CASCADE;
+
+CREATE SCHEMA IF NOT EXISTS issue2922;
+
+/* Create table compound */
+DROP TABLE IF EXISTS issue2922.compound;
+
+CREATE TABLE issue2922.compound
+(
+	compound_id INTEGER NOT NULL,
+    mol_file text,
+    PRIMARY KEY (compound_id)
+);
+
+ALTER TABLE IF EXISTS issue2922.compound
+    OWNER to postgres;
+
+/* Create a bingo index on table compound */
+CREATE INDEX IF NOT EXISTS idx_compound
+    ON issue2922.compound USING bingo_idx
+    (mol_file bingo.molecule);
+
+/* Create table compound_security */
+DROP TABLE IF EXISTS issue2922.compound_security;
+
+CREATE TABLE issue2922.compound_security
+(
+    compound_id INTEGER NOT NULL,
+    PRIMARY KEY (compound_id)
+);
+
+ALTER TABLE IF EXISTS issue2922.compound_security
+    OWNER to postgres;
+
+/* Populate both tables with one row each */
+insert
+  into issue2922.compound_security
+     ( compound_id )
+values
+     ( 736832 );
+
+insert
+  into issue2922.compound
+     ( compound_id, mol_file )
+values ( 736832, 'Unnamed
+MolEngine06122512002D
+
+  0  0        0               999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 13 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 14.907 -3.539 0 0
+M  V30 2 C 16.258 -2.759 0 0
+M  V30 3 H 16.258 -1.199 0 0
+M  V30 4 C 17.609 -3.539 0 0
+M  V30 5 C 18.96 -2.759 0 0
+M  V30 6 H 18.96 -1.199 0 0
+M  V30 7 H 20.311 -3.539 0 0
+M  V30 8 H 17.609 -5.099 0 0
+M  V30 9 H 14.907 -5.099 0 0
+M  V30 10 H 13.556 -2.759 0 0
+M  V30 11 H 14.907 -1.979 0 0
+M  V30 12 H 16.258 -4.319 0 0
+M  V30 13 H 17.609 -1.979 0 0
+M  V30 14 H 20.311 -1.979 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 1 5 7
+M  V30 7 1 4 8
+M  V30 8 1 1 9
+M  V30 9 1 1 10
+M  V30 10 1 1 11
+M  V30 11 1 2 12
+M  V30 12 1 4 13
+M  V30 13 1 5 14
+M  V30 END BOND
+M  V30 END CTAB
+M  END' );
+
+/* The following fails with this error:
+ERROR:  could not find block containing chunk 0x64fdbb8 
+SQL state: XX000
+
+It is attempting to select from a JOIN of the two tables,
+using the bingo index in the WHERE clause.
+*/
+
+SELECT c.compound_id as c
+  FROM issue2922.compound AS c
+INNER JOIN
+       issue2922.compound_security AS cs
+    ON c.compound_id = cs.compound_id
+ WHERE (c.mol_file @ ('Unnamed
+MolEngine06122512002D
+
+  0  0        0               999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 13 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 14.907 -3.539 0 0
+M  V30 2 C 16.258 -2.759 0 0
+M  V30 3 H 16.258 -1.199 0 0
+M  V30 4 C 17.609 -3.539 0 0
+M  V30 5 C 18.96 -2.759 0 0
+M  V30 6 H 18.96 -1.199 0 0
+M  V30 7 H 20.311 -3.539 0 0
+M  V30 8 H 17.609 -5.099 0 0
+M  V30 9 H 14.907 -5.099 0 0
+M  V30 10 H 13.556 -2.759 0 0
+M  V30 11 H 14.907 -1.979 0 0
+M  V30 12 H 16.258 -4.319 0 0
+M  V30 13 H 17.609 -1.979 0 0
+M  V30 14 H 20.311 -1.979 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 1 5 7
+M  V30 7 1 4 8
+M  V30 8 1 1 9
+M  V30 9 1 1 10
+M  V30 10 1 1 11
+M  V30 11 1 2 12
+M  V30 12 1 4 13
+M  V30 13 1 5 14
+M  V30 END BOND
+M  V30 END CTAB
+M  END', '0.1')::bingo.exact) = TRUE;

--- a/bingo/tests/test_exact/test_exact.py
+++ b/bingo/tests/test_exact/test_exact.py
@@ -1,3 +1,5 @@
+from os import O_NDELAY
+
 import pytest
 
 from ..helpers import assert_match_query, query_cases
@@ -35,3 +37,15 @@ class TestExact:
         molecule = entities.get(query_id)
         result = db.exact(molecule, "exact", "MAS FRA 0.1")
         assert_match_query(result, expected)
+
+    def test_exact_join_postgres(self, db, db_backend):
+        if db_backend != "postgres":
+            pytest.skip("JOIN tests only supported in PostgreSQL backend")
+        with open(
+            "data/molecules/exact/import/targets/exact_join.sql"
+        ) as file:
+            result = db._connect.execute(file.read())
+        assert result is not None
+        out = [x for x in result]
+        assert len(out) == 1
+        assert out[0][0] == 736832


### PR DESCRIPTION
Fixes #2922

Found that postres db trying to acces the memory which we already freed in the cursor descriptor. So this memory should be freed only after transaction to avoid this behavior. Created SPIConnection class to be in charge of the SPI connection.

## Generic request
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [x] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated
- [x] unit-tests written
- [x] documentation updated

