### PR TITLE
#3691: PtrArray hybrid contract implementation

### DIFF
--- a/bingo/oracle/src/oracle/bingo_oracle_context.cpp
+++ b/bingo/oracle/src/oracle/bingo_oracle_context.cpp
@@ -359,7 +359,9 @@ void BingoOracleContext::tautomerLoadRules(OracleEnv& env)
             bingoGetTauCondition(param2, rule->aromaticity2, rule->list2);
 
             tautomer_rules.expand(n);
-            tautomer_rules[n - 1] = rule.release();
+            // PtrArray<T>::operator[] no longer returns T*&; use set() for
+            // sparse slot fill. (milestone-19 / issue #783 — ptr_array rewrite)
+            tautomer_rules.set(n - 1, rule.release());
         } while (statement.fetch());
 }
 

--- a/core/indigo-core/CMakeLists.txt
+++ b/core/indigo-core/CMakeLists.txt
@@ -3,8 +3,12 @@ cmake_minimum_required(VERSION 3.6)
 project(indigo-core LANGUAGES C CXX)
 
 if (MSVC)
-    string(APPEND CMAKE_C_FLAGS " -W3 -WX")
-    string(APPEND CMAKE_CXX_FLAGS " -W3  -WX")
+    # /wd4996 — temporary suppression of C4996 (deprecated declarations) during
+    # milestone of core container refactoring. Remove once have
+    # migrated all call sites away from PtrArray::add(T*) / set(int,T*) /
+    # reset(int,T*) deprecated overloads.
+    string(APPEND CMAKE_C_FLAGS " -W3 -WX /wd4996")
+    string(APPEND CMAKE_CXX_FLAGS " -W3  -WX /wd4996")
 endif ()
 
 file(GLOB_RECURSE ${PROJECT_NAME}_SOURCES CONFIUGURE_DEPENDS

--- a/core/indigo-core/common/base_cpp/multimap.h
+++ b/core/indigo-core/common/base_cpp/multimap.h
@@ -230,7 +230,7 @@ RedBlackSet<V>& MultiMap<K, V>::_provide_set(const K& k)
     _keys.insert(k);
     _map.insert(k, _sets.size());
     CHECK_KEYS;
-    return _sets.add(new RedBlackSet<V>());
+    return _sets.emplace();
 }
 
 #endif

--- a/core/indigo-core/common/base_cpp/os_thread_wrapper.cpp
+++ b/core/indigo-core/common/base_cpp/os_thread_wrapper.cpp
@@ -155,7 +155,7 @@ OsCommand* OsCommandDispatcher::_getVacantCommand()
         command->unique_id = _last_unique_command_id++;
     }
     else
-        command = _availableCommands.pop();
+        command = _availableCommands.pop().release();
 
     command->clear();
 
@@ -169,7 +169,7 @@ OsCommandResult* OsCommandDispatcher::_getVacantResult()
     if (_availableResults.size() == 0)
         result = _allocateResult();
     else
-        result = _availableResults.pop();
+        result = _availableResults.pop().release();
     result->clear();
 
     return result;

--- a/core/indigo-core/common/base_cpp/ptr_array.h
+++ b/core/indigo-core/common/base_cpp/ptr_array.h
@@ -19,12 +19,42 @@
 #ifndef __ptr_array__
 #define __ptr_array__
 
-#include "base_cpp/array.h"
+#include <memory>
+#include <utility>
+#include <vector>
 
-#ifdef _WIN32
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif
+#include "base_cpp/exception.h"
+
+// PtrArray<T> — owning, heterogeneous, nullable-slot array of T pointers.
+//
+// Thread safety: NOT thread-safe. Callers must serialize access externally.
+// The underlying `std::vector<std::unique_ptr<T>>` provides no synchronization.
+//
+// History: previously implemented as `Array<T*>` with manual `delete` in the
+// destructor. As part of milestone-19 (issue #783) the internal storage was
+// migrated to `std::vector<std::unique_ptr<T>>`. The public API was kept
+// source-compatible with one exception: `operator[]` and `at()` now return
+// `T*` by value rather than `T*&` (lvalue reference). Direct assignment via
+// `arr[i] = ptr` must be replaced with `arr.set(i, ptr)` / `arr.reset(i, ptr)`.
+//
+// PR-1 (issue #3691) adds ownership-correct overloads and marks the raw-pointer
+// overloads deprecated. Migration guide:
+//   arr.add(new T(x))         →  arr.emplace(x)  or  arr.add(std::make_unique<T>(x))
+//   arr.set(i, new T(x))      →  arr.set(i, std::make_unique<T>(x))
+//   arr.reset(i, new T(x))    →  arr.reset(i, std::make_unique<T>(x))
+//   T* p = arr.pop()          →  auto p = arr.pop()   (std::unique_ptr<T>)
+// NEW in PR-1: arr.release(i) — transfers ownership of slot i out as unique_ptr.
+//
+// Ownership model: PtrArray owns the pointees. `add()`, `set()`, `reset(idx, p)`
+// take ownership of the raw pointer / unique_ptr they receive. `release(idx)`,
+// `pop()` transfer ownership out as `std::unique_ptr<T>`. Slots may legally be
+// `nullptr` (holes); destruction, clear(), and shrink-resize skip null slots.
+//
+// Move/copy: nothrow-movable, non-copyable. Use `clone(const PtrArray&)` if a
+// deep copy is genuinely needed (must be added explicitly per T).
+//
+// See also: tests in core/indigo-core/tests/tests/ptr_array.cpp — they pin
+// the observable contract.
 
 namespace indigo
 {
@@ -32,160 +62,227 @@ namespace indigo
     DECL_EXCEPTION(PtrArrayError);
 
     template <typename T>
-    class PtrArray
+    class PtrArray final
     {
     public:
-        explicit PtrArray()
-        {
-        }
-
-        virtual ~PtrArray()
-        {
-            clear();
-        }
-
         DECL_TPL_ERROR(PtrArrayError);
 
-        T& add(T* obj)
+        PtrArray() = default;
+        ~PtrArray() = default;
+
+        PtrArray(PtrArray&&) noexcept = default;
+        PtrArray& operator=(PtrArray&&) noexcept = default;
+
+        PtrArray(const PtrArray&) = delete;
+        PtrArray& operator=(const PtrArray&) = delete;
+
+        // ----------------------------------------------------------------
+        // add() — owning overload (preferred): takes ownership via unique_ptr.
+        // Precondition: obj != nullptr. Use expand() if you need null slots.
+        // Exception safety: if emplace_back throws (OOM), `obj` is still
+        // owned by the caller's unique_ptr and will be destroyed cleanly.
+        // ----------------------------------------------------------------
+        T& add(std::unique_ptr<T> obj)
         {
-            _ptrarray.push(obj);
-            return *obj;
+            if (!obj)
+                throw Error("add(): null unique_ptr is not allowed; use expand() for null slots");
+            T* raw = obj.get();
+            // emplace_back may throw (OOM) only before the move takes place
+            // (vector growth path). unique_ptr's move constructor is noexcept,
+            // so if we reach the move step the ownership transfer is atomic.
+            // On throw, obj is still intact — its destructor cleans up.
+            _items.emplace_back(std::move(obj));
+            return *raw;
         }
 
-        T* pop(void)
+        // add() — deprecated raw-pointer overload kept for source compatibility.
+        // Prefer add(std::unique_ptr<T>) or emplace(args...) for new code.
+        // Wraps obj into unique_ptr immediately, then delegates to the owning
+        // overload — this closes the OOM-window where a thrown emplace_back
+        // would leak obj (the historical `add(new T())` anti-pattern risk).
+        [[deprecated("use add(std::unique_ptr<T>) or emplace(...)")]] T& add(T* obj)
         {
-            return _ptrarray.pop();
+            return add(std::unique_ptr<T>(obj));
         }
 
-        T* top(void)
+        // emplace() — constructs T in-place and takes ownership.
+        // Strong exception safety: make_unique may throw; the vector is not
+        // modified in that case.
+        template <class... Args>
+        T& emplace(Args&&... args)
         {
-            return at(size() - 1);
+            return add(std::make_unique<T>(std::forward<Args>(args)...));
         }
 
+        // push() / push(args...) — ObjArray-compatible alias for emplace().
+        // Provided to enable a drop-in source-compatible migration of
+        // ObjArray<T> call sites to PtrArray<T> in milestone-19 Step 2:
+        // existing `arr.push(a, b)` works unchanged, the object is now
+        // heap-allocated and owned by PtrArray.
+        template <class... Args>
+        T& push(Args&&... args)
+        {
+            return emplace(std::forward<Args>(args)...);
+        }
+
+        // ----------------------------------------------------------------
+        // pop() — transfers ownership of the last slot to the caller.
+        // The slot is removed from the array. Throws if the array is empty.
+        // [[nodiscard]]: discarding the return value would silently leak.
+        // ----------------------------------------------------------------
+        [[nodiscard]] std::unique_ptr<T> pop()
+        {
+            if (_items.empty())
+                throw Error("stack underflow");
+            std::unique_ptr<T> result = std::move(_items.back());
+            _items.pop_back();
+            return result;
+        }
+
+        // Raw pointer to the last slot (does not transfer ownership). Throws
+        // if the array is empty — symmetric with pop().
+        T* top()
+        {
+            if (_items.empty())
+                throw Error("top(): array is empty");
+            return _items.back().get();
+        }
+
+        // Grow up to `newsize`, filling new slots with nullptr. Smaller
+        // `newsize` is a no-op (does NOT shrink) — matches the historical
+        // contract used by some clients to pre-allocate sparse arrays.
         void expand(int newsize)
         {
-            while (_ptrarray.size() < newsize)
-                _ptrarray.push(0);
+            if (newsize > static_cast<int>(_items.size()))
+                _items.resize(static_cast<std::size_t>(newsize));
         }
 
-        void clear(void)
+        // Destroys all owned objects; size becomes 0. Null slots are skipped
+        // (delete-on-nullptr is well-defined). Safe on an already-empty
+        // array.
+        void clear() noexcept
         {
-            int i;
-
-            for (i = 0; i < _ptrarray.size(); i++)
-            {
-                if (_ptrarray[i] == 0)
-                    continue;
-
-                delete _ptrarray[i];
-                _ptrarray[i] = 0;
-            }
-            _ptrarray.clear();
+            _items.clear();
         }
 
-        int size() const
+        int size() const noexcept
         {
-            return _ptrarray.size();
+            return static_cast<int>(_items.size());
         }
 
-        void resize(const int newsize)
+        // Grow or shrink to `newsize`. On shrink, deletes the trailing
+        // pointees (skipping nulls). On grow, fills new slots with nullptr.
+        void resize(int newsize)
         {
-            int i, oldsize = _ptrarray.size();
-            for (int i = newsize; i < oldsize; i++)
-            {
-                if (_ptrarray[i] == 0)
-                    continue;
-
-                delete _ptrarray[i];
-                _ptrarray[i] = 0;
-            }
-            _ptrarray.resize(newsize);
-            for (i = oldsize; i < newsize; i++)
-                _ptrarray[i] = 0;
+            _items.resize(static_cast<std::size_t>(newsize));
         }
 
         void removeLast()
         {
-            delete _ptrarray.pop();
+            _items.pop_back();
         }
 
+        // Delete the pointee at `idx` (skipping if null) and shift later
+        // elements left, preserving order.
         void remove(int idx)
         {
-            delete _ptrarray[idx];
-
-            _ptrarray.remove(idx);
+            _check_bounds(idx, "remove");
+            _items.erase(_items.begin() + idx);
         }
 
-        void set(int idx, T* obj)
+        // ----------------------------------------------------------------
+        // set() — owning overload (preferred): places `obj` at slot `idx`.
+        // The slot MUST be currently null (throws otherwise).
+        // ----------------------------------------------------------------
+        void set(int idx, std::unique_ptr<T> obj)
         {
-            if (_ptrarray[idx] != 0)
+            _check_bounds(idx, "set");
+            if (_items[idx] != nullptr)
                 throw Error("object #%d already set", idx);
-
-            _ptrarray[idx] = obj;
+            _items[idx] = std::move(obj);
         }
 
+        // set() — deprecated raw-pointer overload kept for source compatibility.
+        // Wraps obj into unique_ptr before delegating, so a throw from the
+        // owning overload cleans up obj automatically.
+        [[deprecated("use set(int, std::unique_ptr<T>)")]] void set(int idx, T* obj)
+        {
+            set(idx, std::unique_ptr<T>(obj));
+        }
+
+        // Delete the pointee at `idx` (idempotent on null) and null the slot.
         void reset(int idx)
         {
-            delete _ptrarray[idx];
-            _ptrarray[idx] = 0;
+            _check_bounds(idx, "reset");
+            _items[idx].reset();
         }
 
-        void reset(int idx, T* obj)
+        // ----------------------------------------------------------------
+        // reset() with replacement — owning overload (preferred): deletes
+        // the pointee at `idx` and takes ownership of `obj`.
+        // ----------------------------------------------------------------
+        void reset(int idx, std::unique_ptr<T> obj)
         {
-            reset(idx);
-            set(idx, obj);
+            _check_bounds(idx, "reset");
+            _items[idx] = std::move(obj);
         }
 
-        T* release(int idx)
+        // reset() — deprecated raw-pointer overload kept for source compatibility.
+        // Wraps obj into unique_ptr before delegating, so a throw from the
+        // owning overload cleans up obj automatically.
+        [[deprecated("use reset(int, std::unique_ptr<T>)")]] void reset(int idx, T* obj)
         {
-            T* result = _ptrarray[idx];
-            _ptrarray[idx] = 0;
-            return result;
+            reset(idx, std::unique_ptr<T>(obj));
         }
 
-        void qsort(int (*cmp)(T* const&, T* const&, const void*), const void* context)
+        // ----------------------------------------------------------------
+        // release() — transfers ownership of slot `idx` to the caller as a
+        // unique_ptr. The slot becomes null but is NOT removed; size is
+        // unchanged. Returns a null unique_ptr if the slot was already null.
+        // [[nodiscard]]: discarding the return value would silently leak the
+        // pointee (the slot is cleared unconditionally).
+        // ----------------------------------------------------------------
+        [[nodiscard]] std::unique_ptr<T> release(int idx)
         {
-            _ptrarray.qsort(cmp, context);
+            _check_bounds(idx, "release");
+            return std::move(_items[idx]);
         }
 
-        const T* operator[](int index) const
+        const T* operator[](int idx) const
         {
-            return _ptrarray[index];
-        }
-        T*& operator[](int index)
-        {
-            return _ptrarray[index];
+            return _items[idx].get();
         }
 
-        const T* at(int index) const
+        // NOTE: returns `T*` by value, not by `T*&` (lvalue reference), unlike
+        // the historical implementation. Direct `arr[i] = newPtr` is no longer
+        // valid — use `arr.set(i, newPtr)` or `arr.reset(i, newPtr)`.
+        T* operator[](int idx)
         {
-            return _ptrarray[index];
-        }
-        T*& at(int index)
-        {
-            return _ptrarray[index];
-        }
-
-        const T* const* ptr() const
-        {
-            return _ptrarray.ptr();
-        }
-        T** ptr()
-        {
-            return _ptrarray.ptr();
+            return _items[idx].get();
         }
 
-    protected:
-        Array<T*> _ptrarray;
+        const T* at(int idx) const
+        {
+            _check_bounds(idx, "at");
+            return _items[idx].get();
+        }
+
+        T* at(int idx)
+        {
+            _check_bounds(idx, "at");
+            return _items[idx].get();
+        }
 
     private:
-        PtrArray(const PtrArray&); // no implicit copy
+        std::vector<std::unique_ptr<T>> _items;
+
+        void _check_bounds(int idx, const char* method) const
+        {
+            if (idx < 0 || idx >= static_cast<int>(_items.size()))
+                throw Error("%s(): invalid index %d (size=%d)", method, idx, size());
+        }
     };
 
 } // namespace indigo
-
-#ifdef _WIN32
-#pragma warning(pop)
-#endif
 
 #endif

--- a/core/indigo-core/graph/max_common_subgraph.h
+++ b/core/indigo-core/graph/max_common_subgraph.h
@@ -187,7 +187,7 @@ namespace indigo
             // adds new RePoint to nodes set
             void addPoint(int id1, int id2)
             {
-                _graph.add(new RePoint(id1, id2));
+                _graph.emplace(id1, id2);
             };
 
             // main method to perform a query

--- a/core/indigo-core/molecule/src/molecule_3d_constraints.cpp
+++ b/core/indigo-core/molecule/src/molecule_3d_constraints.cpp
@@ -446,8 +446,9 @@ void Molecule3dConstraints::removeAtoms(const int* mapping)
 
     for (i = 0; i < new_constraints.size(); i++)
     {
-        _constraints.add(new_constraints.at(i));
-        new_constraints.release(i);
+        // issue #3691: PtrArray::release now returns
+        // unique_ptr<T>; pass ownership directly into the owning add().
+        _constraints.add(new_constraints.release(i));
     }
 }
 

--- a/core/indigo-core/molecule/src/query_molecule_nodes.cpp
+++ b/core/indigo-core/molecule/src/query_molecule_nodes.cpp
@@ -191,7 +191,7 @@ QueryMolecule::Node* QueryMolecule::Node::_nicht(QueryMolecule::Node* node)
 {
     if (node->type == QueryMolecule::OP_NOT)
     {
-        Node* res = (Node*)node->children.pop();
+        Node* res = node->children.pop().release();
         delete node;
         return res;
     }
@@ -1008,14 +1008,18 @@ QueryMolecule::Atom& QueryMolecule::getAtom(int idx)
 QueryMolecule::Atom* QueryMolecule::releaseAtom(int idx)
 {
     updateEditRevision();
-    return _atoms.release(idx);
+    return _atoms.release(idx).release();
 }
 
 void QueryMolecule::resetAtom(int idx, QueryMolecule::Atom* atom)
 {
+    // milestone-19 / issue #783: PtrArray::operator[] no longer returns T*&.
+    // The original code deleted the old slot conditionally then assigned.
+    // reset(idx, atom) collapses both into one well-defined operation; the
+    // identity guard prevents reset() from deleting `atom` if it already
+    // owns it (which would yield a dangling pointer).
     if (atom != _atoms[idx])
-        _atoms.reset(idx);
-    _atoms[idx] = atom;
+        _atoms.reset(idx, atom);
     updateEditRevision();
 }
 
@@ -1061,13 +1065,14 @@ QueryMolecule::Bond& QueryMolecule::getBond(int idx)
 QueryMolecule::Bond* QueryMolecule::releaseBond(int idx)
 {
     updateEditRevision();
-    return _bonds.release(idx);
+    return _bonds.release(idx).release();
 }
 
 void QueryMolecule::resetBond(int idx, QueryMolecule::Bond* bond)
 {
-    _bonds.reset(idx);
-    _bonds[idx] = bond;
+    // milestone-19 / issue #783: PtrArray::operator[] no longer returns T*&.
+    // Collapsed `reset(idx); arr[idx] = bond;` into `reset(idx, bond)`.
+    _bonds.reset(idx, bond);
     _min_h.clear();
     updateEditRevision();
 }

--- a/core/indigo-core/reaction/pathway_reaction.h
+++ b/core/indigo-core/reaction/pathway_reaction.h
@@ -258,7 +258,10 @@ namespace indigo
         {
             std::unique_ptr<BaseMolecule> mol_copy(mol.neu());
             mol_copy->clone(mol);
-            _molecules.add(mol_copy.release());
+            // issue #3691: pass ownership directly through the
+            // owning add() overload — avoids the deprecated add(T*) path that
+            // would emit a C4996 warning on MSVC.
+            _molecules.add(std::move(mol_copy));
             return static_cast<int>(_molecules.size() - 1);
         }
 

--- a/core/indigo-core/reaction/src/reaction_enumerator_state.cpp
+++ b/core/indigo-core/reaction/src/reaction_enumerator_state.cpp
@@ -109,7 +109,7 @@ void ReactionEnumeratorState::ReactionMonomers::removeMonomer(int idx)
     }
 
     _reactant_indexes.pop();
