### PR TITLE
fix SMARTS search in Postgres

### DIFF
--- a/bingo/postgres/src/pg_core/mango_pg_search_engine.cpp
+++ b/bingo/postgres/src/pg_core/mango_pg_search_engine.cpp
@@ -481,10 +481,6 @@ void MangoPgSearchEngine::_prepareGrossSearch(PG_OBJECT scan_desc_ptr)
 void MangoPgSearchEngine::_prepareSmartsSearch(PG_OBJECT scan_desc_ptr)
 {
     _prepareSubSearch(scan_desc_ptr);
-    if (_deferred_finish)
-    {
-        _searchCursor->finishOnTransactionEnd();
-    }
 }
 
 void MangoPgSearchEngine::_prepareMassSearch(PG_OBJECT scan_desc_ptr)

--- a/bingo/tests/test_smarts/test_smarts_index_regression.py
+++ b/bingo/tests/test_smarts/test_smarts_index_regression.py
@@ -1,0 +1,91 @@
+import pytest
+from sqlalchemy import text
+
+from ..helpers import assert_match_query
+
+
+class TestSmarts:
+    @pytest.fixture(scope="class", autouse=True)
+    def regression_table(self, db):
+        if db.dbms != "postgres":
+            yield None
+            return
+
+        table_name = "smarts_regression_m_m_t"
+        db._execute_dml_query(
+            f"DROP TABLE IF EXISTS {db.test_schema}.{table_name} CASCADE"
+        )
+        db.create_data_tables([table_name])
+        db.create_indices([table_name])
+        db._execute_dml_query(
+            f"""
+            INSERT INTO {db.test_schema}.{table_name}(id, data) VALUES
+                (1, 'CCO'),
+                (2, 'CSC'),
+                (3, 'O=S=O'),
+                (4, 'C1=CC=CC=C1'),
+                (5, 'CC(=O)O')
+            """
+        )
+
+        yield table_name
+
+        db._connect.execute(text("COMMIT"))
+        db._execute_dml_query(
+            f"DROP TABLE IF EXISTS {db.test_schema}.{table_name} CASCADE"
+        )
+
+    def _assert_index_scan(self, db, table_name, condition_sql):
+        db._connect.execute(text("SET enable_seqscan = off"))
+        result = db._connect.execute(
+            text(
+                f"""
+                EXPLAIN SELECT id FROM {db.test_schema}.{table_name}
+                WHERE {condition_sql}
+                """
+            )
+        )
+        plan = "\n".join(row[0] for row in result.fetchall())
+        result.close()
+        db._connect.execute(text("COMMIT"))
+        assert "Index Scan" in plan
+
+    def _run_query(self, db, table_name, condition_sql):
+        db._connect.execute(text("SET enable_seqscan = off"))
+        result = db._connect.execute(
+            text(
+                f"""
+                SELECT id FROM {db.test_schema}.{table_name}
+                WHERE {condition_sql}
+                ORDER BY id ASC
+                """
+            )
+        )
+        rows = [row[0] for row in result.fetchall()]
+        result.close()
+        db._connect.execute(text("COMMIT"))
+        return rows
+
+    def test_exact_indexed_regression(self, db, db_backend, regression_table):
+        if db_backend != "postgres":
+            pytest.skip("Regression test only supported in PostgreSQL backend")
+
+        condition = "data @ CAST(('CSC', '') AS bingo.exact)"
+        self._assert_index_scan(db, regression_table, condition)
+        assert_match_query(self._run_query(db, regression_table, condition), [2])
+
+    def test_substructure_indexed_regression(self, db, db_backend, regression_table):
+        if db_backend != "postgres":
+            pytest.skip("Regression test only supported in PostgreSQL backend")
+
+        condition = "data @ CAST(('S', '') AS bingo.sub)"
+        self._assert_index_scan(db, regression_table, condition)
+        assert_match_query(self._run_query(db, regression_table, condition), [2, 3])
+
+    def test_smarts_indexed_regression(self, db, db_backend, regression_table):
+        if db_backend != "postgres":
+            pytest.skip("Regression test only supported in PostgreSQL backend")
+
+        condition = "data @ CAST(('[#16]', '') AS bingo.smarts)"
+        self._assert_index_scan(db, regression_table, condition)
+        assert_match_query(self._run_query(db, regression_table, condition), [2, 3])


### PR DESCRIPTION


- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name does not contain '#'
- [x] base branch (master or release/xx) is correct
- [x] PR is linked with the issue
- [x] task status changed to "Code review"
- [x] code follows product standards
- [x] regression tests updated

This patch fixes #3683 - a PostgreSQL regression introduced in PR #3154 for indexed molecule SMARTS searches. The regression came from treating SMARTS like the cursor-backed exact/gross/mass paths and calling `finishOnTransactionEnd()` in `_prepareSmartsSearch()`. 
Unlike those search types, molecule SMARTS reuses the substructure preparation path and never creates `_searchCursor`, so the added deferred-finish call could only fail there. Molecule substructure is unaffected because it calls `_prepareSubSearch()` directly, and reaction SMARTS is unaffected because the analogous reaction code never added the deferred-finish call.

To lock that behavior down, the new pytest coverage builds a dedicated molecule table and forces bingo_idx usage with enable_seqscan = off, then verifies both the plan shape and the returned IDs for exact, substructure, and SMARTS

