### PR TITLE
Backmerge: #3641, #3642 Add/Remove explicit hydrogens operation causes Error: array: invalid index 2 (size=2) exception

### DIFF
--- a/api/tests/integration/ref/basic/fold_unfold.py.out
+++ b/api/tests/integration/ref/basic/fold_unfold.py.out
@@ -1403,3 +1403,8 @@ testing [CH]C1=CC=CO1 |^4:0|
 [C]([H])C1OC([H])=C([H])C=1[H] |^4:0|
 testing C1C=CC=C([CH])C=1 |^4:5|
 C1([H])=C([H])C([C][H])=C([H])C([H])=C1[H] |^4:5|
+testing queryComponent ket
+4
+[0, 1]
+4
+[0, 1]

--- a/api/tests/integration/tests/basic/fold_unfold.py
+++ b/api/tests/integration/tests/basic/fold_unfold.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import json
 import os
 import sys
 
@@ -131,6 +132,77 @@ def testFoldUnfoldWithExplicitRadicals(smiles):
     print(mol.smiles())
 
 
+def _get_query_component_atoms(ket):
+    node_ref = ket["root"]["nodes"][0]["$ref"]
+    sgroups = ket[node_ref].get("sgroups", [])
+    for sgroup in sgroups:
+        if sgroup.get("type") == "queryComponent":
+            return sgroup.get("atoms", [])
+    return []
+
+
+def testFoldUnfoldQueryComponentKet():
+    print("testing queryComponent ket")
+    ket = """{
+    "ket_version": "2.0.0",
+    "root": {
+        "nodes": [
+            {
+                "$ref": "mol0"
+            }
+        ],
+        "connections": [],
+        "templates": []
+    },
+    "mol0": {
+        "type": "molecule",
+        "atoms": [
+            {
+                "label": "C",
+                "location": [6.007318933201196, -6.390262781767463, 0]
+            },
+            {
+                "label": "C",
+                "location": [7.00731896607563, -6.390262781767463, 0]
+            }
+        ],
+        "bonds": [
+            {
+                "type": 3,
+                "atoms": [0, 1]
+            }
+        ],
+        "sgroups": [
+            {
+                "type": "queryComponent",
+                "atoms": [0, 1]
+            }
+        ],
+        "stereoFlagPosition": {
+            "x": 7.00731896607563,
+            "y": 5.390262781767463,
+            "z": 0
+        }
+    }
+}"""
+
+    mol = indigo.loadQueryMolecule(ket)
+
+    unfolded = mol.clone()
+    unfolded.unfoldHydrogens()
+    unfolded_ket = json.loads(unfolded.json())
+    unfolded_ref = unfolded_ket["root"]["nodes"][0]["$ref"]
+    print(len(unfolded_ket[unfolded_ref]["atoms"]))
+    print(_get_query_component_atoms(unfolded_ket))
+
+    auto = mol.clone()
+    auto.foldUnfoldHydrogens()
+    auto_ket = json.loads(auto.json())
+    auto_ref = auto_ket["root"]["nodes"][0]["$ref"]
+    print(len(auto_ket[auto_ref]["atoms"]))
+    print(_get_query_component_atoms(auto_ket))
+
+
 testFoldUnfoldSDF(
     joinPathPy("../../../../../data/molecules/basic/sugars.sdf", __file__)
 )
@@ -209,3 +281,4 @@ testFoldUnfoldWithExplicitRadicals("[CH2] |^3:0|")
 testFoldUnfoldWithExplicitRadicals("[CH2] |^4:0|")
 testFoldUnfoldWithExplicitRadicals("[CH]C1=CC=CO1 |^4:0|")
 testFoldUnfoldWithExplicitRadicals("C1C=CC=C([CH])C=1 |^4:5|")
+testFoldUnfoldQueryComponentKet()

--- a/core/indigo-core/molecule/src/molecule_json_saver.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_saver.cpp
@@ -227,10 +227,14 @@ void MoleculeJsonSaver::saveSGroups(BaseMolecule& mol, JsonWriter& writer)
     if (mol.isQueryMolecule())
     {
         QueryMolecule& qmol = static_cast<QueryMolecule&>(mol);
-        if (qmol.components.size() > 0 && qmol.components[0])
+        for (int i = 0; i < qmol.components.size(); ++i)
         {
-            componentDefined = true;
-            sGroupsCount++;
+            if (qmol.components[i] > 0)
+            {
+                componentDefined = true;
+                sGroupsCount++;
+                break;
+            }
         }
     }
 
@@ -256,7 +260,7 @@ void MoleculeJsonSaver::saveSGroups(BaseMolecule& mol, JsonWriter& writer)
             writer.StartArray();
             for (int i = 0; i < qmol.vertexCount(); i++)
             {
-                if (qmol.components[i])
+                if (i < qmol.components.size() && qmol.components[i] > 0)
                 {
                     writer.Int(i);
                 }

--- a/core/indigo-core/molecule/src/query_molecule_nodes.cpp
+++ b/core/indigo-core/molecule/src/query_molecule_nodes.cpp
@@ -993,6 +993,8 @@ int QueryMolecule::addAtom(Atom* atom)
 
     _atoms.expand(idx + 1);
     _atoms.set(idx, atom);
+    // Keep queryComponent metadata aligned with vertex indices.
+    components.expandFill(idx + 1, 0);
 
     updateEditRevision();
     return idx;


### PR DESCRIPTION
## Backmerge request
- [ ] PR name follows the pattern `Backmerge: #1234 – issue name`
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] code contains only backmerge changes
