### PR TITLE
Fix indigo-ci

### DIFF
--- a/.github/workflows/indigo-ci.yaml
+++ b/.github/workflows/indigo-ci.yaml
@@ -507,7 +507,6 @@ jobs:
       fail-fast: false 
       matrix: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-
     needs: [ merge_indigo_wrappers, test_indigo_python_x86_64, set_matrix ]
     steps:
       - name: Checkout
@@ -959,7 +958,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: [build_bingo_postgres_linux_x86_64, build_bingo_postgres_windows_msvc_x86_64, build_bingo_postgres_macos_x86_64]
+    needs: [build_bingo_postgres_linux_x86_64, build_bingo_postgres_windows_msvc_x86_64, build_bingo_postgres_macos_x86_64, set_matrix]
     if: ${{ always() && (needs.build_bingo_postgres_macos_x86_64.result == 'success' || needs.build_bingo_postgres_macos_x86_64.result == 'skipped') }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Return set-matrix to needs for build_indigo_utils_x86_64 - it needed for matrix
[no-ci]

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
