### PR TITLE
 #3688 - `Add explicit hydrogens` operation causes unfolded hydrogen out of query component

### DIFF
--- a/api/tests/integration/ref/basic/fold_unfold.py.out
+++ b/api/tests/integration/ref/basic/fold_unfold.py.out
@@ -1405,6 +1405,6 @@ testing C1C=CC=C([CH])C=1 |^4:5|
 C1([H])=C([H])C([C][H])=C([H])C([H])=C1[H] |^4:5|
 testing queryComponent ket
 4
-[0, 1]
+[0, 1, 2, 3]
 4
-[0, 1]
+[0, 1, 2, 3]

--- a/core/indigo-core/molecule/base_molecule.h
+++ b/core/indigo-core/molecule/base_molecule.h
@@ -405,6 +405,7 @@ namespace indigo
         virtual int addBond_Silent(int beg, int end, int order) = 0;
 
         void unfoldHydrogens(Array<int>* markers_out, int max_h_cnt = -1, bool impl_h_no_throw = false, bool only_selected = false);
+        virtual void registerUnfoldedHydrogenQueryComponent(int /*atom_idx*/, int /*added_hydrogen*/){}; // QueryMolecule only
 
         virtual int getImplicitH(int idx, bool impl_h_no_throw) = 0;
         virtual void setImplicitH(int idx, int impl_h) = 0;

--- a/core/indigo-core/molecule/query_molecule.h
+++ b/core/indigo-core/molecule/query_molecule.h
@@ -433,6 +433,8 @@ namespace indigo
         // must belong to different connected components of the target molecule
         Array<int> components;
 
+        virtual void registerUnfoldedHydrogenQueryComponent(int atom_idx, int added_hydrogen);
+
         void getComponentNeighbors(std::list<std::unordered_set<int>>& componentNeighbors);
 
         void invalidateAtom(int index, int mask) override;

--- a/core/indigo-core/molecule/src/base_molecule_properties.cpp
+++ b/core/indigo-core/molecule/src/base_molecule_properties.cpp
@@ -440,6 +440,7 @@ void BaseMolecule::unfoldHydrogens(Array<int>* markers_out, int max_h_cnt, bool 
                 cis_trans.registerUnfoldedHydrogen(*this, i, new_h_idx);
                 allene_stereo.registerUnfoldedHydrogen(i, new_h_idx);
                 sgroups.registerUnfoldedHydrogen(i, new_h_idx);
+                registerUnfoldedHydrogenQueryComponent(i, new_h_idx);
             }
 
             setImplicitH(i, impl_h - h_cnt);

--- a/core/indigo-core/molecule/src/query_molecule.cpp
+++ b/core/indigo-core/molecule/src/query_molecule.cpp
@@ -1379,6 +1379,12 @@ void QueryMolecule::getQueryAtomLabel(int qa, Array<char>& result)
         result.readString(it->second.c_str(), true);
 }
 
+void QueryMolecule::registerUnfoldedHydrogenQueryComponent(int atom_idx, int added_hydrogen)
+{
+    components.expandFill(added_hydrogen + 1, 0);
+    components[added_hydrogen] = components[atom_idx];
+}
+
 void QueryMolecule::getComponentNeighbors(std::list<std::unordered_set<int>>& componentNeighbors)
 {
     std::unordered_map<int, std::unordered_set<int>> componentAtoms;


### PR DESCRIPTION
 Fix code. Add UT`Add explicit hydrogens` operation causes unfolded hydrogen out of query component


## Generic request
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name does not contain '#'
- [ ] base branch (master or release/xx) is correct
- [ ] PR is linked with the issue
- [ ] task status changed to "Code review"
- [ ] code follows product standards
- [ ] regression tests updated
### For release/xx branch
- [ ] backmerge to master (or newer release/xx) branch is created
