### PR TITLE
CHEMBUGS-64 Automapping fails to guard against contradictory reaction center annotation, corrupts future structure export data

### DIFF
--- a/core/indigo-core/reaction/src/reaction_automapper.cpp
+++ b/core/indigo-core/reaction/src/reaction_automapper.cpp
@@ -619,7 +619,7 @@ bool ReactionAutomapper::_checkAtomMapping(bool change_rc, bool change_aam, bool
                             continue;
                         }
 
-                        //YQ: Sapio JIRA [CHEMBUGS-64] fixes:
+                        // YQ: Sapio JIRA [CHEMBUGS-64] fixes:
                         bool bond_cond_simple = RSubstructureMcs::bondConditionReactSimple(pmol, rmol, mapping[i], bond_idx, &rsm);
 
                         const bool is_unchanged = bond_cond_simple || (react_arom && prod_arom);
@@ -627,12 +627,15 @@ bool ReactionAutomapper::_checkAtomMapping(bool change_rc, bool change_aam, bool
                         const bool order_changed = !is_unchanged || aromaticity_changed;
 
                         // Make ORDER_CHANGED dominate UNCHANGED on this bond
-                        int &flags = bond_centers[mol_idx][bond_idx];
-                        if (order_changed) {
+                        int& flags = bond_centers[mol_idx][bond_idx];
+                        if (order_changed)
+                        {
                             // ensure exclusivity: once ORDER_CHANGED is set, never keep UNCHANGED
                             flags &= ~RC_UNCHANGED;
                             flags |= RC_ORDER_CHANGED;
-                        } else {
+                        }
+                        else
+                        {
                             // only mark UNCHANGED if ORDER_CHANGED wasn't set by a previous candidate
                             if ((flags & RC_ORDER_CHANGED) == 0)
                                 flags |= RC_UNCHANGED;


### PR DESCRIPTION
Issue details:
If auto-mapping is done on a reaction center that alreacy have RC_UNCHANGED, but changing into RC_ORDER_CHANGED, or the other way around, you can get a broken (RC_ORDER_CHANGED | RC_UNCHANGED) flag happening at the same time in the same react center, causing future load of any exports to MOL V3000 to fail.

Original Reporter:
Rob Brown, Head of Science Office @ Sapio Sciences LLC.

Implementation Done By:
Yechen Qiao, Core Platform Developer @ Sapio Sciences LLC.

Test file:
[CuAAC Click Example fixed.zip](https://github.com/user-attachments/files/22931102/CuAAC.Click.Example.fixed.zip)

Test instruction:
Extract zip to get the RXN data. 
Use the automap(keep) in python or whatever other api you prefer.
Export V3000.
Try load it back using ketcher or something.

Before the fix, you will fail to load because it has a section that looks like this:
M  V30 4 2 3 2 RXCTR=10
**RXCTR=10 is bad** because it is a bitwise OR to both RC_UNCHANGED = 2 and RC_ORDER_CHANGED = 8
Fun fact: Chemaxon automatically fix this condition on load by picking one or another during MOL V3000 loading, but that is not in this PR. I'm not sure if it's a good idea to fix automatically without throwing a warning. This PR only contains fixes to automapping logic.

After the fix, the export after automap will load normally without error.

## Remove-me-section
* Notify reviewers about the pull request
* Keep only necessary sections below for the review

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated

