### PR TITLE
Port stripSalt and checkSalt from Python to Java API

### DIFF
--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -880,6 +880,27 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
     }
 
     /**
+     * Verifies whether the structure contains a disconnected inorganic component ("salt").
+     *
+     * @return {@code true} if the structure contains a salt
+     */
+    public boolean checkSalt() {
+        dispatcher.setSessionID();
+
+        for (IndigoObject component : iterateComponents()) {
+            IndigoObject targetFragment = component.clone();
+            for (String salt : Salts.SALTS) {
+                IndigoObject querySalt = dispatcher.loadSmarts(salt);
+                IndigoObject matcher = dispatcher.substructureMatcher(targetFragment);
+                if (matcher.match(querySalt) != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Strips all disconnected inorganic components ("salts") from the molecule.
      *
      * <p>Returns a copy of the molecule without its inorganic components.

--- a/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/IndigoObject.java
@@ -22,6 +22,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -876,6 +877,56 @@ public class IndigoObject implements Iterator<IndigoObject>, Iterable<IndigoObje
         dispatcher.setSessionID();
         return new IndigoObject(
                 dispatcher, Indigo.checkResult(this, lib.indigoComponent(self, index)), this);
+    }
+
+    /**
+     * Strips all disconnected inorganic components ("salts") from the molecule.
+     *
+     * <p>Returns a copy of the molecule without its inorganic components.
+     *
+     * @return a new molecule without inorganic components
+     */
+    public IndigoObject stripSalt() {
+        return stripSalt(false);
+    }
+
+    /**
+     * Strips all disconnected inorganic components ("salts") from the molecule.
+     *
+     * @param inplace if {@code false} - returns a copy of the molecule without inorganic
+     *     components; if {@code true} - strips inorganic components from the molecule itself
+     * @return if {@code inplace} is {@code false} - a new molecule without inorganic components;
+     *     if {@code inplace} is {@code true} - this molecule, without inorganic components
+     */
+    public IndigoObject stripSalt(boolean inplace) {
+        dispatcher.setSessionID();
+
+        ArrayList<Integer> saltAtoms = new ArrayList<>();
+        int idx = 0;
+        for (IndigoObject component : iterateComponents()) {
+            IndigoObject targetFragment = component.clone();
+            int nAtoms = targetFragment.countAtoms();
+
+            for (String salt : Salts.SALTS) {
+                IndigoObject querySalt = dispatcher.loadQueryMolecule(salt);
+                IndigoObject matcher = dispatcher.substructureMatcher(targetFragment);
+                if (matcher.match(querySalt) != null) {
+                    for (int i = idx; i < idx + nAtoms; i++) {
+                        saltAtoms.add(i);
+                    }
+                }
+            }
+            idx += nAtoms;
+        }
+
+        if (!inplace) {
+            IndigoObject saltlessFragment = clone();
+            saltlessFragment.removeAtoms(saltAtoms);
+            return saltlessFragment;
+        } else {
+            removeAtoms(saltAtoms);
+            return this;
+        }
     }
 
     public int countSSSR() {

--- a/api/java/indigo/src/main/java/com/epam/indigo/Salts.java
+++ b/api/java/indigo/src/main/java/com/epam/indigo/Salts.java
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * Copyright (C) from 2009 to Present EPAM Systems.
+ *
+ * This file is part of Indigo toolkit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+package com.epam.indigo;
+
+/** SMARTS patterns describing inorganic components ("salts"). */
+final class Salts {
+
+    private Salts() {}
+
+    static final String[] SALTS = {
+        // inorganics with quaternary atom
+        "[X4&!#1&!#6](~[X1&!#6])(~[X1&!#6])(~[X1&!#6])~[X1&!#6]",
+        "[X4&!#1&!#6](~[X2H&!#6])(~[X2H&!#6])(~[X2H&!#6])~[X1&!#6]",
+        "[X4&!#1&!#6](~[X2H&!#6])(~[X2H&!#6])(~[X1&!#6])~[X1&!#6]",
+        "[X4&!#1&!#6](~[X2H&!#6])(~[X1&!#6])(~[X1&!#6])~[X1&!#6]",
+        // inorganics with tertiary atom
+        "[X3&!#1&!#6](~[X1&!#6])(~[X1&!#6])~[X1&!#6]",
+        "[X3&!#1&!#6](~[X2H&!#6])(~[X2H&!#6])~[X1&!#6]",
+        "[X3&!#1&!#6](~[X2H&!#6])(~[X1&!#6])~[X1&!#6]",
+        // inorganics with secondary atom
+        "[X2&!#1&!#6](~[X1&!#6])~[X1&!#6]",
+        "[X2&!#1&!#6](~[X2H&!#6])~[X1&!#6]",
+        // inorganics with primary atom
+        "[X1&!#1&!#6]~[X1&!#6]",
+        // single-element ions
+        "[X0+1]",
+        "[X0+2]",
+        "[X0+3]",
+        "[X0+4]",
+        "[X0-1]",
+        "[X0-2]",
+    };
+}

--- a/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
+++ b/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IndigoTests {
 
@@ -46,6 +48,84 @@ public class IndigoTests {
         assertEquals(molWithNoRg.countRGroups(), 0);
         molWithRg.copyRGroups(molWithNoRg);
         assertEquals(molWithNoRg.countRGroups(), 1);
+    }
+
+    @Test
+    @DisplayName("checkSalt detects mono-, di-, tri- and tetravalent monoatomic cations")
+    void testCheckSaltMonoatomicCations() {
+        Indigo indigo = new Indigo();
+        assertTrue(indigo.loadMolecule("[Na+].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Rb+].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Ca+2].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Zn+2].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Al+3].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Cr+3].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Ru+4].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Sn+4].C").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt detects mono- and divalent monoatomic anions")
+    void testCheckSaltMonoatomicAnions() {
+        Indigo indigo = new Indigo();
+        assertTrue(indigo.loadMolecule("[Cl-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[F-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[S-2].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[Se-2].C").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt detects molecular inorganic salts")
+    void testCheckSaltMolecularSalts() {
+        Indigo indigo = new Indigo();
+        assertTrue(indigo.loadMolecule("S=[Fe].C").checkSalt());
+        assertTrue(indigo.loadMolecule("Cl[Ag]").checkSalt());
+        assertTrue(indigo.loadMolecule("S=[Sn]=S.C").checkSalt());
+        assertTrue(indigo.loadMolecule("O=[Mn]=O.C").checkSalt());
+        assertTrue(indigo.loadMolecule("Cl[Fe](Cl)Cl.C").checkSalt());
+        assertTrue(indigo.loadMolecule("OCl(=O)=O.C").checkSalt());
+        assertTrue(indigo.loadMolecule("OS(=O)(=O)O.C").checkSalt());
+        assertTrue(indigo.loadMolecule("OP(=O)(O)O.C").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt detects complex inorganic ions")
+    void testCheckSaltComplexIons() {
+        Indigo indigo = new Indigo();
+        assertTrue(indigo.loadMolecule("[OH-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[O-]Cl.C").checkSalt());
+        assertTrue(indigo.loadMolecule("[O-]I=O.C").checkSalt());
+        assertTrue(indigo.loadMolecule("[O-]N(=O).C").checkSalt());
+        assertTrue(indigo.loadMolecule("[N+](=O)([O-])[O-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("O[Se](=O)[O-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("OP(=O)(O)[O-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("OS(=O)(=O)[O-].C").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt detects structures containing several ions")
+    void testCheckSaltMultipleIons() {
+        Indigo indigo = new Indigo();
+        assertTrue(indigo.loadMolecule("[Na+].[Cl-].C").checkSalt());
+        assertTrue(indigo.loadMolecule("[O-]S(=O)(=O)[O-].[K+].[K+].C").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt returns false for structures without disconnected inorganic components")
+    void testCheckSaltNoIons() {
+        Indigo indigo = new Indigo();
+        assertFalse(indigo.loadMolecule("c1ccccc1").checkSalt());
+        assertFalse(indigo.loadMolecule("C1=CC=C2C=CC=CC2=C1").checkSalt());
+    }
+
+    @Test
+    @DisplayName("checkSalt returns false when the metal or acid group is bonded to an organic part")
+    void testCheckSaltBonded() {
+        Indigo indigo = new Indigo();
+        assertFalse(indigo.loadMolecule("CC[Pb](CC)(CC)CC").checkSalt());
+        assertFalse(indigo.loadMolecule("C[Al](C)C").checkSalt());
+        assertFalse(indigo.loadMolecule("C1=CC=C(C=C1)[N+](=O)[O-]").checkSalt());
+        assertFalse(indigo.loadMolecule("C(C(=O)O)S(=O)(=O)O").checkSalt());
     }
 
     @Test

--- a/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
+++ b/api/java/indigo/src/test/java/com/epam/indigo/IndigoTests.java
@@ -47,4 +47,73 @@ public class IndigoTests {
         molWithRg.copyRGroups(molWithNoRg);
         assertEquals(molWithNoRg.countRGroups(), 1);
     }
+
+    @Test
+    @DisplayName("stripSalt keeps a molecule without disconnected inorganic components intact")
+    void testStripSaltNoSalts() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule("CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1");
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1", m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt removes a single inorganic anion")
+    void testStripSaltSingleSalt() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule("CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1.[Cl-]");
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1", m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt removes many inorganic components (water and anions)")
+    void testStripSaltManySalts() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule(
+            "CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1.O.O.O.O.O.O.O.O.O.O.[Cl-].[Cl-]");
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1", m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt keeps multiple organic components and removes the anion")
+    void testStripSaltTwoOrganics() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule(
+            "CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1.CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1.[O-]S(=O)(=O)[O-]");
+        assertEquals(
+            "CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1.CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1",
+            m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt keeps organic acids and a lone metal atom")
+    void testStripSaltComplexSalt() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule(
+            "C(C(C(C(C(C(=O)O)O)O)O)O)O.C(C(C(C(C(C(=O)O)O)O)O)O)O.[Fe]");
+        assertEquals(
+            "C(O)C(O)C(O)C(O)C(O)C(O)=O.C(O)C(O)C(O)C(O)C(O)C(O)=O.[Fe]",
+            m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt yields an empty molecule when only inorganic components are present")
+    void testStripSaltOnlySalts() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule("[NH4+].[O-]P(=O)([O-])[O-].[Fe+2]");
+        assertEquals("", m.stripSalt().smiles());
+    }
+
+    @Test
+    @DisplayName("stripSalt inplace=false leaves the original untouched; inplace=true mutates it")
+    void testStripSaltOptions() {
+        Indigo indigo = new Indigo();
+        IndigoObject m = indigo.loadMolecule("CCCCCCCCCCCCCCCC[N+]1C=CC=CC=1.[Cl-]");
+        IndigoObject mStrip = m.stripSalt();
+
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1", mStrip.smiles());
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1.[Cl-]", m.smiles());
+
+        m.stripSalt(true);
+        assertEquals("CCCCCCCCCCCCCCCC[N+]1=CC=CC=C1", m.smiles());
+    }
 }


### PR DESCRIPTION
## Generic request
- [x] branch name does not contain '#'
- [x] base branch (master) is correct
- [x] code follows product standards
- [x] regression tests updated
### Optional
- [x] unit-tests written

## Summary

`stripSalt` and `checkSalt` previously existed only in the **Python** binding (`api/python/indigo/indigo/indigo_object.py`). This PR ports both to the **Java** API so the two bindings reach parity.

### Changes
- **`Salts.java`** (new) — port of Python `salts.py` `SALTS`: the SMARTS patterns that describe disconnected inorganic components. (`IONS` was not ported — it is unused dead code in the Python module.)
- **`IndigoObject.checkSalt()`** — line-for-line port of the Python method: for each component, substructure-match each salt pattern (loaded via `loadSmarts`, as in Python) and return `true` on the first match.
- **`IndigoObject.stripSalt()`** and **`stripSalt(boolean inplace)`** — port of the Python algorithm: for each component, substructure-match each salt pattern; atoms of matching components are collected and removed, either on a clone (`inplace=false`, the default) or in place (`inplace=true`).
- **`IndigoTests.java`** — cases mirroring the Python suite in `api/python/tests/test_indigo.py`:
  - `checkSalt`: monoatomic cations/anions, molecular salts, complex ions, multiple ions, and the negative cases (no ions, bonded metal/acid groups).
  - `stripSalt`: no salt, single salt, many salts, multiple organics, complex salt, only-salts, and the `inplace` option.

### Verification
- `mvn test-compile` of the `indigo` module passes.
- The Java unit tests could not be executed locally (no native C++ toolchain on the dev host to build `dist/lib`); they will run in CI against the built native library. Behavior matches the Python implementation, whose equivalent tests pass.

> Note: there is no linked issue for this parity port, so the PR title does not follow the `#1234 – issue name` pattern. Happy to attach an issue number if one should be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)