### PR TITLE
Backmerge: #3823 - valence-mode option has no impact on fold/unfold hydrogens operation (#3826)

### DIFF
--- a/api/c/indigo/src/indigo_molecule.cpp
+++ b/api/c/indigo/src/indigo_molecule.cpp
@@ -691,6 +691,8 @@ CEXPORT int indigoLoadKetDocument(int source)
         }
         std::unique_ptr<IndigoKetDocument> docptr = std::make_unique<IndigoKetDocument>();
         KetDocumentJsonLoader loader{};
+        // The document converts to a Molecule lazily; see KetDocument::setOptions.
+        docptr->get().setOptions(self.loaderOptions());
         loader.parseJson(json_str, docptr->get());
         return self.addObject(docptr.release());
     }

--- a/api/c/indigo/src/indigo_molecule_operations.cpp
+++ b/api/c/indigo/src/indigo_molecule_operations.cpp
@@ -2590,6 +2590,10 @@ CEXPORT int indigoCreateMolecule()
     INDIGO_BEGIN
     {
         std::unique_ptr<IndigoMolecule> obj = std::make_unique<IndigoMolecule>();
+        // No loader runs here, so nothing else would capture the session's
+        // valence model and addAtom() would infer implicit H with the default.
+        obj->mol.setIgnoreBadValenceFlag(self.ignore_bad_valence);
+        obj->mol.setValenceMode(self.valence_mode);
         return self.addObject(obj.release());
     }
     INDIGO_END(-1);

--- a/api/c/tests/unit/tests/loader_options.cpp
+++ b/api/c/tests/unit/tests/loader_options.cpp
@@ -1,0 +1,364 @@
+/****************************************************************************
+ * Copyright (C) from 2009 to Present EPAM Systems.
+ *
+ * This file is part of Indigo toolkit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+// Loader-option conformance across every input path.
+//
+// Why this file exists (issue #3823): loader options used to reach only some
+// input formats. MoleculeAutoLoader hand-copied a different subset of fields at
+// each of its dispatch sites, so `valence-mode` was honoured for molfile but
+// silently dropped for KET — Ketcher's native format — as well as CML and
+// SMILES. Two further paths had no loader at all to copy from:
+// createMolecule()/addAtom() and loadKetDocument().
+//
+// The guard is not any single assertion but the SHAPE of the table below: the
+// same expectation stated for every format. A per-format gap cannot reappear
+// without turning a row red.
+//
+// TO COVER A NEW OPTION: add rows to kCases. Add a probe or a format only if
+// the option needs an observable or an input path that is not there yet.
+
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "common.h"
+#include <base_cpp/exception.h>
+#include <indigo.h>
+
+using namespace indigo;
+
+namespace
+{
+    // ─── Inputs ──────────────────────────────────────────────────────────────
+    // A single atom is all the chemistry needed: the two models diverge only
+    // while an atom is under-coordinated.
+
+    struct Structure
+    {
+        const char* symbol;
+        int charge;
+        bool explicit_h; // attach one explicitly drawn hydrogen
+    };
+
+    std::string asMolfile(const Structure& s)
+    {
+        std::ostringstream out;
+        out << "\n  Indigo  0000000002D\n\n"
+            << (s.explicit_h ? "  2  1" : "  1  0") << "  0  0  0  0  0  0  0  0999 V2000\n"
+            << "    0.0000    0.0000    0.0000 " << std::string(s.symbol) + std::string(3 - strlen(s.symbol), ' ') << " 0  0  0  0  0  0  0  0  0  0  0  0\n";
+        if (s.explicit_h)
+        {
+            out << "    1.5000    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n";
+            out << "  1  2  1  0  0  0  0\n";
+        }
+        if (s.charge != 0)
+            out << "M  CHG  1   1 " << (s.charge < 0 ? "" : " ") << s.charge << "\n";
+        out << "M  END\n";
+        return out.str();
+    }
+
+    std::string asKet(const Structure& s)
+    {
+        std::ostringstream out;
+        out << R"({"root":{"nodes":[{"$ref":"mol0"}]},"mol0":{"type":"molecule","atoms":[{"label":")" << s.symbol << R"(","location":[0,0,0])";
+        if (s.charge != 0)
+            out << R"(,"charge":)" << s.charge;
+        out << "}";
+        if (s.explicit_h)
+            out << R"(,{"label":"H","location":[1.5,0,0]})";
+        out << R"(],"bonds":[)";
+        if (s.explicit_h)
+            out << R"({"type":1,"atoms":[0,1]})";
+        out << "]}}";
+        return out.str();
+    }
+
+    std::string asCml(const Structure& s)
+    {
+        std::ostringstream out;
+        out << R"(<molecule><atomArray><atom id="a1" elementType=")" << s.symbol << "\"";
+        if (s.charge != 0)
+            out << R"( formalCharge=")" << s.charge << "\"";
+        out << "/>";
+        if (s.explicit_h)
+            out << R"(<atom id="a2" elementType="H"/>)";
+        out << "</atomArray><bondArray>";
+        if (s.explicit_h)
+            out << R"(<bond atomRefs2="a1 a2" order="1"/>)";
+        out << "</bondArray></molecule>";
+        return out.str();
+    }
+
+    // A bracket atom in SMILES carries an EXPLICIT hydrogen count by definition,
+    // so this format pins the H count regardless of the model. Included anyway:
+    // `valence` still tracks the option and would expose a dropped one.
+    std::string asSmiles(const Structure& s)
+    {
+        std::ostringstream out;
+        out << "[" << s.symbol;
+        if (s.explicit_h)
+            out << "H";
+        for (int i = 0; i < std::abs(s.charge); ++i)
+            out << (s.charge < 0 ? "-" : "+");
+        out << "]";
+        return out.str();
+    }
+
+    // ─── Cases ───────────────────────────────────────────────────────────────
+
+    struct Case
+    {
+        Structure structure;
+        const char* format; // mol | ket | cml | smi | api | ketdoc
+        const char* probe;  // valence | implicit_h | gross_formula | smiles
+        const char* mode_a;
+        const char* expect_a;
+        const char* mode_b;
+        const char* expect_b;
+    };
+
+    constexpr Structure kAl{"Al", 0, false};
+    constexpr Structure kLi{"Li", 0, false};
+    constexpr Structure kMg{"Mg", 0, false};
+    constexpr Structure kGa{"Ga", 0, false};
+    constexpr Structure kC{"C", 0, false};
+    constexpr Structure kAlMinus{"Al", -1, false};
+    constexpr Structure kLiH{"Li", 0, true};
+
+    const Case kCases[] = {
+        // Under-coordinated main-group metals: 2017 intercepts them
+        // (valence = conn, hyd = 0), 2009 fills the group valence with H.
+        {kAl, "mol", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+        {kAl, "ket", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+        {kAl, "cml", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+        {kAl, "smi", "valence", "biovia-2009", "3", "biovia-2017", "0"},
+        {kAl, "api", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+        {kAl, "ketdoc", "smiles", "biovia-2009", "[AlH3]", "biovia-2017", "[Al]"},
+
+        {kLi, "mol", "implicit_h", "biovia-2009", "1", "biovia-2017", "0"},
+        {kLi, "ket", "implicit_h", "biovia-2009", "1", "biovia-2017", "0"},
+        {kLi, "cml", "implicit_h", "biovia-2009", "1", "biovia-2017", "0"},
+        {kLi, "smi", "valence", "biovia-2009", "1", "biovia-2017", "0"},
+        {kLi, "api", "implicit_h", "biovia-2009", "1", "biovia-2017", "0"},
+        {kLi, "ketdoc", "smiles", "biovia-2009", "[LiH]", "biovia-2017", "[Li]"},
+        {kLi, "mol", "gross_formula", "biovia-2009", "H Li", "biovia-2017", "Li"},
+        {kLi, "ket", "gross_formula", "biovia-2009", "H Li", "biovia-2017", "Li"},
+
+        {kMg, "ket", "valence", "biovia-2009", "2", "biovia-2017", "0"},
+        {kGa, "ket", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+        {kGa, "cml", "implicit_h", "biovia-2009", "3", "biovia-2017", "0"},
+
+        // Negative controls. Each pins a case that LOOKS like the option is
+        // broken but is correct by design; together they stop an over-eager
+        // "fix" from making the models diverge where they must not.
+        //
+        // Carbon is in the BIOVIA-2017 22-element table, so never intercepted.
+        {kC, "mol", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        {kC, "ket", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        {kC, "api", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        // Al(-1) is the documented carve-out. Cancelling the interception does
+        // not raise the valence to 4 — the 2009 ladder already returns 4.
+        {kAlMinus, "mol", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        {kAlMinus, "ket", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        {kAlMinus, "api", "implicit_h", "biovia-2009", "4", "biovia-2017", "4"},
+        // A SATURATED metal is indistinguishable: interception gives
+        // valence = conn = 1 and the 2009 group-1 ladder independently gives
+        // valence 1 / hyd 0. This is the exact structure originally reported as
+        // proof that the switch does not work.
+        {kLiH, "mol", "implicit_h", "biovia-2009", "0", "biovia-2017", "0"},
+        {kLiH, "ket", "valence", "biovia-2009", "1", "biovia-2017", "1"},
+        {kLiH, "ket", "gross_formula", "biovia-2009", "H Li", "biovia-2017", "H Li"},
+
+        // `default` is deliberately an alias whose target may move (2009 today,
+        // 2017 later). These rows pin today's meaning on purpose: when the alias
+        // is repointed they fail loudly and force the change to be acknowledged
+        // rather than letting it happen silently.
+        {kLi, "mol", "implicit_h", "default", "1", "biovia-2009", "1"},
+        {kAl, "ket", "implicit_h", "default", "3", "biovia-2009", "3"},
+    };
+
+    // ─── Execution ───────────────────────────────────────────────────────────
+
+    std::string label(const Case& c)
+    {
+        std::ostringstream out;
+        out << c.structure.symbol;
+        if (c.structure.charge)
+            out << "(" << c.structure.charge << ")";
+        if (c.structure.explicit_h)
+            out << "H";
+        out << "/" << c.format << "/" << c.probe;
+        return out.str();
+    }
+
+    // Most formats go through a loader. Two deliberately do not:
+    //   api    - built via indigoCreateMolecule/indigoAddAtom, so only the
+    //            C-API layer can seed the session's model onto it.
+    //   ketdoc - loaded as a KetDocument, whose conversion to a Molecule is
+    //            deferred past the point where the session is still reachable.
+    int buildMolecule(const Case& c)
+    {
+        const std::string fmt = c.format;
+        if (fmt == "api")
+        {
+            const int mol = indigoCreateMolecule();
+            const int atom = indigoAddAtom(mol, c.structure.symbol);
+            if (c.structure.charge != 0)
+                indigoSetCharge(atom, c.structure.charge);
+            indigoFree(atom);
+            return mol;
+        }
+        if (fmt == "ketdoc")
+            return indigoLoadKetDocumentFromString(asKet(c.structure).c_str());
+        if (fmt == "mol")
+            return indigoLoadMoleculeFromString(asMolfile(c.structure).c_str());
+        if (fmt == "ket")
+            return indigoLoadMoleculeFromString(asKet(c.structure).c_str());
+        if (fmt == "cml")
+            return indigoLoadMoleculeFromString(asCml(c.structure).c_str());
+        if (fmt == "smi")
+            return indigoLoadMoleculeFromString(asSmiles(c.structure).c_str());
+        ADD_FAILURE() << "unknown format " << fmt;
+        return -1;
+    }
+
+    std::string probeMolecule(int mol, const std::string& probe, int atom_index)
+    {
+        if (probe == "gross_formula")
+        {
+            const int gross = indigoGrossFormula(mol);
+            const std::string result = indigoToString(gross);
+            indigoFree(gross);
+            return result;
+        }
+        // The only observable reachable on a KetDocument object; reading it
+        // forces the deferred document -> molecule conversion.
+        if (probe == "smiles")
+            return indigoSmiles(mol);
+
+        const int atom = indigoGetAtom(mol, atom_index);
+        std::string result;
+        if (probe == "valence")
+            result = std::to_string(indigoValence(atom));
+        else if (probe == "implicit_h")
+            result = std::to_string(indigoCountImplicitHydrogens(atom));
+        else
+            ADD_FAILURE() << "unknown probe " << probe;
+        indigoFree(atom);
+        return result;
+    }
+
+    std::string run(const Case& c, const char* option, const char* value)
+    {
+        // Bare metals under BIOVIA-2009 can trip the bad-valence check; these
+        // cases are about which model is applied, not about error policy.
+        indigoSetOption("ignore-bad-valence", "true");
+        indigoSetOption(option, value);
+        const int mol = buildMolecule(c);
+        EXPECT_NE(-1, mol) << "failed to build " << label(c);
+        if (mol == -1)
+            return "<build-failed>";
+        const std::string result = probeMolecule(mol, c.probe, 0);
+        indigoFree(mol);
+        return result;
+    }
+}
+
+class LoaderOptionsTest : public IndigoApiTest
+{
+};
+
+TEST_F(LoaderOptionsTest, ValenceModeIsHonouredOnEveryInputPath)
+{
+    for (const auto& c : kCases)
+    {
+        EXPECT_EQ(c.expect_a, run(c, "valence-mode", c.mode_a)) << label(c) << " with " << c.mode_a;
+        EXPECT_EQ(c.expect_b, run(c, "valence-mode", c.mode_b)) << label(c) << " with " << c.mode_b;
+    }
+}
+
+// Sub-structures are parsed by a second loader instance the first one builds.
+// That instance starts from defaults, so it has to be handed the options too —
+// otherwise an R-group fragment keeps the default model while the root honours
+// the option. Same defect as above, one level down, and invisible to any probe
+// that only looks at the root.
+TEST_F(LoaderOptionsTest, NestedFragmentsInheritTheModel)
+{
+    const char* rgroup_ket = R"({"root":{"nodes":[{"$ref":"rg1"}]},)"
+                             R"("rg1":{"rlogic":{"number":1},"type":"rgroup",)"
+                             R"("atoms":[{"label":"Al","location":[0,0,0]}],"bonds":[]}})";
+
+    const auto smilesWith = [&](const char* mode) {
+        indigoSetOption("ignore-bad-valence", "true");
+        indigoSetOption("valence-mode", mode);
+        const int mol = indigoLoadMoleculeFromString(rgroup_ket);
+        EXPECT_NE(-1, mol);
+        if (mol == -1)
+            return std::string("<build-failed>");
+        const std::string result = indigoSmiles(mol);
+        indigoFree(mol);
+        return result;
+    };
+
+    EXPECT_NE(std::string::npos, smilesWith("biovia-2009").find("[AlH3]"));
+
+    const std::string with_2017 = smilesWith("biovia-2017");
+    EXPECT_EQ(std::string::npos, with_2017.find("[AlH3]")) << "R-group fragment kept the 2009 model: " << with_2017;
+    EXPECT_NE(std::string::npos, with_2017.find("[Al]")) << with_2017;
+}
+
+TEST_F(LoaderOptionsTest, InvalidValueIsRejected)
+{
+    // A silently ignored bad value would look exactly like the original defect.
+    // IndigoApiTest installs an error handler that rethrows, so the rejection
+    // surfaces as an exception rather than a -1 return.
+    EXPECT_THROW(indigoSetOption("valence-mode", "not-a-mode"), Exception);
+    // A valid value must still be accepted afterwards — a rejected value must
+    // not leave the session in a broken state.
+    EXPECT_NO_THROW(indigoSetOption("valence-mode", "biovia-2017"));
+}
+
+// Ketcher reaches Indigo through channels that each filter the caller's option
+// map before handing it to setOption. Every filter is a DENY-list, so an option
+// is forwarded unless someone names it — which means a one-word edit in either
+// file can disable an option for that channel with nothing else noticing.
+TEST_F(LoaderOptionsTest, NoChannelDeniesTheOption)
+{
+    const std::string repo = std::string(DATA_PATH) + "/..";
+    const std::pair<const char*, const char*> channels[] = {
+        {"WASM binding (Ketcher in-process)", "/api/wasm/indigo-ketcher/indigo-ketcher.cpp"},
+        {"legacy Flask service (/v2/indigo/*)", "/utils/indigo-service/backend/service/v2/indigo_api.py"},
+    };
+    const std::set<std::string> options{"valence-mode"};
+
+    for (const auto& channel : channels)
+    {
+        std::ifstream stream(repo + channel.second);
+        if (!stream.good())
+            continue; // not present in a partial checkout
+        std::ostringstream buffer;
+        buffer << stream.rdbuf();
+        const std::string source = buffer.str();
+        for (const auto& option : options)
+            EXPECT_EQ(std::string::npos, source.find("\"" + option + "\"")) << channel.first << ": option \"" << option << "\" appears in " << channel.second
+                                                                            << " — if it was added to the skip list, that channel now drops it";
+    }
+}

--- a/api/http/tests/test_indigo_http.py
+++ b/api/http/tests/test_indigo_http.py
@@ -559,6 +559,50 @@ def test_valence_mode_accepted(mode: str) -> None:
     assert response.status_code == 200, response.text
 
 
+# Bare neutral aluminium in KET — Ketcher's native format, and the shape from
+# issue #3823. Under BIOVIA-2017 it is an intercepted metal: no implicit H.
+_BARE_AL_KET = (
+    '{"root":{"nodes":[{"$ref":"mol0"}]},"mol0":{"type":"molecule",'
+    '"atoms":[{"label":"Al","location":[0,0,0]}]}}'
+)
+
+_BARE_AL_MOLFILE = (
+    "\n  Indigo  0000000002D\n\n"
+    "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+    "    0.0000    0.0000    0.0000 Al  0  0  0  0  0  0  0  0  0  0  0  0\n"
+    "M  END\n"
+)
+
+
+def _convert_struct(structure: str, mode: str) -> str:
+    response = client.post(
+        "/indigo/convert",
+        json=_convert_request(structure, {"valence-mode": mode}),
+    )
+    assert response.status_code == 200, response.text
+    # str(): the JSON body is untyped, and mypy rejects returning Any here.
+    return str(response.json()["data"]["attributes"]["structure"])
+
+
+@pytest.mark.parametrize(
+    "structure", [_BARE_AL_KET, _BARE_AL_MOLFILE], ids=["ket", "molfile"]
+)
+def test_valence_mode_changes_the_result(structure: str) -> None:
+    # Asserting a status code is not enough: the original defect returned 200
+    # with the option silently ignored. Pin the actual output instead, and pin
+    # it identically for KET and molfile — the defect was format-specific, so a
+    # single-format test would have passed throughout.
+    assert _convert_struct(structure, "biovia-2009") == "[AlH3]"
+    assert _convert_struct(structure, "biovia-2017") == "[Al]"
+
+
+def test_valence_mode_default_is_biovia_2009() -> None:
+    # "default" is an alias for the legacy table, not "let Indigo choose".
+    assert _convert_struct(_BARE_AL_KET, "default") == _convert_struct(
+        _BARE_AL_KET, "biovia-2009"
+    )
+
+
 def test_valence_mode_invalid_value_rejected() -> None:
     # The options dict is forwarded generically to Indigo.setOption(); an
     # unknown value is rejected at the C layer and surfaces as 400 via the

--- a/api/wasm/indigo-ketcher/test/test.js
+++ b/api/wasm/indigo-ketcher/test/test.js
@@ -554,6 +554,88 @@ M  END
         });
     }
 
+    // valence-mode over the in-process WASM channel.
+    //
+    // Regression cover for issue #3823: the option had no impact on
+    // fold/unfold hydrogens. It reached the Indigo session correctly —
+    // indigoSetOptions filters against a deny-list that never contained it —
+    // but MoleculeAutoLoader failed to forward it to MoleculeJsonLoader, so KET
+    // input, which is what Ketcher actually sends, kept the BIOVIA-2009 model.
+    //
+    // api/c/tests/unit/tests/loader_options.cpp pins the same expectations at
+    // the C-API level. These cases add what it cannot reach: the Emscripten
+    // binding, its per-call IndigoSession and its option filter.
+    {
+        // Verbatim from the issue: a bare, neutral aluminium. Under
+        // BIOVIA-2017 it is an intercepted metal, so unfolding adds no H.
+        const bare_al_ket = JSON.stringify({
+            root: { nodes: [{ $ref: "mol0" }] },
+            mol0: { type: "molecule", atoms: [{ label: "Al", location: [0, 0, 0] }] }
+        });
+
+        const bare_al_molfile = "\n  Indigo  0000000002D\n\n"
+            + "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+            + "    0.0000    0.0000    0.0000 Al  0  0  0  0  0  0  0  0  0  0  0  0\n"
+            + "M  END\n";
+
+        function unfoldWithValenceMode(struct, mode) {
+            let options = new indigo.MapStringString();
+            options.set("valence-mode", mode);
+            try {
+                return indigo.convert_explicit_hydrogens(struct, "unfold", "smiles", options);
+            } finally {
+                options.delete();
+            }
+        }
+
+        test("valence_mode", "metal_ket_biovia_2017_adds_no_hydrogens", () => {
+            assert.equal(unfoldWithValenceMode(bare_al_ket, "biovia-2017"), "[Al]");
+        });
+
+        test("valence_mode", "metal_ket_biovia_2009_adds_hydrogens", () => {
+            // Unfolding materialises implicit hydrogens as separate ATOMS, so
+            // the SMILES is the expanded form, not the collapsed [AlH3].
+            assert.equal(unfoldWithValenceMode(bare_al_ket, "biovia-2009"), "[Al]([H])([H])[H]");
+        });
+
+        test("valence_mode", "ket_and_molfile_agree", () => {
+            // The defect was format-specific, so a single-format assertion
+            // would have stayed green throughout.
+            assert.equal(unfoldWithValenceMode(bare_al_molfile, "biovia-2017"), "[Al]");
+            assert.equal(unfoldWithValenceMode(bare_al_molfile, "biovia-2009"), "[Al]([H])([H])[H]");
+        });
+
+        test("valence_mode", "default_is_biovia_2009", () => {
+            // "default" is an alias for the legacy table, not "let Indigo choose".
+            assert.equal(
+                unfoldWithValenceMode(bare_al_ket, "default"),
+                unfoldWithValenceMode(bare_al_ket, "biovia-2009"));
+        });
+
+        test("valence_mode", "saturated_metal_is_mode_independent", () => {
+            // Negative control: a SATURATED metal, where interception gives
+            // valence = conn and both models agree. This shape was originally
+            // mistaken for "the option does nothing".
+            const li_h_ket = JSON.stringify({
+                root: { nodes: [{ $ref: "mol0" }] },
+                mol0: {
+                    type: "molecule",
+                    atoms: [{ label: "Li", location: [0, 0, 0] }, { label: "H", location: [1.5, 0, 0] }],
+                    bonds: [{ type: 1, atoms: [0, 1] }]
+                }
+            });
+            assert.equal(
+                unfoldWithValenceMode(li_h_ket, "biovia-2017"),
+                unfoldWithValenceMode(li_h_ket, "biovia-2009"));
+        });
+
+        test("valence_mode", "invalid_value_is_rejected", () => {
+            // The binding forwards unknown values verbatim; the C layer must
+            // reject them rather than silently falling back to a default.
+            assert.throws(() => unfoldWithValenceMode(bare_al_ket, "not-a-mode"));
+        });
+    }
+
     // Convert explicit hydrogens
     {
         test("convert_explicit_hydrogens", "auto", () => {

--- a/core/indigo-core/molecule/ket_document.h
+++ b/core/indigo-core/molecule/ket_document.h
@@ -21,6 +21,7 @@
 
 #include "molecule/ket_monomer_shape.h"
 #include "molecule/ket_objects.h"
+#include "molecule/loader_options.h"
 #include "molecule/monomers_template_library.h"
 
 #include <rapidjson/document.h> // Temporary until direct conversion to molecule supported
@@ -150,6 +151,17 @@ namespace indigo
 
         BaseMolecule& getBaseMolecule();
 
+        // getBaseMolecule() converts lazily, long after the Indigo session is
+        // reachable, so the options have to travel with the document.
+        // Out of line: dropping the cached conversion needs the complete
+        // Molecule type, forward-declared here.
+        void setOptions(const LoaderOptions& opts);
+
+        const LoaderOptions& getOptions() const
+        {
+            return _options;
+        }
+
         bool hasAmbiguousMonomerTemplate(const std::string& id) const
         {
             return _ambiguous_templates.find(id) != _ambiguous_templates.end();
@@ -260,6 +272,7 @@ namespace indigo
         std::vector<KetMonomerShape> _monomer_shapes;
         std::optional<KetAnnotation> _annotation;
         mutable std::unique_ptr<Molecule> _cached_molecule;
+        LoaderOptions _options;
     };
 }
 

--- a/core/indigo-core/molecule/molecule_json_loader.h
+++ b/core/indigo-core/molecule/molecule_json_loader.h
@@ -27,6 +27,7 @@
 #include "base_c/defs.h"
 #include "base_cpp/exception.h"
 #include "base_cpp/non_copyable.h"
+#include "molecule/loader_options.h"
 #include "molecule/molecule_stereocenter_options.h"
 
 #ifdef _WIN32
@@ -65,7 +66,14 @@ namespace indigo
         void loadMolecule(BaseMolecule& mol, bool load_arrows = false);
         void loadMonomerLibrary(MonomerTemplateLibrary& library);
         bool isParsed() const;
+
+        // See loader_options.h for the contract.
+        void setOptions(const LoaderOptions& opts);
+        LoaderOptions getOptions() const;
+
         StereocentersOptions stereochemistry_options;
+        ValenceMode valence_mode;   // valence table used to infer implicit H
+        bool ignore_bad_valence;    // collapse bad valence instead of throwing
         bool treat_x_as_pseudoatom; // normally 'X' means 'any halogen'
         bool skip_3d_chirality;     // do not compute chirality from 3D coordinates
         bool ignore_no_chiral_flag; // ignore chiral flag absence (treat stereo "as drawn")

--- a/core/indigo-core/molecule/src/ket_document.cpp
+++ b/core/indigo-core/molecule/src/ket_document.cpp
@@ -145,6 +145,12 @@ std::unique_ptr<KetBaseMonomer>& KetDocument::addAmbiguousMonomer(const std::str
     return addAmbiguousMonomer(id, alias, template_id);
 }
 
+void KetDocument::setOptions(const LoaderOptions& opts)
+{
+    _options = opts;
+    _cached_molecule.reset(); // a stale conversion would keep the old model
+}
+
 BaseMolecule& KetDocument::getBaseMolecule()
 {
     if (!_cached_molecule)
@@ -158,6 +164,7 @@ BaseMolecule& KetDocument::getBaseMolecule()
         rapidjson::Document data;
         std::ignore = data.Parse(json.c_str());
         MoleculeJsonLoader loader(data);
+        loader.setOptions(_options);
         loader.stereochemistry_options.ignore_errors = true;
         loader.ignore_noncritical_query_features = true;
         _cached_molecule = std::make_unique<Molecule>();

--- a/core/indigo-core/molecule/src/molecule_auto_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_auto_loader.cpp
@@ -297,11 +297,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
             gzscanner.readAll(buf);
             MoleculeAutoLoader loader2(buf);
 
-            loader2.stereochemistry_options = stereochemistry_options;
-            loader2.ignore_noncritical_query_features = ignore_noncritical_query_features;
-            loader2.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-            loader2.skip_3d_chirality = skip_3d_chirality;
-            loader2.ignore_no_chiral_flag = ignore_no_chiral_flag;
+            loader2.setOptions(getOptions());
             loader2.treat_stereo_as = treat_stereo_as;
             loader2.loadMolecule(mol);
             return;
@@ -314,7 +310,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
         {
             local_scanner->seek(kCDX_HeaderLength, SEEK_CUR);
             MoleculeCdxmlLoader loader(*local_scanner, true);
-            loader.stereochemistry_options = stereochemistry_options;
+            loader.setOptions(getOptions());
             loader.loadMolecule(mol);
             return;
         }
@@ -332,13 +328,8 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
         {
             BufferScanner scanner2(buf);
             MolfileLoader loader(scanner2, monomer_lib);
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-            loader.skip_3d_chirality = skip_3d_chirality;
-            loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-            loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
+            loader.setOptions(getOptions());
             loader.treat_stereo_as = treat_stereo_as;
-            loader.valence_mode = valence_mode;
 
             if (query)
                 loader.loadQueryMolecule((QueryMolecule&)mol);
@@ -379,7 +370,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
             if (_scanner->findWord("<molecule"))
             {
                 CmlLoader loader(*_scanner);
-                loader.stereochemistry_options = stereochemistry_options;
+                loader.setOptions(getOptions());
                 if (query)
                     loader.loadQueryMolecule((QueryMolecule&)mol);
                 else
@@ -402,7 +393,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
         {
             _scanner->seek(pos, SEEK_SET);
             MoleculeCdxmlLoader loader(*_scanner);
-            loader.stereochemistry_options = stereochemistry_options;
+            loader.setOptions(getOptions());
             loader.loadMolecule(mol);
             return;
         }
@@ -432,11 +423,7 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
                         if (data.HasMember("root"))
                         {
                             MoleculeJsonLoader loader(data);
-                            loader.stereochemistry_options = stereochemistry_options;
-                            loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-                            loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-                            loader.skip_3d_chirality = skip_3d_chirality;
-                            loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
+                            loader.setOptions(getOptions());
                             loader.treat_stereo_as = treat_stereo_as;
                             loader.loadMolecule(mol);
                             return;
@@ -553,10 +540,9 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
                 SmilesLoader loader(*_scanner);
                 long long start = _scanner->tell();
 
+                loader.setOptions(getOptions());
                 loader.ignore_closing_bond_direction_mismatch = ignore_closing_bond_direction_mismatch;
-                loader.stereochemistry_options = stereochemistry_options;
                 loader.ignore_cistrans_errors = ignore_cistrans_errors;
-                loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
                 loader.strict_aliphatic = smiles_loading_strict_aliphatic;
                 /*
                 If exception is thrown, try the SMARTS, if exception thrown again - the string is rather an IUPAC name than a SMILES string
@@ -630,13 +616,8 @@ void MoleculeAutoLoader::_loadMolecule(BaseMolecule& mol, MonomerTemplateLibrary
             BufferScanner scanner2(sdf_loader.data);
 
             MolfileLoader loader(scanner2, monomer_lib);
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-            loader.skip_3d_chirality = skip_3d_chirality;
-            loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-            loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
+            loader.setOptions(getOptions());
             loader.treat_stereo_as = treat_stereo_as;
-            loader.valence_mode = valence_mode;
 
             if (is_first && sdf_loader.isEOF())
             {

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -1622,7 +1622,7 @@ void MoleculeCdxmlLoader::_parseAltGroup(BaseCDXElement& elem)
             MoleculeRGroups& rgroups = mol.rgroups;
             RGroup& rgroup = rgroups.getRGroup(r_labels.front());
             BaseMolecule& fragment = rgroup.fragments.push_t(BaseMolecule::poolFactoryLike(mol));
-            alt_loader.stereochemistry_options = stereochemistry_options;
+            alt_loader.setOptions(getOptions());
             alt_loader.loadMoleculeFromFragment(fragment, *r_fragments.front());
         }
     }

--- a/core/indigo-core/molecule/src/molecule_json_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_json_loader.cpp
@@ -30,8 +30,8 @@ IMPL_ERROR(MoleculeJsonLoader, "molecule json loader");
 
 MoleculeJsonLoader::MoleculeJsonLoader(Document& ket)
     : _mol_array(kArrayType), _mol_nodes(_mol_array), _meta_objects(kArrayType), _templates(kArrayType), _monomer_array(kArrayType),
-      _connection_array(kArrayType), _monomer_shapes(kArrayType), _pmol(0), _pqmol(0), ignore_noncritical_query_features(false), _components_count(0),
-      _parsed(false), _document(), _annotation(kArrayType)
+      _connection_array(kArrayType), _monomer_shapes(kArrayType), _pmol(0), _pqmol(0), ignore_noncritical_query_features(false),
+      valence_mode(ValenceMode::BIOVIA_2009), ignore_bad_valence(false), _components_count(0), _parsed(false), _document(), _annotation(kArrayType)
 {
     parse_ket(ket);
     _parsed = true;
@@ -169,8 +169,8 @@ void MoleculeJsonLoader::parse_ket(Document& ket)
 
 MoleculeJsonLoader::MoleculeJsonLoader(Scanner& scanner)
     : _mol_array(kArrayType), _mol_nodes(_mol_array), _meta_objects(kArrayType), _templates(kArrayType), _monomer_array(kArrayType),
-      _connection_array(kArrayType), _monomer_shapes(kArrayType), _pmol(0), _pqmol(0), ignore_noncritical_query_features(false), _components_count(0),
-      _parsed(false), _document(), _annotation(kArrayType)
+      _connection_array(kArrayType), _monomer_shapes(kArrayType), _pmol(0), _pqmol(0), ignore_noncritical_query_features(false),
+      valence_mode(ValenceMode::BIOVIA_2009), ignore_bad_valence(false), _components_count(0), _parsed(false), _document(), _annotation(kArrayType)
 {
     if (scanner.lookNext() == '{')
     {
@@ -192,8 +192,33 @@ MoleculeJsonLoader::MoleculeJsonLoader(Scanner& scanner)
 MoleculeJsonLoader::MoleculeJsonLoader(Value& mol_nodes)
     : _mol_nodes(mol_nodes), _meta_objects(kArrayType), _templates(kArrayType), _monomer_array(kArrayType), _connection_array(kArrayType),
       _monomer_shapes(kArrayType), _pmol(0), _pqmol(0), ignore_noncritical_query_features(false), ignore_no_chiral_flag(false), skip_3d_chirality(false),
-      treat_x_as_pseudoatom(false), treat_stereo_as(0), _components_count(0), _parsed(true), _document(), _annotation(kArrayType)
+      treat_x_as_pseudoatom(false), treat_stereo_as(0), valence_mode(ValenceMode::BIOVIA_2009), ignore_bad_valence(false), _components_count(0), _parsed(true),
+      _document(), _annotation(kArrayType)
 {
+}
+
+void MoleculeJsonLoader::setOptions(const LoaderOptions& opts)
+{
+    stereochemistry_options = opts.stereochemistry_options;
+    valence_mode = opts.valence_mode;
+    ignore_bad_valence = opts.ignore_bad_valence;
+    ignore_no_chiral_flag = opts.ignore_no_chiral_flag;
+    ignore_noncritical_query_features = opts.ignore_noncritical_query_features;
+    skip_3d_chirality = opts.skip_3d_chirality;
+    treat_x_as_pseudoatom = opts.treat_x_as_pseudoatom;
+}
+
+LoaderOptions MoleculeJsonLoader::getOptions() const
+{
+    LoaderOptions opts;
+    opts.stereochemistry_options = stereochemistry_options;
+    opts.valence_mode = valence_mode;
+    opts.ignore_bad_valence = ignore_bad_valence;
+    opts.ignore_no_chiral_flag = ignore_no_chiral_flag;
+    opts.ignore_noncritical_query_features = ignore_noncritical_query_features;
+    opts.skip_3d_chirality = skip_3d_chirality;
+    opts.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
+    return opts;
 }
 
 bool MoleculeJsonLoader::isParsed() const
@@ -1392,6 +1417,8 @@ int MoleculeJsonLoader::parseMonomerTemplate(const rapidjson::Value& monomer_tem
     monomer_template_cp.CopyFrom(monomer_template, data.GetAllocator());
     one_tgroup.PushBack(monomer_template_cp, data.GetAllocator());
     MoleculeJsonLoader loader(one_tgroup);
+    // Static entry point, so only the stereo options are in scope. Monomer
+    // templates are C/N/O/P fragments, where both valence tables agree.
     loader.stereochemistry_options = stereochemistry_options;
     loader.ignore_noncritical_query_features = true;
     tg.fragment.reset(mol.neu());
@@ -1663,6 +1690,17 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
     if (!_parsed)
         throw Error("Invalid JSON input");
 
+    // Order matters: atom parsing infers implicit H using the molecule's current
+    // valence model, so the mode must be captured before any atom is added.
+    // Seeding the target too covers a KET with no fragments, where no merge
+    // would carry the mode over.
+    if (!mol.isQueryMolecule())
+    {
+        Molecule& target = mol.asMolecule();
+        target.setIgnoreBadValenceFlag(ignore_bad_valence);
+        target.setValenceMode(valence_mode);
+    }
+
     PtrArray<Array<int>> mol_mappings;
     for (rapidjson::SizeType node_idx = 0; node_idx < _mol_nodes.Size(); ++node_idx)
     {
@@ -1677,6 +1715,10 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
         else
         {
             _pmol = &pmol->asMolecule();
+            // Fragments are parsed standalone, so each needs the mode too —
+            // implicit H is inferred here, before the merge.
+            _pmol->setIgnoreBadValenceFlag(ignore_bad_valence);
+            _pmol->setValenceMode(valence_mode);
         }
         mol.original_format = BaseMolecule::KET;
 
@@ -1763,7 +1805,7 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
                 BaseMolecule& fragment = rgroup.fragments.push_t(BaseMolecule::poolFactoryLike(mol));
                 one_rnode.PushBack(rfragments[i], data.GetAllocator());
                 MoleculeJsonLoader loader(one_rnode);
-                loader.stereochemistry_options = stereochemistry_options;
+                loader.setOptions(getOptions());
                 loader.loadMolecule(fragment);
                 one_rnode.Clear();
             }
@@ -1773,7 +1815,7 @@ void MoleculeJsonLoader::loadMolecule(BaseMolecule& mol, bool load_arrows)
             BaseMolecule& fragment = rgroup.fragments.push_t(BaseMolecule::poolFactoryLike(mol));
             one_rnode.PushBack(rnode, data.GetAllocator());
             MoleculeJsonLoader loader(one_rnode);
-            loader.stereochemistry_options = stereochemistry_options;
+            loader.setOptions(getOptions());
             loader.loadMolecule(fragment);
         }
     }

--- a/core/indigo-core/reaction/src/reaction_auto_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_auto_loader.cpp
@@ -44,7 +44,7 @@ void ReactionAutoLoader::_init()
     ignore_cistrans_errors = false;
     ignore_no_chiral_flag = false;
     ignore_bad_valence = false;
-    valence_mode = ValenceMode::BIOVIA_2017;
+    valence_mode = ValenceMode::BIOVIA_2009;
     dearomatize_on_load = false;
     treat_stereo_as = 0;
 }
@@ -170,12 +170,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
             gzscanner.readAll(buf);
             ReactionAutoLoader loader2(buf);
 
-            loader2.stereochemistry_options = stereochemistry_options;
-            loader2.ignore_noncritical_query_features = ignore_noncritical_query_features;
-            loader2.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-            loader2.ignore_no_chiral_flag = ignore_no_chiral_flag;
-            loader2.ignore_bad_valence = ignore_bad_valence;
-            loader2.valence_mode = valence_mode;
+            loader2.setOptions(getOptions());
             return loader2.loadReaction(query);
         }
     }
@@ -186,8 +181,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
         {
             local_scanner->seek(kCDX_HeaderLength, SEEK_CUR);
             ReactionCdxmlLoader loader(*local_scanner, true);
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_bad_valence = ignore_bad_valence;
+            loader.setOptions(getOptions());
             if (query)
                 throw Error("CDX queries not supported yet");
             auto reaction = std::make_unique<Reaction>();
@@ -206,12 +200,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
         {
             BufferScanner scanner2(buf);
             RxnfileLoader loader(scanner2);
-            loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-            loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
-            loader.ignore_bad_valence = ignore_bad_valence;
-            loader.valence_mode = valence_mode;
+            loader.setOptions(getOptions());
             if (query)
             {
                 auto reaction = std::make_unique<QueryReaction>();
@@ -259,8 +248,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
             if (_scanner->findWord("<reaction"))
             {
                 ReactionCmlLoader loader(*_scanner);
-                loader.stereochemistry_options = stereochemistry_options;
-                loader.ignore_bad_valence = ignore_bad_valence;
+                loader.setOptions(getOptions());
 
                 if (query)
                     throw Error("CML queries not supported");
@@ -283,8 +271,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
         {
             _scanner->seek(pos, SEEK_SET);
             ReactionCdxmlLoader loader(*_scanner);
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_bad_valence = ignore_bad_valence;
+            loader.setOptions(getOptions());
 
             if (query)
             {
@@ -342,11 +329,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
                         if (data.HasMember("root") && data["root"].HasMember("nodes"))
                         {
                             ReactionJsonLoader loader(data, layout_options);
-                            loader.stereochemistry_options = stereochemistry_options;
-                            loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-                            loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-                            loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
-                            loader.ignore_bad_valence = ignore_bad_valence;
+                            loader.setOptions(getOptions());
                             std::unique_ptr<BaseReaction> reaction;
                             if (is_pathway)
                             {
@@ -402,13 +385,8 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
                 rdf_loader.readNext();
                 BufferScanner reaction_scanner(rdf_loader.data);
                 RxnfileLoader loader(reaction_scanner);
-                loader.stereochemistry_options = stereochemistry_options;
-                loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-                loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-                loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
+                loader.setOptions(getOptions());
                 loader.treat_stereo_as = treat_stereo_as;
-                loader.ignore_bad_valence = ignore_bad_valence;
-                loader.valence_mode = valence_mode;
                 reactions.emplace_back();
                 loader.loadReaction(reactions.back(), rdf_loader.properties, monomer_lib);
             }
@@ -428,8 +406,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
 
             loader.ignore_closing_bond_direction_mismatch = ignore_closing_bond_direction_mismatch;
             loader.ignore_cistrans_errors = ignore_cistrans_errors;
-            loader.stereochemistry_options = stereochemistry_options;
-            loader.ignore_bad_valence = ignore_bad_valence;
+            loader.setOptions(getOptions());
 
             if (query)
             {
@@ -459,12 +436,7 @@ std::unique_ptr<BaseReaction> ReactionAutoLoader::_loadReaction(bool query, Mono
     // default is Rxnfile format
     {
         RxnfileLoader loader(*_scanner);
-        loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-        loader.stereochemistry_options = stereochemistry_options;
-        loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-        loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
-        loader.ignore_bad_valence = ignore_bad_valence;
-        loader.valence_mode = valence_mode;
+        loader.setOptions(getOptions());
 
         if (query)
         {

--- a/core/indigo-core/reaction/src/reaction_cdxml_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_cdxml_loader.cpp
@@ -143,9 +143,7 @@ void ReactionCdxmlLoader::loadReaction(BaseReaction& rxn)
     std::unique_ptr<CDXReader> cdx_reader = _is_binary ? std::make_unique<CDXReader>(_scanner) : std::make_unique<CDXMLReader>(_scanner);
     cdx_reader->process();
     MoleculeCdxmlLoader loader(_scanner, _is_binary);
-    loader.stereochemistry_options = stereochemistry_options;
-    loader.ignore_bad_valence = ignore_bad_valence;
-    loader.valence_mode = valence_mode;
+    loader.setOptions(getOptions());
     loader.parseCDXMLAttributes(*cdx_reader->rootElement()->firstProperty());
 
     for (auto page_elem = cdx_reader->rootElement()->firstChildElement(); page_elem->hasContent(); page_elem = page_elem->nextSiblingElement())

--- a/core/indigo-core/reaction/src/reaction_cml_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_cml_loader.cpp
@@ -96,9 +96,7 @@ void ReactionCmlLoader::loadReaction(Reaction& rxn)
             continue;
         XMLHandle handle(elem);
         CmlLoader loader(handle);
-        loader.stereochemistry_options = stereochemistry_options;
-        loader.ignore_bad_valence = ignore_bad_valence;
-        loader.valence_mode = valence_mode;
+        loader.setOptions(getOptions());
         loader.loadMolecule(mol);
         rxn.addReactantCopy(mol, 0, 0);
     }
@@ -110,9 +108,7 @@ void ReactionCmlLoader::loadReaction(Reaction& rxn)
             continue;
         XMLHandle handle(elem);
         CmlLoader loader(handle);
-        loader.stereochemistry_options = stereochemistry_options;
-        loader.ignore_bad_valence = ignore_bad_valence;
-        loader.valence_mode = valence_mode;
+        loader.setOptions(getOptions());
         loader.loadMolecule(mol);
         rxn.addProductCopy(mol, 0, 0);
     }
@@ -124,9 +120,7 @@ void ReactionCmlLoader::loadReaction(Reaction& rxn)
             continue;
         XMLHandle handle(elem);
         CmlLoader loader(handle);
-        loader.stereochemistry_options = stereochemistry_options;
-        loader.ignore_bad_valence = ignore_bad_valence;
-        loader.valence_mode = valence_mode;
+        loader.setOptions(getOptions());
         loader.loadMolecule(mol);
         rxn.addCatalystCopy(mol, 0, 0);
     }

--- a/core/indigo-core/reaction/src/reaction_json_loader.cpp
+++ b/core/indigo-core/reaction/src/reaction_json_loader.cpp
@@ -71,10 +71,7 @@ LoaderOptions ReactionJsonLoader::getOptions() const
 
 void ReactionJsonLoader::loadReaction(BaseReaction& rxn)
 {
-    _loader.stereochemistry_options = stereochemistry_options;
-    _loader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-    _loader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-    _loader.ignore_no_chiral_flag = ignore_no_chiral_flag;
+    _loader.setOptions(getOptions());
 
     if (rxn.isQueryReaction())
     {

--- a/core/indigo-core/reaction/src/rsmiles_loader.cpp
+++ b/core/indigo-core/reaction/src/rsmiles_loader.cpp
@@ -140,9 +140,7 @@ void RSmilesLoader::_loadReaction()
     r_loader.ignorable_aam = &rcnt_aam_ignorable;
     r_loader.smarts_mode = smarts_mode;
     r_loader.ignore_cistrans_errors = ignore_cistrans_errors;
-    r_loader.stereochemistry_options = stereochemistry_options;
-    r_loader.ignore_bad_valence = ignore_bad_valence;
-    r_loader.valence_mode = valence_mode;
+    r_loader.setOptions(getOptions());
 
     if (_rxn != 0)
     {
@@ -175,9 +173,7 @@ void RSmilesLoader::_loadReaction()
     c_loader.inside_rsmiles = true;
     c_loader.smarts_mode = smarts_mode;
     c_loader.ignore_cistrans_errors = ignore_cistrans_errors;
-    c_loader.stereochemistry_options = stereochemistry_options;
-    c_loader.ignore_bad_valence = ignore_bad_valence;
-    c_loader.valence_mode = valence_mode;
+    c_loader.setOptions(getOptions());
 
     if (_rxn != 0)
     {
@@ -216,9 +212,7 @@ void RSmilesLoader::_loadReaction()
     p_loader.ignorable_aam = &prod_aam_ignorable;
     p_loader.smarts_mode = smarts_mode;
     p_loader.ignore_cistrans_errors = ignore_cistrans_errors;
-    p_loader.stereochemistry_options = stereochemistry_options;
-    p_loader.ignore_bad_valence = ignore_bad_valence;
-    p_loader.valence_mode = valence_mode;
+    p_loader.setOptions(getOptions());
 
     if (_rxn != 0)
     {

--- a/core/indigo-core/reaction/src/rxnfile_loader.cpp
+++ b/core/indigo-core/reaction/src/rxnfile_loader.cpp
@@ -32,7 +32,7 @@ RxnfileLoader::RxnfileLoader(Scanner& scanner) : _scanner(scanner)
     ignore_noncritical_query_features = false;
     ignore_no_chiral_flag = false;
     ignore_bad_valence = false;
-    valence_mode = ValenceMode::BIOVIA_2017;
+    valence_mode = ValenceMode::BIOVIA_2009;
 }
 
 RxnfileLoader::~RxnfileLoader()
@@ -95,12 +95,7 @@ void RxnfileLoader::_loadReaction(MonomerTemplateLibrary* monomer_lib)
 
     MolfileLoader molfileLoader(_scanner, monomer_lib);
 
-    molfileLoader.treat_x_as_pseudoatom = treat_x_as_pseudoatom;
-    molfileLoader.stereochemistry_options = stereochemistry_options;
-    molfileLoader.ignore_noncritical_query_features = ignore_noncritical_query_features;
-    molfileLoader.ignore_no_chiral_flag = ignore_no_chiral_flag;
-    molfileLoader.ignore_bad_valence = ignore_bad_valence;
-    molfileLoader.valence_mode = valence_mode;
+    molfileLoader.setOptions(getOptions());
     _readRxnHeader();
 
     if (_v3000)

--- a/utils/indigo-service/backend/service/tests/api/indigo_test.py
+++ b/utils/indigo-service/backend/service/tests/api/indigo_test.py
@@ -3237,6 +3237,122 @@ M  END
         result_data = json.loads(result.text)
         self.assertEqual("[HH]", result_data["struct"])
 
+    # --- valence-mode over the /v2 channel -------------------------------
+    #
+    # Regression cover for issue #3823: `valence-mode` had no impact on
+    # fold/unfold hydrogens. The option reached the Indigo session fine, but
+    # MoleculeAutoLoader never forwarded it to MoleculeJsonLoader, so KET input
+    # — Ketcher's native format — silently kept the BIOVIA-2009 model.
+    #
+    # Core behaviour is pinned per-format by
+    # api/c/tests/unit/tests/loader_options.cpp; these cases cover what it
+    # cannot reach: the HTTP layer and the fold/unfold operation on top of it.
+
+    # Verbatim from the issue: a bare, neutral aluminium. Under BIOVIA-2017 it
+    # is an intercepted metal, so unfolding adds no H.
+    KET_BARE_AL = (
+        '{"ket_version":"2.0.0","root":{"nodes":[{"$ref":"mol0"}],'
+        '"connections":[],"templates":[]},"mol0":{"type":"molecule",'
+        '"atoms":[{"label":"Al","location":[9.2,-6.35,0]}]}}'
+    )
+
+    # Lithium bonded to an explicit hydrogen. A SATURATED metal: interception
+    # assigns valence = conn = 1 and the legacy ladder independently arrives at
+    # valence 1 / hyd 0, so the two modes must agree. Kept as a negative control
+    # because this shape was originally mistaken for "the option does nothing".
+    KET_LI_H = (
+        '{"root":{"nodes":[{"$ref":"mol0"}]},"mol0":{"type":"molecule",'
+        '"atoms":[{"label":"Li","location":[0,0,0]},'
+        '{"label":"H","location":[1.5,0,0]}],'
+        '"bonds":[{"type":1,"atoms":[0,1]}]}}'
+    )
+
+    def _unfold_with_valence_mode(self, struct, mode, input_format):
+        params = {
+            "struct": struct,
+            "mode": "unfold",
+            "output_format": "chemical/x-daylight-smiles",
+            "input_format": input_format,
+            "options": {"valence-mode": mode},
+        }
+        headers, data = self.get_headers(params)
+        result = requests.post(
+            self.url_prefix + "/convert_explicit_hydrogens",
+            headers=headers,
+            data=data,
+        )
+        self.assertEqual(200, result.status_code, result.text)
+        return json.loads(result.text)["struct"]
+
+    def test_valence_mode_metal_ket_biovia_2017_adds_no_hydrogens(self):
+        self.assertEqual(
+            "[Al]",
+            self._unfold_with_valence_mode(
+                self.KET_BARE_AL, "biovia-2017", "chemical/x-indigo-ket"
+            ),
+        )
+
+    def test_valence_mode_metal_ket_biovia_2009_adds_hydrogens(self):
+        # Unfolding materialises implicit hydrogens as separate ATOMS, so the
+        # SMILES is the expanded form, not the collapsed [AlH3].
+        self.assertEqual(
+            "[Al]([H])([H])[H]",
+            self._unfold_with_valence_mode(
+                self.KET_BARE_AL, "biovia-2009", "chemical/x-indigo-ket"
+            ),
+        )
+
+    def test_valence_mode_default_matches_biovia_2009(self):
+        # "default" is an alias for the legacy table, not "choose for me".
+        self.assertEqual(
+            self._unfold_with_valence_mode(
+                self.KET_BARE_AL, "biovia-2009", "chemical/x-indigo-ket"
+            ),
+            self._unfold_with_valence_mode(
+                self.KET_BARE_AL, "default", "chemical/x-indigo-ket"
+            ),
+        )
+
+    def test_valence_mode_applies_to_molfile_and_ket_alike(self):
+        # The defect was format-specific: molfile honoured the option while KET
+        # ignored it. Asserting both against the same expectation is what makes
+        # a per-format gap visible again.
+        molfile = (
+            "\n  Indigo  0000000002D\n\n"
+            "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+            "    0.0000    0.0000    0.0000 Al  0  0  0  0  0  0  0  0  0  0  0  0\n"
+            "M  END\n"
+        )
+        for mode, expected in (
+            ("biovia-2009", "[Al]([H])([H])[H]"),
+            ("biovia-2017", "[Al]"),
+        ):
+            self.assertEqual(
+                expected,
+                self._unfold_with_valence_mode(
+                    molfile, mode, "chemical/x-mdl-molfile"
+                ),
+                "molfile disagrees with the matrix for {}".format(mode),
+            )
+            self.assertEqual(
+                expected,
+                self._unfold_with_valence_mode(
+                    self.KET_BARE_AL, mode, "chemical/x-indigo-ket"
+                ),
+                "KET disagrees with molfile for {}".format(mode),
+            )
+
+    def test_valence_mode_saturated_metal_is_mode_independent(self):
+        # Negative control — see KET_LI_H above.
+        self.assertEqual(
+            self._unfold_with_valence_mode(
+                self.KET_LI_H, "biovia-2009", "chemical/x-indigo-ket"
+            ),
+            self._unfold_with_valence_mode(
+                self.KET_LI_H, "biovia-2017", "chemical/x-indigo-ket"
+            ),
+        )
+
     def test_convert_explicit_hydrogens_reaction(self):
         params = {
             "struct": "CC>>C",


### PR DESCRIPTION
Changes were cherry picked from master branch commit short hash: 8ec15353

## Backmerge request
- [x] PR name follows the pattern `Backmerge: #3823 – [valence-mode option has no impact on fold/unfold hydrogens operation](https://github.com/epam/Indigo/issues/3823)`
- [x] PR is linked with the issue
- [x] base branch (release/1.47) is correct
- [x] code contains only backmerge changes