-    delete (_monomers.pop());
+    (void)_monomers.pop(); // unique_ptr destroys the popped molecule
     _deep_levels.pop();
     _tube_indexes.pop();
 }

--- a/core/indigo-core/tests/tests/ptr_array.cpp
+++ b/core/indigo-core/tests/tests/ptr_array.cpp
@@ -275,7 +275,7 @@ TEST_F(PtrArrayTest, Pop_TransfersOwnership_NoDelete)
 TEST_F(PtrArrayTest, Pop_OnEmpty_Throws)
 {
     PtrArray<Tracked> arr;
-    EXPECT_ANY_THROW(arr.pop());
+    EXPECT_ANY_THROW((void)arr.pop());
 }
 
 TEST_F(PtrArrayTest, RemoveLast_DeletesObject)

--- a/core/indigo-core/tests/tests/ptr_array.cpp
+++ b/core/indigo-core/tests/tests/ptr_array.cpp
@@ -1,0 +1,805 @@
+/****************************************************************************
+ * Copyright (C) from 2009 to Present EPAM Systems.
+ *
+ * This file is part of Indigo toolkit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+// Characterization tests for indigo::PtrArray<T>.
+//
+// Purpose: lock current observable behavior of PtrArray before refactoring
+// (Phase 1 of milestone-19 ObjArray/PtrArray rewrite). These tests must pass
+// against the existing Array<T*>-based implementation AND against the future
+// std::vector<std::unique_ptr<T>>-based wrapper. Anything that diverges
+// between the two implementations represents a breaking-change candidate
+// that must be either reconciled or explicitly documented in the migration
+// notes.
+
+#include <gtest/gtest.h>
+
+#include <base_cpp/ptr_array.h>
+
+#include <stdexcept>
+#include <type_traits>
+
+using namespace indigo;
+
+namespace
+{
+    // Tracked: counts live instances and records construction order. Used to
+    // verify destruction (no leaks, no double-free) and ownership transfers.
+    struct Tracked
+    {
+        static int s_live;
+        static int s_constructed_total;
+
+        int id;
+
+        explicit Tracked(int v = 0) : id(v)
+        {
+            ++s_live;
+            ++s_constructed_total;
+        }
+        Tracked(const Tracked&) = delete;
+        Tracked& operator=(const Tracked&) = delete;
+        ~Tracked()
+        {
+            --s_live;
+            id = -1;
+        }
+
+        static void reset_counters()
+        {
+            s_live = 0;
+            s_constructed_total = 0;
+        }
+    };
+
+    int Tracked::s_live = 0;
+    int Tracked::s_constructed_total = 0;
+
+    // ThrowOnConstruct: throws on construction when the counter reaches zero.
+    // Used to test exception safety of emplace().
+    struct ThrowOnConstruct
+    {
+        static int s_live;
+        static int s_throw_countdown; // if > 0, decremented; throws when hits 0
+
+        int id;
+
+        explicit ThrowOnConstruct(int v = 0)
+        {
+            if (s_throw_countdown > 0 && --s_throw_countdown == 0)
+                throw std::runtime_error("ThrowOnConstruct: intentional throw");
+            id = v;
+            ++s_live;
+        }
+        ~ThrowOnConstruct()
+        {
+            --s_live;
+        }
+
+        static void reset_counters(int countdown = 0)
+        {
+            s_live = 0;
+            s_throw_countdown = countdown;
+        }
+    };
+
+    int ThrowOnConstruct::s_live = 0;
+    int ThrowOnConstruct::s_throw_countdown = 0;
+
+    // Per-test fixture that resets counters and asserts no leaks at TearDown.
+    class PtrArrayTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            Tracked::reset_counters();
+            ThrowOnConstruct::reset_counters();
+        }
+        void TearDown() override
+        {
+            // Subtests must leave Tracked::s_live at 0 by the time the
+            // fixture tears down (i.e. arrays have gone out of scope).
+            EXPECT_EQ(0, Tracked::s_live) << "Tracked instances leaked across test boundary";
+            EXPECT_EQ(0, ThrowOnConstruct::s_live) << "ThrowOnConstruct instances leaked across test boundary";
+        }
+    };
+} // namespace
+
+// =====================================================================
+// Type-trait characterization (compile-time contract).
+// =====================================================================
+
+TEST(PtrArrayTraits, NotCopyable)
+{
+    static_assert(!std::is_copy_constructible_v<PtrArray<int>>, "PtrArray must not be copy-constructible");
+    static_assert(!std::is_copy_assignable_v<PtrArray<int>>, "PtrArray must not be copy-assignable");
+}
+
+TEST(PtrArrayTraits, DefaultConstructible)
+{
+    static_assert(std::is_default_constructible_v<PtrArray<int>>, "PtrArray must be default-constructible");
+}
+
+// Post-Phase-1: PtrArray is nothrow-movable (std::vector + unique_ptr give
+// us this by default). Compile-time enforcement matters here because the
+// downstream rationale for the rewrite is "client containers like
+// std::vector<PtrArray<X>> become viable" — that requires nothrow move.
+TEST(PtrArrayTraits, Movable_PostRefactor)
+{
+    static_assert(std::is_nothrow_move_constructible_v<PtrArray<int>>, "PtrArray must be nothrow-move-constructible");
+    static_assert(std::is_nothrow_move_assignable_v<PtrArray<int>>, "PtrArray must be nothrow-move-assignable");
+    // Belt-and-suspenders runtime check so a regression shows up in test
+    // output even on compilers that allow the static_asserts to lie.
+    EXPECT_TRUE(std::is_nothrow_move_constructible_v<PtrArray<int>>);
+    EXPECT_TRUE(std::is_nothrow_move_assignable_v<PtrArray<int>>);
+}
+
+// Verify move actually transfers ownership and leaves the source empty.
+TEST_F(PtrArrayTest, MoveCtor_TransfersOwnership)
+{
+    PtrArray<Tracked> src;
+    src.emplace(1);
+    src.emplace(2);
+    EXPECT_EQ(2, Tracked::s_live);
+
+    PtrArray<Tracked> dst(std::move(src));
+    EXPECT_EQ(2, dst.size());
+    EXPECT_EQ(0, src.size());      // moved-from is empty
+    EXPECT_EQ(2, Tracked::s_live); // nothing destroyed by the move
+    EXPECT_EQ(1, dst[0]->id);
+    EXPECT_EQ(2, dst[1]->id);
+}
+
+TEST_F(PtrArrayTest, MoveAssign_ReplacesOwnedObjects)
+{
+    PtrArray<Tracked> dst;
+    dst.emplace(100); // dst owns this
+    PtrArray<Tracked> src;
+    src.emplace(200);
+    src.emplace(300);
+
+    dst = std::move(src);
+    // dst's old object (id=100) must be destroyed; dst now owns id=200, 300.
+    EXPECT_EQ(2, dst.size());
+    EXPECT_EQ(200, dst[0]->id);
+    EXPECT_EQ(300, dst[1]->id);
+    EXPECT_EQ(0, src.size());
+    EXPECT_EQ(2, Tracked::s_live);
+}
+
+// =====================================================================
+// Basic API: construction, add, size, operator[], at, top.
+// =====================================================================
+
+TEST_F(PtrArrayTest, DefaultConstructed_IsEmpty)
+{
+    PtrArray<Tracked> arr;
+    EXPECT_EQ(0, arr.size());
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Add_TakesOwnershipAndIncreasesSize)
+{
+    PtrArray<Tracked> arr;
+    Tracked& ref = arr.emplace(42);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(42, ref.id);
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Add_Multiple_PreservesInsertionOrder)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    arr.emplace(3);
+    ASSERT_EQ(3, arr.size());
+    EXPECT_EQ(1, arr[0]->id);
+    EXPECT_EQ(2, arr[1]->id);
+    EXPECT_EQ(3, arr[2]->id);
+    EXPECT_EQ(3, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Destructor_DeletesAllOwnedPointers)
+{
+    {
+        PtrArray<Tracked> arr;
+        arr.emplace(10);
+        arr.emplace(20);
+        EXPECT_EQ(2, Tracked::s_live);
+    }
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, At_EquivalentToBracket)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(7);
+    arr.emplace(8);
+    EXPECT_EQ(arr.at(0)->id, arr[0]->id);
+    EXPECT_EQ(arr.at(1)->id, arr[1]->id);
+}
+
+TEST_F(PtrArrayTest, At_ConstOverload_ReturnsConstPointer)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(11);
+    const PtrArray<Tracked>& cref = arr;
+    const Tracked* p = cref.at(0);
+    EXPECT_EQ(11, p->id);
+}
+
+TEST_F(PtrArrayTest, Top_ReturnsLastElement)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(100);
+    arr.emplace(200);
+    EXPECT_EQ(200, arr.top()->id);
+}
+
+// =====================================================================
+// Pop, removeLast, remove: ownership transfer and shifts.
+// =====================================================================
+
+TEST_F(PtrArrayTest, Pop_TransfersOwnership_NoDelete)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    EXPECT_EQ(2, Tracked::s_live);
+
+    auto popped = arr.pop(); // std::unique_ptr<Tracked>
+    ASSERT_NE(nullptr, popped);
+    EXPECT_EQ(2, popped->id);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(2, Tracked::s_live) << "pop() must not delete the object";
+
+    popped.reset(); // explicit destruction via unique_ptr
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Pop_OnEmpty_Throws)
+{
+    PtrArray<Tracked> arr;
+    EXPECT_ANY_THROW(arr.pop());
+}
+
+TEST_F(PtrArrayTest, RemoveLast_DeletesObject)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    arr.removeLast();
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, Tracked::s_live);
+    EXPECT_EQ(1, arr[0]->id);
+}
+
+TEST_F(PtrArrayTest, Remove_DeletesAndShifts)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(10);
+    arr.emplace(20);
+    arr.emplace(30);
+    arr.remove(1);
+    EXPECT_EQ(2, arr.size());
+    EXPECT_EQ(10, arr[0]->id);
+    EXPECT_EQ(30, arr[1]->id);
+    EXPECT_EQ(2, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Remove_OnNullSlot_IsSafe)
+{
+    // The contract: delete-on-nullptr is well-defined (no-op).
+    PtrArray<Tracked> arr;
+    arr.expand(3); // fills with null
+    arr.remove(1); // delete nullptr -> no-op; shifts
+    EXPECT_EQ(2, arr.size());
+}
+
+// =====================================================================
+// Clear, expand, resize.
+// =====================================================================
+
+TEST_F(PtrArrayTest, Clear_DeletesAllAndResetsSize)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    arr.emplace(3);
+    arr.clear();
+    EXPECT_EQ(0, arr.size());
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Clear_OnEmpty_IsSafe)
+{
+    PtrArray<Tracked> arr;
+    arr.clear();
+    EXPECT_EQ(0, arr.size());
+}
+
+TEST_F(PtrArrayTest, Expand_FillsWithNull_DoesNotShrink)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.expand(4);
+    EXPECT_EQ(4, arr.size());
+    EXPECT_EQ(1, arr[0]->id);
+    EXPECT_EQ(nullptr, arr[1]);
+    EXPECT_EQ(nullptr, arr[2]);
+    EXPECT_EQ(nullptr, arr[3]);
+
+    // expand to smaller size must be no-op (contract from current impl).
+    arr.expand(2);
+    EXPECT_EQ(4, arr.size());
+}
+
+TEST_F(PtrArrayTest, Resize_Grow_FillsWithNull)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.resize(4);
+    EXPECT_EQ(4, arr.size());
+    EXPECT_EQ(1, arr[0]->id);
+    EXPECT_EQ(nullptr, arr[1]);
+    EXPECT_EQ(nullptr, arr[2]);
+    EXPECT_EQ(nullptr, arr[3]);
+}
+
+TEST_F(PtrArrayTest, Resize_Shrink_DeletesExcess)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(10);
+    arr.emplace(20);
+    arr.emplace(30);
+    EXPECT_EQ(3, Tracked::s_live);
+    arr.resize(1);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, Tracked::s_live);
+    EXPECT_EQ(10, arr[0]->id);
+}
+
+TEST_F(PtrArrayTest, Resize_ToZero_EmptiesArray)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    arr.resize(0);
+    EXPECT_EQ(0, arr.size());
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Resize_Same_NoEffect)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.emplace(2);
+    arr.resize(2);
+    EXPECT_EQ(2, arr.size());
+    EXPECT_EQ(2, Tracked::s_live);
+}
+
+// =====================================================================
+// Set, reset, release.
+// =====================================================================
+
+TEST_F(PtrArrayTest, Set_OnNullSlot_TakesOwnership)
+{
+    PtrArray<Tracked> arr;
+    arr.expand(3);
+    arr.set(1, std::make_unique<Tracked>(42));
+    EXPECT_EQ(42, arr[1]->id);
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Set_OnOccupiedSlot_Throws)
+{
+    PtrArray<Tracked> arr;
+    arr.expand(3);
+    arr.set(0, std::make_unique<Tracked>(1));
+    auto second = std::make_unique<Tracked>(2);
+    EXPECT_ANY_THROW(arr.set(0, std::move(second)));
+    // second is now null (moved-from into the function parameter). The throw
+    // fires before _items[idx] is modified, so arr still holds id=1.
+    // The parameter unique_ptr (holding id=2) is destroyed during stack
+    // unwind — so id=2 object is gone, s_live == 1.
+    EXPECT_EQ(1, arr[0]->id);
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Reset_NullSlot_IsIdempotent)
+{
+    PtrArray<Tracked> arr;
+    arr.expand(2);
+    arr.reset(0); // delete nullptr is OK
+    arr.reset(0); // again, still OK
+    EXPECT_EQ(nullptr, arr[0]);
+}
+
+TEST_F(PtrArrayTest, Reset_OccupiedSlot_DeletesAndNulls)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(99);
+    arr.reset(0);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(nullptr, arr[0]);
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Reset_WithReplacement_DeletesOldTakesNew)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(100);
+    arr.reset(0, std::make_unique<Tracked>(200));
+    EXPECT_EQ(200, arr[0]->id);
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Release_TransfersOwnership_NoDelete)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(7);
+    arr.emplace(8);
+
+    auto released = arr.release(0); // std::unique_ptr<Tracked>
+    ASSERT_NE(nullptr, released);
+    EXPECT_EQ(7, released->id);
+    EXPECT_EQ(nullptr, arr[0]) << "Released slot must become null";
+    EXPECT_EQ(2, arr.size()) << "Release must NOT shrink the array";
+    EXPECT_EQ(2, Tracked::s_live) << "Released object must NOT be deleted";
+
+    released.reset();
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, Release_NullSlot_ReturnsNullptr)
+{
+    PtrArray<Tracked> arr;
+    arr.expand(2);
+    auto released = arr.release(0);
+    EXPECT_EQ(nullptr, released);
+    EXPECT_EQ(2, arr.size());
+}
+
+// =====================================================================
+// qsort: intentionally NOT tested.
+//
+// PtrArray::qsort(cmp, context) declares `const void* context` and forwards
+// it to Array<T*>::qsort which expects `void* context`. This produces a
+// hard compile error at instantiation time (function-pointer signature
+// mismatch). No call site in the codebase instantiates it — it is dead
+// code. After Phase 1 refactor we will simply drop the method.
+// =====================================================================
+
+// =====================================================================
+// ptr(): intentionally NOT tested.
+//
+// The historical `T** ptr()` / `const T* const* ptr() const` API exposed
+// the raw underlying C array of pointers. Post-Phase-1 the backing is
+// `std::vector<std::unique_ptr<T>>` whose element layout (`unique_ptr`,
+// not `T*`) is incompatible with the historical contract. The method was
+// dropped: a codebase-wide grep found no real callers on PtrArray-typed
+// variables. Should one resurface, the appropriate replacement is to
+// build a `std::vector<T*>` view on-demand from the array.
+// =====================================================================
+
+// =====================================================================
+// Null-handling contract: nullptr slots are valid and ignored by
+// destruction logic (clear, resize-shrink, dtor).
+// =====================================================================
+
+TEST_F(PtrArrayTest, NullHoles_AreIgnoredByClear)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+    arr.expand(3); // slots 1, 2 are nullptr
+    arr.emplace(4);
+    EXPECT_EQ(4, arr.size());
+    EXPECT_EQ(2, Tracked::s_live);
+    arr.clear();
+    EXPECT_EQ(0, arr.size());
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+TEST_F(PtrArrayTest, NullHoles_AreIgnoredByDestructor)
+{
+    {
+        PtrArray<Tracked> arr;
+        arr.expand(5); // all nullptr
+        arr.set(2, std::make_unique<Tracked>(99));
+        EXPECT_EQ(1, Tracked::s_live);
+    }
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+// =====================================================================
+// Stress / sequence test: combination of operations matches expectations.
+// =====================================================================
+
+TEST_F(PtrArrayTest, StressSequence_NoLeaksNoDoubleFree)
+{
+    PtrArray<Tracked> arr;
+    for (int i = 0; i < 10; ++i)
+        arr.emplace(i);
+    EXPECT_EQ(10, Tracked::s_live);
+
+    // remove a few from middle and end
+    arr.remove(3);    // delete id=3
+    arr.removeLast(); // delete id=9
+    EXPECT_EQ(8, arr.size());
+    EXPECT_EQ(8, Tracked::s_live);
+
+    // release one
+    auto released = arr.release(2);
+    EXPECT_EQ(2, released->id);
+    EXPECT_EQ(8, arr.size()); // released slot is null, size unchanged
+    EXPECT_EQ(nullptr, arr[2]);
+    EXPECT_EQ(8, Tracked::s_live);
+
+    // resize down
+    arr.resize(4);
+    EXPECT_EQ(4, arr.size());
+    // surviving: id=0,1,nullptr,4
+    EXPECT_EQ(0, arr[0]->id);
+    EXPECT_EQ(1, arr[1]->id);
+    EXPECT_EQ(nullptr, arr[2]);
+    EXPECT_EQ(4, arr[3]->id);
+
+    released.reset();
+    // clear destroys remaining 3 owned objects
+    arr.clear();
+    EXPECT_EQ(0, Tracked::s_live);
+}
+
+// =====================================================================
+// PR-1 new tests: unique_ptr-based API, emplace, exception safety.
+// =====================================================================
+
+// add(unique_ptr<T>): ownership transfers into the container.
+TEST_F(PtrArrayTest, Add_FromUniquePtr_TakesOwnership)
+{
+    PtrArray<Tracked> arr;
+    auto obj = std::make_unique<Tracked>(55);
+    Tracked* raw = obj.get();
+
+    Tracked& ref = arr.add(std::move(obj));
+
+    EXPECT_EQ(nullptr, obj) << "unique_ptr must be empty after move";
+    EXPECT_EQ(raw, &ref) << "returned reference must point to the object";
+    EXPECT_EQ(55, ref.id);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, Tracked::s_live);
+    EXPECT_EQ(raw, arr[0]) << "container must store the same pointer";
+}
+
+// emplace(): constructs in-place, returns reference to the new element.
+TEST_F(PtrArrayTest, Emplace_ConstructsInPlace)
+{
+    PtrArray<Tracked> arr;
+
+    Tracked& ref = arr.emplace(77);
+
+    EXPECT_EQ(77, ref.id);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, Tracked::s_live);
+    EXPECT_EQ(&ref, arr[0]) << "returned reference must alias the stored element";
+    EXPECT_EQ(1, Tracked::s_constructed_total);
+}
+
+// push() is an ObjArray-compatible alias for emplace() — added to ease the
+// future Step 2 migration of ObjArray<T> call sites to PtrArray<T> without
+// having to mechanically rewrite every push(args) into emplace(args).
+TEST_F(PtrArrayTest, Push_IsAliasForEmplace)
+{
+    PtrArray<Tracked> arr;
+
+    Tracked& a = arr.push();   // 0-arg form (Tracked default ctor)
+    Tracked& b = arr.push(42); // 1-arg form
+
+    EXPECT_EQ(0, a.id);
+    EXPECT_EQ(42, b.id);
+    EXPECT_EQ(2, arr.size());
+    EXPECT_EQ(2, Tracked::s_live);
+    EXPECT_EQ(&a, arr[0]);
+    EXPECT_EQ(&b, arr[1]);
+    EXPECT_EQ(2, Tracked::s_constructed_total);
+}
+
+// pop() returns unique_ptr; object lives until the unique_ptr goes out of scope.
+TEST_F(PtrArrayTest, Pop_ReturnsUniquePtr_AutoDeletes)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(10);
+    arr.emplace(20);
+    EXPECT_EQ(2, Tracked::s_live);
+
+    {
+        auto p = arr.pop();
+        ASSERT_NE(nullptr, p);
+        EXPECT_EQ(20, p->id);
+        EXPECT_EQ(1, arr.size());
+        EXPECT_EQ(2, Tracked::s_live) << "object must be alive while unique_ptr holds it";
+    }
+    // p went out of scope — Tracked destructor must have been called
+    EXPECT_EQ(1, Tracked::s_live) << "unique_ptr destructor must delete the object";
+}
+
+// release(int) returns unique_ptr; slot becomes null; object is not deleted
+// until the returned unique_ptr is destroyed.
+TEST_F(PtrArrayTest, Release_NodiscardWarning_DoesNotLeak)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(33);
+    arr.emplace(44);
+
+    {
+        auto p = arr.release(0);
+        ASSERT_NE(nullptr, p);
+        EXPECT_EQ(33, p->id);
+        EXPECT_EQ(nullptr, arr[0]) << "slot must be null after release";
+        EXPECT_EQ(2, arr.size()) << "size must not change after release";
+        EXPECT_EQ(2, Tracked::s_live) << "object must be alive while unique_ptr holds it";
+    }
+    // p destroyed — id=33 object cleaned up
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+// Deprecated raw-pointer overload of add() still compiles and works.
+// Suppressing the deprecation warning explicitly so the test suite remains
+// warning-clean under -Werror when this test is intentionally exercising
+// the legacy path.
+TEST_F(PtrArrayTest, Add_FromDeprecatedRaw_StillWorks)
+{
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+    PtrArray<Tracked> arr;
+    Tracked& ref = arr.add(new Tracked(99));
+    EXPECT_EQ(99, ref.id);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, Tracked::s_live);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}
+
+// emplace(): if T's constructor throws, the container must be unchanged
+// (strong exception safety: make_unique throws before emplace_back is called).
+TEST_F(PtrArrayTest, Emplace_ExceptionInCtor_ContainerUnchanged)
+{
+    PtrArray<ThrowOnConstruct> arr;
+
+    // Pre-populate one element successfully.
+    arr.emplace(1);
+    EXPECT_EQ(1, arr.size());
+    EXPECT_EQ(1, ThrowOnConstruct::s_live);
+
+    // On the next construction attempt the counter fires and throws.
+    ThrowOnConstruct::s_throw_countdown = 1;
+    EXPECT_THROW(arr.emplace(2), std::runtime_error);
+
+    // Container must be exactly as before the failed emplace.
+    EXPECT_EQ(1, arr.size()) << "size must not change after failed emplace";
+    EXPECT_EQ(1, arr[0]->id) << "existing element must be unaffected";
+    EXPECT_EQ(1, ThrowOnConstruct::s_live) << "no partially-constructed objects must survive";
+}
+
+// add() with a null unique_ptr is rejected — the T& return type cannot
+// represent "no object", and silently storing a null slot would be a UB trap
+// for downstream code. Use expand() if null slots are needed.
+TEST_F(PtrArrayTest, Add_NullUniquePtr_Throws)
+{
+    PtrArray<Tracked> arr;
+    arr.emplace(1);
+
+    std::unique_ptr<Tracked> null_ptr;
+    ASSERT_EQ(nullptr, null_ptr);
+
+    EXPECT_ANY_THROW(arr.add(std::move(null_ptr)));
+    EXPECT_EQ(1, arr.size()) << "size must not change on rejected add";
+    EXPECT_EQ(1, arr[0]->id);
+    EXPECT_EQ(1, Tracked::s_live);
+}
+
+// Deprecated set(int, T*) overload delegates to the owning overload — verifies
+// it still compiles and the slot is occupied as expected.
+TEST_F(PtrArrayTest, Set_FromDeprecatedRaw_StillWorks)
+{
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+    PtrArray<Tracked> arr;
+    arr.expand(2);
+    arr.set(1, new Tracked(77));
+    EXPECT_EQ(77, arr[1]->id);
+    EXPECT_EQ(1, Tracked::s_live);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}
+
+// Deprecated reset(int, T*) overload — verifies delegation works and the
+// previous slot occupant is destroyed.
+TEST_F(PtrArrayTest, Reset_FromDeprecatedRaw_StillWorks)
+{
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+    PtrArray<Tracked> arr;
+    arr.emplace(10);
+    arr.reset(0, new Tracked(20));
+    EXPECT_EQ(20, arr[0]->id);
+    EXPECT_EQ(1, Tracked::s_live) << "previous occupant must be destroyed";
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}
+
+// Bounds checks: set/reset/release/at/remove must throw on out-of-range indices.
+// Symmetric coverage of negative and beyond-end indices for every mutator.
+TEST_F(PtrArrayTest, BoundsChecks_OutOfRange_Throw)
+{
+    PtrArray<Tracked> arr;
+    arr.expand(2);
+
+    EXPECT_ANY_THROW(arr.set(-1, std::make_unique<Tracked>(1)));
+    EXPECT_ANY_THROW(arr.set(5, std::make_unique<Tracked>(2)));
+    EXPECT_ANY_THROW(arr.reset(-1));
+    EXPECT_ANY_THROW(arr.reset(5));
+    EXPECT_ANY_THROW(arr.reset(-1, std::make_unique<Tracked>(3)));
+    EXPECT_ANY_THROW(arr.reset(5, std::make_unique<Tracked>(4)));
+    EXPECT_ANY_THROW(arr.remove(-1));
+    EXPECT_ANY_THROW(arr.remove(5));
+    EXPECT_ANY_THROW((void)arr.release(-1));
+    EXPECT_ANY_THROW((void)arr.release(5));
+    EXPECT_ANY_THROW((void)arr.at(-1));
+    EXPECT_ANY_THROW((void)arr.at(5));
+    EXPECT_EQ(2, arr.size()) << "size must remain unchanged after rejected ops";
+    EXPECT_EQ(0, Tracked::s_live) << "rejected setters must not leak temporaries";
+}
+
+// top() on empty array — throws (symmetric with pop()).
+TEST_F(PtrArrayTest, Top_OnEmpty_Throws)
+{
+    PtrArray<Tracked> arr;
+    EXPECT_ANY_THROW((void)arr.top());
+}


### PR DESCRIPTION


This is first PR from container refactoring Milestone. Tightens PtrArray<T> API contract on top of #783 baseline, while keeping source compatibility for existing call sites via [[deprecated]] overloads that delegate to the new owning overloads (DRY + strong exception safety).

## Remove-me-section
* Notify reviewers about the pull request
* Keep only necessary sections below for the review

## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
