### PR TITLE
Backmerge: #3169 - Export to IDT doesn't work if R1-only CHEM stays on five prime position

### DIFF
--- a/api/tests/integration/ref/formats/ket_to_idt.py.out
+++ b/api/tests/integration/ref/formats/ket_to_idt.py.out
@@ -8,6 +8,7 @@ idt_52moera_sp.ket:SUCCEED
 idt_52moera_sp_32moera.ket:SUCCEED
 idt_52moera_sp_i2moera_sp.ket:SUCCEED
 idt_52moera_with_3phos.ket:SUCCEED
+idt_5end_without_r2.ket:SUCCEED
 idt_5phos.ket:SUCCEED
 idt_baseless.ket:SUCCEED
 idt_bases.ket:SUCCEED

--- a/api/tests/integration/tests/formats/ket_to_idt.py
+++ b/api/tests/integration/tests/formats/ket_to_idt.py
@@ -68,6 +68,7 @@ idt_data = {
     "idt_issue_2257": "/3ThioMC3-D/",
     "idt_issue_3144": "/5AmMC6/rA/3Phos/",
     "idt_baseless": "/5dSp//idSp//3dSp/",
+    "idt_5end_without_r2": "/5DigN/rA",
 }
 
 for filename in sorted(idt_data.keys()):

--- a/core/indigo-core/molecule/ket_document.h
+++ b/core/indigo-core/molecule/ket_document.h
@@ -221,7 +221,8 @@ namespace indigo
 
     protected:
         void collect_sequence_side(const std::string& monomer_id, bool left_side, std::set<std::string>& monomers, std::set<std::string>& used_monomers,
-                                   std::deque<std::string>& sequence, std::map<std::pair<std::string, std::string>, const KetConnection&>& ap_to_connection);
+                                   std::deque<std::string>& sequence, std::map<std::pair<std::string, std::string>, const KetConnection&>& ap_to_connection,
+                                   bool for_idt);
 
     private:
         molecules_map _molecules;


### PR DESCRIPTION
Backmerge to master


## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes
