### PR TITLE
 #3206 - Export (or import) to (from) Mol v3000 works wrong for CHEM monomers

### DIFF
--- a/api/tests/integration/tests/formats/ref/3094-chem-3000.ket
+++ b/api/tests/integration/tests/formats/ref/3094-chem-3000.ket
@@ -26,7 +26,7 @@
     "monomerTemplate-4aPEGMal_1": {
         "type": "monomerTemplate",
         "id": "4aPEGMal_1",
-        "class": "Linker",
+        "class": "Chem",
         "classHELM": "CHEM",
         "alias": "4aPEGMal",
         "name": "4aPEGMal",

--- a/api/tests/integration/tests/formats/ref/chem_rna_hydro.ket
+++ b/api/tests/integration/tests/formats/ref/chem_rna_hydro.ket
@@ -108,7 +108,7 @@
     "monomerTemplate-MCC_1": {
         "type": "monomerTemplate",
         "id": "MCC_1",
-        "class": "Linker",
+        "class": "Chem",
         "classHELM": "CHEM",
         "alias": "MCC",
         "name": "MCC",

--- a/api/tests/integration/tests/formats/ref/conjugate.ket
+++ b/api/tests/integration/tests/formats/ref/conjugate.ket
@@ -4062,7 +4062,7 @@
     "monomerTemplate-SMCC_15": {
         "type": "monomerTemplate",
         "id": "SMCC_15",
-        "class": "Linker",
+        "class": "Chem",
         "classHELM": "CHEM",
         "alias": "SMCC",
         "name": "SMCC",

--- a/core/indigo-core/molecule/src/molfile_loader.cpp
+++ b/core/indigo-core/molecule/src/molfile_loader.cpp
@@ -2907,7 +2907,10 @@ void MolfileLoader::_readCtab3000()
                     QS_DEF(Array<char>, temp_class);
                     strscan.readWord(temp_class, 0);
                     temp_class.push(0);
-                    _bmol->setTemplateAtomClass(i, temp_class.ptr());
+                    if (strcasecmp(temp_class.ptr(), kMonomerClassLINKER) == 0)
+                        _bmol->setTemplateAtomClass(i, kMonomerClassCHEM);
+                    else
+                        _bmol->setTemplateAtomClass(i, temp_class.ptr());
                 }
                 else if (strcmp(prop, "SEQID") == 0)
                 {
@@ -3646,16 +3649,21 @@ void MolfileLoader::_readSGroup3000(const char* str)
         }
         else if (strcmp(entity.ptr(), "CLASS") == 0)
         {
+            Array<char> class_str;
             while (!scanner.isEOF())
             {
                 char c = scanner.readChar();
                 if (c == ' ')
                     break;
                 if (sup != 0)
-                    sup->sa_class.push(c);
+                    class_str.push(c);
             }
+            class_str.push(0);
             if (sup != 0)
-                sup->sa_class.push(0);
+                if (strcasecmp(class_str.ptr(), kMonomerClassLINKER) == 0)
+                    sup->sa_class.copy(kMonomerClassCHEM, 5);
+                else
+                    sup->sa_class.copy(class_str);
         }
         else if (strcmp(entity.ptr(), "SEQID") == 0)
         {
@@ -3827,7 +3835,10 @@ void MolfileLoader::_readTGroups3000()
                 char stop_char = strscan.readChar();
                 if (stop_char == '/')
                 {
-                    tgroup.tgroup_class.copy(word);
+                    if (strcasecmp(word.ptr(), kMonomerClassLINKER) == 0)
+                        tgroup.tgroup_class.copy(kMonomerClassCHEM, 5);
+                    else
+                        tgroup.tgroup_class.copy(word);
                     strscan.readWord(word, " /");
                     tgroup.tgroup_name.copy(word);
 


### PR DESCRIPTION
Convert linker to chem at mol file load. Fix UT


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
