### PR TITLE
#108: Fix Bingo PostgreSQL index corruption during concurrent writes and crash recovery

### DIFF
--- a/bingo/postgres/src/pg_am/pg_bingo_build.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_build.cpp
@@ -11,6 +11,7 @@ extern "C"
 #include "catalog/index.h"
 #include "catalog/pg_type.h"
 #include "storage/bufmgr.h"
+#include "utils/memutils.h"
 #include "utils/rel.h"
 
 #if PG_VERSION_NUM / 100 >= 906
@@ -191,6 +192,7 @@ Datum bingo_build(PG_FUNCTION_ARGS)
     //   BlockNumber relpages;
     IndexBuildResult* result = 0;
     double reltuples = 0;
+    ErrorData* volatile build_error = nullptr;
 
     //   signal(SIGINT, &error_handler);
     elog(DEBUG1, "bingo: build: start building index");
@@ -224,10 +226,13 @@ Datum bingo_build(PG_FUNCTION_ARGS)
 
         {
             BingoPgBuild build_engine(index, schema_name, index_schema, true);
+            MemoryContext oldcontext = CurrentMemoryContext;
+
             /*
-             * Do the heap scan and build index
+             * Preserve PostgreSQL errors raised by the heap scan, including
+             * QUERY_CANCELED. Do not convert them into a Bingo XX000 error.
              */
-            BINGO_PG_TRY
+            PG_TRY();
             {
 #if PG_VERSION_NUM / 100 >= 1200
                 reltuples = table_index_build_scan(heap, index, indexInfo, true, true, bingoIndexCallback, (void*)&build_engine, NULL);
@@ -237,24 +242,38 @@ Datum bingo_build(PG_FUNCTION_ARGS)
                 reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine);
 #endif
             }
-            BINGO_PG_HANDLE(throw BingoPgError("Error while executing build index procedure %s", message));
+            PG_CATCH();
+            {
+                MemoryContextSwitchTo(oldcontext);
+                build_error = CopyErrorData();
+                FlushErrorState();
+            }
+            PG_END_TRY();
 
-            build_engine.flush();
+            if (build_error == nullptr)
+                build_engine.finish();
         }
 
-        bingoLogBuiltRelation(index);
-        /*
-         * Return statistics
-         */
-        result = (IndexBuildResult*)palloc(sizeof(IndexBuildResult));
+        if (build_error == nullptr)
+        {
+            bingoLogBuiltRelation(index);
+            /*
+             * Return statistics
+             */
+            result = (IndexBuildResult*)palloc(sizeof(IndexBuildResult));
 
-        result->heap_tuples = reltuples;
-        /*
-         * Index is always cost cheaper so set tuples number 1
-         */
-        result->index_tuples = 1;
+            result->heap_tuples = reltuples;
+            /*
+             * Index is always cost cheaper so set tuples number 1
+             */
+            result->index_tuples = 1;
+        }
     }
     PG_BINGO_END
+
+    if (build_error != nullptr)
+        ReThrowError((ErrorData*)build_error);
+
 #if PG_VERSION_NUM / 100 >= 906
     return result;
 #else
@@ -338,6 +357,7 @@ Datum bingo_buildempty(PG_FUNCTION_ARGS)
 
         {
             BingoPgBuild build_engine(index, schema_name, index_schema, true);
+            build_engine.finish();
         }
 
         bingoLogBuiltRelation(index);

--- a/bingo/postgres/src/pg_am/pg_bingo_build.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_build.cpp
@@ -239,7 +239,7 @@ Datum bingo_build(PG_FUNCTION_ARGS)
 #elif PG_VERSION_NUM / 100 >= 1100
                 reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine, NULL);
 #else
-                reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine);
+            reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine);
 #endif
             }
             PG_CATCH();

--- a/bingo/postgres/src/pg_am/pg_bingo_build.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_build.cpp
@@ -7,6 +7,7 @@ extern "C"
 #include "fmgr.h"
 
 #include "access/htup.h"
+#include "access/xloginsert.h"
 #include "catalog/index.h"
 #include "catalog/pg_type.h"
 #include "storage/bufmgr.h"
@@ -82,10 +83,6 @@ extern "C"
 }
 
 #if PG_VERSION_NUM / 100 >= 906
-/*
- * Bingo handler function: return IndexAmRoutine with access method parameters
- * and callbacks.
- */
 Datum bingo_handler(PG_FUNCTION_ARGS)
 {
     IndexAmRoutine* amroutine = makeNode(IndexAmRoutine);
@@ -148,14 +145,26 @@ static void bingoIndexCallback(Relation index, ItemPointer item_ptr, Datum* valu
 static void bingoIndexCallback(Relation index, HeapTuple htup, Datum* values, bool* isnull, bool tupleIsAlive, void* state);
 #endif
 
-// #include <signal.h>
-//  void error_handler(int i) {
-//    elog(ERROR, "query was cancelled");
-// }
+static void bingoLogBuiltRelation(Relation index)
+{
+    if (!RelationNeedsWAL(index))
+        return;
 
-/*
- * Bingo build the index
- */
+    BlockNumber nblocks = RelationGetNumberOfBlocks(index);
+    if (nblocks == 0)
+        return;
+
+    /*
+     * Block 0 is a Bingo-specific raw metapage whose useful metadata lives in
+     * the area PostgreSQL calls the standard-page free-space hole. Log it as a
+     * non-standard full image. All remaining Bingo pages use ordinary PageInit
+     * + IndexTuple layout and can use standard-page hole compression.
+     */
+    log_newpage_range(index, MAIN_FORKNUM, 0, 1, false);
+    if (nblocks > 1)
+        log_newpage_range(index, MAIN_FORKNUM, 1, nblocks, true);
+}
+
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBuildResult* bingo_build(Relation heap, Relation index, struct IndexInfo* indexInfo)
 {
@@ -167,30 +176,16 @@ Datum bingo_build(PG_FUNCTION_ARGS)
     IndexInfo* indexInfo = (IndexInfo*)PG_GETARG_POINTER(2);
 #endif
 
-    //   BlockNumber relpages;
     IndexBuildResult* result = 0;
     double reltuples = 0;
 
-    //   signal(SIGINT, &error_handler);
     elog(DEBUG1, "bingo: build: start building index");
 
-    /*
-     * We expect to be called exactly once for any index relation. If that's
-     * not the case, big trouble's what we have.
-     */
     if (RelationGetNumberOfBlocks(index) != 0)
         elog(ERROR, "index \"%s\" already contains data", RelationGetRelationName(index));
 
-    //   /*
-    //    * Estimate the number of rows currently present in the table
-    //    */
-    //   estimate_rel_size(heap, NULL, &relpages, &reltuples);
-
     PG_BINGO_BEGIN
     {
-        /*
-         * Initialize the bingo index metadata page and initial blocks
-         */
         BingoPgWrapper func_namespace;
 #if PG_VERSION_NUM / 100 >= 906
         const char* schema_name = "bingo";
@@ -201,32 +196,26 @@ Datum bingo_build(PG_FUNCTION_ARGS)
         BingoPgWrapper rel_namespace;
         const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
 
-        BingoPgBuild build_engine(index, schema_name, index_schema, true);
-        /*
-         * Do the heap scan and build index
-         */
-        BINGO_PG_TRY
         {
+            BingoPgBuild build_engine(index, schema_name, index_schema, true);
+            BINGO_PG_TRY
+            {
 #if PG_VERSION_NUM / 100 >= 1200
-            reltuples = table_index_build_scan(heap, index, indexInfo, true, true, bingoIndexCallback, (void*)&build_engine, NULL);
+                reltuples = table_index_build_scan(heap, index, indexInfo, true, true, bingoIndexCallback, (void*)&build_engine, NULL);
 #elif PG_VERSION_NUM / 100 >= 1100
-            reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine, NULL);
+                reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine, NULL);
 #else
-        reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine);
+                reltuples = IndexBuildHeapScan(heap, index, indexInfo, true, bingoIndexCallback, (void*)&build_engine);
 #endif
+            }
+            BINGO_PG_HANDLE(throw BingoPgError("Error while executing build index procedure %s", message));
+            build_engine.flush();
         }
-        BINGO_PG_HANDLE(throw BingoPgError("Error while executing build index procedure %s", message));
 
-        build_engine.flush();
-        /*
-         * Return statistics
-         */
+        bingoLogBuiltRelation(index);
+
         result = (IndexBuildResult*)palloc(sizeof(IndexBuildResult));
-
         result->heap_tuples = reltuples;
-        /*
-         * Index is always cost cheaper so set tuples number 1
-         */
         result->index_tuples = 1;
     }
     PG_BINGO_END
@@ -236,25 +225,13 @@ Datum bingo_build(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(result);
 #endif
 }
-/*
- * Bingo build callback. Accepts heap relation.
- */
+
 static void bingoIndexCallbackImpl(Relation index, PG_OBJECT item_ptr, Datum* values, bool* isnull, bool tupleIsAlive, void* state)
 {
-    /*
-     * Skip inserting null tuples
-     */
     if (*isnull)
         return;
 
-    /*
-     * Get bingo state
-     */
     BingoPgBuild& build_engine = *(BingoPgBuild*)state;
-
-    /*
-     * Insert a new structure (single or parallel)
-     */
     PG_BINGO_BEGIN
     {
         build_engine.insertStructure(item_ptr, values[0]);
@@ -285,23 +262,11 @@ Datum bingo_buildempty(PG_FUNCTION_ARGS)
 
     elog(NOTICE, "start bingo empty build ");
 
-    /*
-     * We expect to be called exactly once for any index relation. If that's
-     * not the case, big trouble's what we have.
-     */
     if (RelationGetNumberOfBlocks(index) != 0)
         elog(ERROR, "index \"%s\" already contains data", RelationGetRelationName(index));
 
-    //   /*
-    //    * Estimate the number of rows currently present in the table
-    //    */
-    //   estimate_rel_size(heap, NULL, &relpages, &reltuples);
-
     PG_BINGO_BEGIN
     {
-        /*
-         * Initialize the bingo index metadata page and initial blocks
-         */
         BingoPgWrapper func_namespace;
 #if PG_VERSION_NUM / 100 >= 906
         const char* schema_name = "bingo";
@@ -311,7 +276,11 @@ Datum bingo_buildempty(PG_FUNCTION_ARGS)
         BingoPgWrapper rel_namespace;
         const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
 
-        BingoPgBuild build_engine(index, schema_name, index_schema, true);
+        {
+            BingoPgBuild build_engine(index, schema_name, index_schema, true);
+        }
+
+        bingoLogBuiltRelation(index);
     }
     PG_BINGO_END
 #if PG_VERSION_NUM / 100 < 906

--- a/bingo/postgres/src/pg_am/pg_bingo_build.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_build.cpp
@@ -83,6 +83,10 @@ extern "C"
 }
 
 #if PG_VERSION_NUM / 100 >= 906
+/*
+ * Bingo handler function: return IndexAmRoutine with access method parameters
+ * and callbacks.
+ */
 Datum bingo_handler(PG_FUNCTION_ARGS)
 {
     IndexAmRoutine* amroutine = makeNode(IndexAmRoutine);
@@ -145,6 +149,11 @@ static void bingoIndexCallback(Relation index, ItemPointer item_ptr, Datum* valu
 static void bingoIndexCallback(Relation index, HeapTuple htup, Datum* values, bool* isnull, bool tupleIsAlive, void* state);
 #endif
 
+// #include <signal.h>
+//  void error_handler(int i) {
+//    elog(ERROR, "query was cancelled");
+// }
+
 static void bingoLogBuiltRelation(Relation index)
 {
     if (!RelationNeedsWAL(index))
@@ -165,6 +174,9 @@ static void bingoLogBuiltRelation(Relation index)
         log_newpage_range(index, MAIN_FORKNUM, 1, nblocks, true);
 }
 
+/*
+ * Bingo build the index
+ */
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBuildResult* bingo_build(Relation heap, Relation index, struct IndexInfo* indexInfo)
 {
@@ -176,16 +188,30 @@ Datum bingo_build(PG_FUNCTION_ARGS)
     IndexInfo* indexInfo = (IndexInfo*)PG_GETARG_POINTER(2);
 #endif
 
+    //   BlockNumber relpages;
     IndexBuildResult* result = 0;
     double reltuples = 0;
 
+    //   signal(SIGINT, &error_handler);
     elog(DEBUG1, "bingo: build: start building index");
 
+    /*
+     * We expect to be called exactly once for any index relation. If that's
+     * not the case, big trouble's what we have.
+     */
     if (RelationGetNumberOfBlocks(index) != 0)
         elog(ERROR, "index \"%s\" already contains data", RelationGetRelationName(index));
 
+    //   /*
+    //    * Estimate the number of rows currently present in the table
+    //    */
+    //   estimate_rel_size(heap, NULL, &relpages, &reltuples);
+
     PG_BINGO_BEGIN
     {
+        /*
+         * Initialize the bingo index metadata page and initial blocks
+         */
         BingoPgWrapper func_namespace;
 #if PG_VERSION_NUM / 100 >= 906
         const char* schema_name = "bingo";
@@ -198,6 +224,9 @@ Datum bingo_build(PG_FUNCTION_ARGS)
 
         {
             BingoPgBuild build_engine(index, schema_name, index_schema, true);
+            /*
+             * Do the heap scan and build index
+             */
             BINGO_PG_TRY
             {
 #if PG_VERSION_NUM / 100 >= 1200
@@ -209,13 +238,20 @@ Datum bingo_build(PG_FUNCTION_ARGS)
 #endif
             }
             BINGO_PG_HANDLE(throw BingoPgError("Error while executing build index procedure %s", message));
+
             build_engine.flush();
         }
 
         bingoLogBuiltRelation(index);
-
+        /*
+         * Return statistics
+         */
         result = (IndexBuildResult*)palloc(sizeof(IndexBuildResult));
+
         result->heap_tuples = reltuples;
+        /*
+         * Index is always cost cheaper so set tuples number 1
+         */
         result->index_tuples = 1;
     }
     PG_BINGO_END
@@ -225,13 +261,25 @@ Datum bingo_build(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(result);
 #endif
 }
-
+/*
+ * Bingo build callback. Accepts heap relation.
+ */
 static void bingoIndexCallbackImpl(Relation index, PG_OBJECT item_ptr, Datum* values, bool* isnull, bool tupleIsAlive, void* state)
 {
+    /*
+     * Skip inserting null tuples
+     */
     if (*isnull)
         return;
 
+    /*
+     * Get bingo state
+     */
     BingoPgBuild& build_engine = *(BingoPgBuild*)state;
+
+    /*
+     * Insert a new structure (single or parallel)
+     */
     PG_BINGO_BEGIN
     {
         build_engine.insertStructure(item_ptr, values[0]);
@@ -262,11 +310,23 @@ Datum bingo_buildempty(PG_FUNCTION_ARGS)
 
     elog(NOTICE, "start bingo empty build ");
 
+    /*
+     * We expect to be called exactly once for any index relation. If that's
+     * not the case, big trouble's what we have.
+     */
     if (RelationGetNumberOfBlocks(index) != 0)
         elog(ERROR, "index \"%s\" already contains data", RelationGetRelationName(index));
 
+    //   /*
+    //    * Estimate the number of rows currently present in the table
+    //    */
+    //   estimate_rel_size(heap, NULL, &relpages, &reltuples);
+
     PG_BINGO_BEGIN
     {
+        /*
+         * Initialize the bingo index metadata page and initial blocks
+         */
         BingoPgWrapper func_namespace;
 #if PG_VERSION_NUM / 100 >= 906
         const char* schema_name = "bingo";

--- a/bingo/postgres/src/pg_am/pg_bingo_options.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_options.cpp
@@ -65,7 +65,9 @@ static relopt_int intRelOpts[] = {
      -1,
      100000000,
      2000000000},
-    {{"autovacuum_freeze_table_age", "Age at which VACUUM should perform a full table sweep to replace old Xid values with FrozenXID",
+    {{"autovacuum_freeze_table_age",
+      "Age at which VACUUM should perform a full table sweep to replace old "
+      "Xid values with FrozenXID",
       RELOPT_KIND_HEAP | RELOPT_KIND_TOAST},
      -1,
      0,
@@ -92,28 +94,50 @@ static relopt_int intRelOpts[] = {
 
 };
 
-static relopt_real realRelOpts[] = {
-    {{"autovacuum_vacuum_scale_factor", "Number of tuple updates or deletes prior to vacuum as a fraction of reltuples", RELOPT_KIND_HEAP | RELOPT_KIND_TOAST},
-     -1,
-     0.0,
-     100.0},
-    {{"autovacuum_analyze_scale_factor", "Number of tuple inserts, updates or deletes prior to analyze as a fraction of reltuples", RELOPT_KIND_HEAP},
-     -1,
-     0.0,
-     100.0},
-    {{"seq_page_cost", "Sets the planner's estimate of the cost of a sequentially fetched disk page.", RELOPT_KIND_TABLESPACE}, -1, 0.0, DBL_MAX},
-    {{"random_page_cost", "Sets the planner's estimate of the cost of a nonsequentially fetched disk page.", RELOPT_KIND_TABLESPACE}, -1, 0.0, DBL_MAX},
-    {{"n_distinct", "Sets the planner's estimate of the number of distinct values appearing in a column (excluding child relations).", RELOPT_KIND_ATTRIBUTE},
-     0,
-     -1.0,
-     DBL_MAX},
-    {{"n_distinct_inherited", "Sets the planner's estimate of the number of distinct values appearing in a column (including child relations).",
-      RELOPT_KIND_ATTRIBUTE},
-     0,
-     -1.0,
-     DBL_MAX},
-    /* list terminator */
-    {{NULL}}};
+static relopt_real realRelOpts[] = {{{"autovacuum_vacuum_scale_factor",
+                                      "Number of tuple updates or deletes prior to vacuum as a fraction of "
+                                      "reltuples",
+                                      RELOPT_KIND_HEAP | RELOPT_KIND_TOAST},
+                                     -1,
+                                     0.0,
+                                     100.0},
+                                    {{"autovacuum_analyze_scale_factor",
+                                      "Number of tuple inserts, updates or deletes prior to analyze as a "
+                                      "fraction of reltuples",
+                                      RELOPT_KIND_HEAP},
+                                     -1,
+                                     0.0,
+                                     100.0},
+                                    {{"seq_page_cost",
+                                      "Sets the planner's estimate of the cost of a sequentially fetched disk "
+                                      "page.",
+                                      RELOPT_KIND_TABLESPACE},
+                                     -1,
+                                     0.0,
+                                     DBL_MAX},
+                                    {{"random_page_cost",
+                                      "Sets the planner's estimate of the cost of a nonsequentially fetched "
+                                      "disk page.",
+                                      RELOPT_KIND_TABLESPACE},
+                                     -1,
+                                     0.0,
+                                     DBL_MAX},
+                                    {{"n_distinct",
+                                      "Sets the planner's estimate of the number of distinct values appearing "
+                                      "in a column (excluding child relations).",
+                                      RELOPT_KIND_ATTRIBUTE},
+                                     0,
+                                     -1.0,
+                                     DBL_MAX},
+                                    {{"n_distinct_inherited",
+                                      "Sets the planner's estimate of the number of distinct values appearing "
+                                      "in a column (including child relations).",
+                                      RELOPT_KIND_ATTRIBUTE},
+                                     0,
+                                     -1.0,
+                                     DBL_MAX},
+                                    /* list terminator */
+                                    {{NULL}}};
 
 // static relopt_string stringRelOpts[] =
 //{
@@ -402,7 +426,8 @@ void _PG_init(void)
                           AccessExclusiveLock);
     }
 
-    /* -2 means the index option is unset; -1 keeps its historical automatic meaning. */
+    /* -2 means the index option is unset; -1 keeps its historical automatic
+     * meaning. */
     add_int_reloption(bingo_relopt_kind, "nthreads", "", -2, -1, 2000000000, AccessExclusiveLock);
 }
 #endif
@@ -533,24 +558,33 @@ Datum bingo_options(PG_FUNCTION_ARGS)
 //         attributes.clear();
 //         for (int i = 0; i < noptions; i++) {
 //            int text_len;
-//            char* text_data = BingoPgCommon::getTextData(&optiondatums[i], text_len);
-//            Helpers::addAttributeAndValue(text_data, text_len, attributes);
+//            char* text_data = BingoPgCommon::getTextData(&optiondatums[i],
+//            text_len); Helpers::addAttributeAndValue(text_data, text_len,
+//            attributes);
 //         }
 //      }
 //
 //      rdopts = (BingoStdRdOptions*)palloc0(sizeof(BingoStdRdOptions));
 //
-//      Helpers::mapParameter(attributes, "treat_x_as_pseudoatom", rdopts->index_parameters.treat_x_as_pseudoatom);
-//      Helpers::mapParameter(attributes, "ignore_closing_bond_direction_mismatch", rdopts->index_parameters.ignore_closing_bond_direction_mismatch);
-//      Helpers::mapParameter(attributes, "fp_ord_size", rdopts->index_parameters.fp_ord_size);
-//      Helpers::mapParameter(attributes, "fp_any_size", rdopts->index_parameters.fp_any_size);
-//      Helpers::mapParameter(attributes, "fp_tau_size", rdopts->index_parameters.fp_tau_size);
-//      Helpers::mapParameter(attributes, "fp_sim_size", rdopts->index_parameters.fp_sim_size);
-//      Helpers::mapParameter(attributes, "sub_screening_max_bits", rdopts->index_parameters.sub_screening_max_bits);
-//      Helpers::mapParameter(attributes, "sim_screening_pass_mark", rdopts->index_parameters.sim_screening_pass_mark);
+//      Helpers::mapParameter(attributes, "treat_x_as_pseudoatom",
+//      rdopts->index_parameters.treat_x_as_pseudoatom);
+//      Helpers::mapParameter(attributes,
+//      "ignore_closing_bond_direction_mismatch",
+//      rdopts->index_parameters.ignore_closing_bond_direction_mismatch);
+//      Helpers::mapParameter(attributes, "fp_ord_size",
+//      rdopts->index_parameters.fp_ord_size); Helpers::mapParameter(attributes,
+//      "fp_any_size", rdopts->index_parameters.fp_any_size);
+//      Helpers::mapParameter(attributes, "fp_tau_size",
+//      rdopts->index_parameters.fp_tau_size); Helpers::mapParameter(attributes,
+//      "fp_sim_size", rdopts->index_parameters.fp_sim_size);
+//      Helpers::mapParameter(attributes, "sub_screening_max_bits",
+//      rdopts->index_parameters.sub_screening_max_bits);
+//      Helpers::mapParameter(attributes, "sim_screening_pass_mark",
+//      rdopts->index_parameters.sim_screening_pass_mark);
 //
 //      if(validate && attributes.size() > 0)
-//         elog(ERROR, "Error while loading options: unknown option %s\n", attributes.key(attributes.begin()));
+//         elog(ERROR, "Error while loading options: unknown option %s\n",
+//         attributes.key(attributes.begin()));
 //
 //   } catch (Exception& e) {
 //      elog(ERROR, "Error while loading options: %s\n", e.message());

--- a/bingo/postgres/src/pg_am/pg_bingo_options.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_options.cpp
@@ -36,7 +36,16 @@ extern "C"
 }
 #endif
 
-#define RELOPT_KIND_BINGO 1 << 8
+/*
+ * PostgreSQL 12 and older use Bingo's legacy self-contained parser, where this
+ * private bit is only meaningful inside this file. PostgreSQL 13+ registers a
+ * dynamically allocated reloption kind with the core registry instead.
+ */
+#define RELOPT_KIND_BINGO_LEGACY 1 << 8
+
+#if PG_VERSION_NUM / 100 > 1200
+static relopt_kind bingo_relopt_kind = RELOPT_KIND_LOCAL;
+#endif
 
 static relopt_bool boolRelOpts[] = {{{"autovacuum_enabled", "Enables autovacuum in this relation", RELOPT_KIND_HEAP | RELOPT_KIND_TOAST}, true},
                                     /* list terminator */
@@ -61,23 +70,23 @@ static relopt_int intRelOpts[] = {
      -1,
      0,
      2000000000},
-    {{"treat_x_as_pseudoatom", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"ignore_closing_bond_direction_mismatch", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"ignore_stereocenter_errors", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"stereochemistry_bidirectional_mode", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"stereochemistry_detect_haworth_projection", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"ignore_cistrans_errors", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"allow_non_unique_dearomatization", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"zero_unknown_aromatic_hydrogens", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"reject_invalid_structures", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"ignore_bad_valence", "", RELOPT_KIND_BINGO}, -1, 0, 1},
-    {{"fp_ord_size", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"fp_any_size", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"fp_tau_size", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"fp_sim_size", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"sub_screening_max_bits", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"sim_screening_pass_mark", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
-    {{"nthreads", "", RELOPT_KIND_BINGO}, -1, 0, 2000000000},
+    {{"treat_x_as_pseudoatom", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"ignore_closing_bond_direction_mismatch", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"ignore_stereocenter_errors", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"stereochemistry_bidirectional_mode", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"stereochemistry_detect_haworth_projection", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"ignore_cistrans_errors", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"allow_non_unique_dearomatization", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"zero_unknown_aromatic_hydrogens", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"reject_invalid_structures", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"ignore_bad_valence", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 1},
+    {{"fp_ord_size", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"fp_any_size", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"fp_tau_size", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"fp_sim_size", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"sub_screening_max_bits", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"sim_screening_pass_mark", "", RELOPT_KIND_BINGO_LEGACY}, -1, 0, 2000000000},
+    {{"nthreads", "", RELOPT_KIND_BINGO_LEGACY}, -2, -1, 2000000000},
     /* list terminator */
     {{NULL}}
 
@@ -112,7 +121,7 @@ static relopt_real realRelOpts[] = {
 //		{
 //				"similarity_type",
 //				"",
-//				RELOPT_KIND_BINGO,
+//				RELOPT_KIND_BINGO_LEGACY,
 //                                AccessExclusiveLock
 //		}, 3, false, nullptr, "SIM"
 //	},
@@ -349,6 +358,55 @@ relopt_value* bingoParseRelOptions(Datum options, bool validate, int kind, int* 
     return reloptions;
 }
 
+#if PG_VERSION_NUM / 100 > 1200
+/*
+ * Since PostgreSQL 13 the AM option parser (build_reloptions) matches input
+ * options against options registered with the core reloptions registry only.
+ * The legacy self-contained tables above are not visible to it, so every
+ * Bingo WITH (...) option would be rejected with "unrecognized parameter".
+ * Allocate a dedicated extension reloption kind and register the Bingo option
+ * names under that kind once per backend library load. Types must match the
+ * tab[] entries below (all INT), including the boolean-like flags whose
+ * accepted values stay 0/1.
+ */
+extern "C" void _PG_init(void);
+
+void _PG_init(void)
+{
+    bingo_relopt_kind = add_reloption_kind();
+    static const struct
+    {
+        const char* name;
+        int min_val;
+        int max_val;
+    } bingo_int_options[] = {{"treat_x_as_pseudoatom", 0, 1},
+                             {"ignore_closing_bond_direction_mismatch", 0, 1},
+                             {"ignore_stereocenter_errors", 0, 1},
+                             {"stereochemistry_bidirectional_mode", 0, 1},
+                             {"stereochemistry_detect_haworth_projection", 0, 1},
+                             {"ignore_cistrans_errors", 0, 1},
+                             {"allow_non_unique_dearomatization", 0, 1},
+                             {"zero_unknown_aromatic_hydrogens", 0, 1},
+                             {"reject_invalid_structures", 0, 1},
+                             {"ignore_bad_valence", 0, 1},
+                             {"fp_ord_size", 0, 2000000000},
+                             {"fp_any_size", 0, 2000000000},
+                             {"fp_tau_size", 0, 2000000000},
+                             {"fp_sim_size", 0, 2000000000},
+                             {"sub_screening_max_bits", 0, 2000000000},
+                             {"sim_screening_pass_mark", 0, 2000000000}};
+
+    for (size_t i = 0; i < lengthof(bingo_int_options); ++i)
+    {
+        add_int_reloption(bingo_relopt_kind, bingo_int_options[i].name, "", -1, bingo_int_options[i].min_val, bingo_int_options[i].max_val,
+                          AccessExclusiveLock);
+    }
+
+    /* -2 means the index option is unset; -1 keeps its historical automatic meaning. */
+    add_int_reloption(bingo_relopt_kind, "nthreads", "", -2, -1, 2000000000, AccessExclusiveLock);
+}
+#endif
+
 bytea* bingo_reloptions(Datum reloptions, bool validate)
 {
     relopt_value* options;
@@ -391,10 +449,9 @@ bytea* bingo_reloptions(Datum reloptions, bool validate)
         {"nthreads", RELOPT_TYPE_INT, offsetof(BingoStdRdOptions, index_parameters) + offsetof(BingoIndexOptions, nthreads)}};
 
 #if PG_VERSION_NUM / 100 > 1200
-    relopt_kind kind = static_cast<relopt_kind>(RELOPT_KIND_BINGO);
-    rdopts = build_reloptions(reloptions, validate, kind, sizeof(BingoStdRdOptions), tab, lengthof(tab));
+    rdopts = build_reloptions(reloptions, validate, bingo_relopt_kind, sizeof(BingoStdRdOptions), tab, lengthof(tab));
 #else
-    options = bingoParseRelOptions(reloptions, validate, RELOPT_KIND_BINGO, &numoptions);
+    options = bingoParseRelOptions(reloptions, validate, RELOPT_KIND_BINGO_LEGACY, &numoptions);
 
     /* if none set, we're done */
     if (numoptions == 0)

--- a/bingo/postgres/src/pg_am/pg_bingo_update.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_update.cpp
@@ -7,6 +7,7 @@ extern "C"
 #include "catalog/index.h"
 #include "fmgr.h"
 #include "storage/bufmgr.h"
+#include "storage/lmgr.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
 #if PG_VERSION_NUM / 100 >= 1200
@@ -32,6 +33,22 @@ extern "C"
     BINGO_FUNCTION_EXPORT(bingo_vacuumcleanup);
 }
 #endif
+
+/*
+ * Bingo updates several index pages and metadata structures as one logical
+ * operation. Those read/modify/write sequences are not safe when two backends
+ * mutate the same Bingo index concurrently. Use PostgreSQL's per-relation
+ * extension lock as a dedicated mutation mutex for the Bingo index.
+ */
+static void bingoLockIndexMutation(Relation index)
+{
+    LockRelationForExtension(index, ExclusiveLock);
+}
+
+static void bingoUnlockIndexMutation(Relation index)
+{
+    UnlockRelationForExtension(index, ExclusiveLock);
+}
 
 /*
  *	Insert an index tuple into a bingo table.
@@ -69,18 +86,29 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
 
     bool result = false;
 
-    PG_BINGO_BEGIN
+    bingoLockIndexMutation(index);
+    PG_TRY();
     {
-        BingoPgWrapper rel_namespace;
-        const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
+        PG_BINGO_BEGIN
+        {
+            BingoPgWrapper rel_namespace;
+            const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
 
-        BingoPgBuild build_engine(index, 0, index_schema, false);
-        /*
-         * Insert a new structure
-         */
-        result = build_engine.insertStructureSingle(ht_ctid, values[0]);
+            BingoPgBuild build_engine(index, 0, index_schema, false);
+            /*
+             * Insert a new structure
+             */
+            result = build_engine.insertStructureSingle(ht_ctid, values[0]);
+        }
+        PG_BINGO_END
     }
-    PG_BINGO_END
+    PG_CATCH();
+    {
+        bingoUnlockIndexMutation(index);
+        PG_RE_THROW();
+    }
+    PG_END_TRY();
+    bingoUnlockIndexMutation(index);
 
     // #ifdef NOT_USED
     //	Relation	heapRel = (Relation) PG_GETARG_POINTER(4);
@@ -140,59 +168,71 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
 
     elog(NOTICE, "bingo.index: start bulk delete");
 
-    PG_BINGO_BEGIN
+    Relation index_rel = info->index;
+    bingoLockIndexMutation(index_rel);
+    PG_TRY();
     {
-        /*
-         * Initialize local variables
-         */
-        Relation index_rel = info->index;
-        double tuples_removed = 0;
-        ItemPointerData item_data;
-        ItemPointer item_ptr = &item_data;
-        BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
-
-        /*
-         * Create index manager
-         */
-        BingoPgIndex bingo_index(index_rel);
-
-        /*
-         * Iterate through all the sections and search for removed tuples
-         */
-        int section_idx = bingo_index.readBegin();
-        for (; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
+        PG_BINGO_BEGIN
         {
-            bingo_index.getSectionBitset(section_idx, section_bitset);
             /*
-             * Iterate through section structures
+             * Initialize local variables
              */
-            for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
+            double tuples_removed = 0;
+            ItemPointerData item_data;
+            ItemPointer item_ptr = &item_data;
+            BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
+
+            /*
+             * Create index manager
+             */
+            BingoPgIndex bingo_index(index_rel);
+
+            /*
+             * Iterate through all the sections and search for removed tuples
+             */
+            int section_idx = bingo_index.readBegin();
+            for (; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
             {
-                bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
-                if (bulk_del_cb(item_ptr, cb_state))
+                bingo_index.getSectionBitset(section_idx, section_bitset);
+                /*
+                 * Iterate through section structures
+                 */
+                for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
                 {
-                    /*
-                     * Remove the structure from the bingo index
-                     */
-                    bingo_index.removeStructure(section_idx, mol_idx);
-                    tuples_removed += 1;
+                    bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
+                    if (bulk_del_cb(item_ptr, cb_state))
+                    {
+                        /*
+                         * Remove the structure from the bingo index
+                         */
+                        bingo_index.removeStructure(section_idx, mol_idx);
+                        tuples_removed += 1;
+                    }
                 }
             }
+            /*
+             * Write new structures number
+             */
+            bingo_index.writeMetaInfo();
+            /*
+             * Always return null since no index values are removed
+             */
+            //      if (stats == NULL)
+            //         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
+            //
+            //      stats->estimated_count = false;
+            //      stats->tuples_removed = tuples_removed;
         }
-        /*
-         * Write new structures number
-         */
-        bingo_index.writeMetaInfo();
-        /*
-         * Always return null since no index values are removed
-         */
-        //      if (stats == NULL)
-        //         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
-        //
-        //      stats->estimated_count = false;
-        //      stats->tuples_removed = tuples_removed;
+        PG_BINGO_END
     }
-    PG_BINGO_END
+    PG_CATCH();
+    {
+        bingoUnlockIndexMutation(index_rel);
+        PG_RE_THROW();
+    }
+    PG_END_TRY();
+    bingoUnlockIndexMutation(index_rel);
+
     /*
      * Always return null since no index values are removed
      */

--- a/bingo/postgres/src/pg_am/pg_bingo_update.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_update.cpp
@@ -51,7 +51,8 @@ static void bingoUnlockIndexMutation(Relation index)
 }
 
 /*
- * Insert an index tuple into a bingo table.
+ *	Insert an index tuple into a bingo table.
+ *
  */
 #if PG_VERSION_NUM / 100 >= 1400
 CEXPORT bool bingo_insert(Relation index, Datum* values, bool* isnull, ItemPointer ht_ctid, Relation heapRelation, IndexUniqueCheck checkUnique,
@@ -73,6 +74,9 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     ItemPointer ht_ctid = (ItemPointer)PG_GETARG_POINTER(3);
 #endif
 
+    /*
+     * Skip inserting null tuples
+     */
     if (*isnull)
 #if PG_VERSION_NUM / 100 >= 906
         return false;
@@ -91,6 +95,9 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
             const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
 
             BingoPgBuild build_engine(index, 0, index_schema, false);
+            /*
+             * Insert a new structure
+             */
             result = build_engine.insertStructureSingle(ht_ctid, values[0]);
         }
         PG_BINGO_END
@@ -103,6 +110,35 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     PG_END_TRY();
     bingoUnlockIndexMutation(index);
 
+    // #ifdef NOT_USED
+    //	Relation	heapRel = (Relation) PG_GETARG_POINTER(4);
+    //	IndexUniqueCheck checkUnique = (IndexUniqueCheck) PG_GETARG_INT32(5);
+    // #endif
+    //	IndexTuple	itup;
+    //
+    //	/* generate an index tuple */
+    //	itup = _hash_form_tuple(rel, values, isnull);
+    //	itup->t_tid = *ht_ctid;
+    //
+    //	/*
+    //	 * If the single index key is null, we don't insert it into the index.
+    //	 * Hash tables support scans on '='. Relational algebra says that A = B
+    //	 * returns null if either A or B is null.  This means that no
+    //	 * qualification used in an index scan could ever return true on a null
+    //	 * attribute.  It also means that indices can't be used by ISNULL or
+    //	 * NOTNULL scans, but that's an artifact of the strategy map architecture
+    //	 * chosen in 1986, not of the way nulls are handled here.
+    //	 */
+    //	if (IndexTupleHasNulls(itup))
+    //	{
+    //		pfree(itup);
+    //		PG_RETURN_BOOL(false);
+    //	}
+    //
+    //	_hash_doinsert(rel, itup);
+    //
+    //	pfree(itup);
+
 #if PG_VERSION_NUM / 100 >= 906
     return result;
 #else
@@ -114,7 +150,10 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
  * Bulk deletion of all index entries pointing to a set of heap tuples.
  * The set of target tuples is specified via a callback routine that tells
  * whether any given heap tuple (identified by ItemPointer) is being deleted.
+ *
+ * Result: a palloc'd struct containing statistical info for VACUUM displays.
  */
+
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBulkDeleteResult* bingo_bulkdelete(IndexVacuumInfo* info, IndexBulkDeleteResult* stats, IndexBulkDeleteCallback bulk_del_cb, void* cb_state)
 {
@@ -135,29 +174,51 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
     {
         PG_BINGO_BEGIN
         {
+            /*
+             * Initialize local variables
+             */
+            double tuples_removed = 0;
             ItemPointerData item_data;
             ItemPointer item_ptr = &item_data;
             BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
 
             /*
-             * VACUUM mutates the section existence bitsets and metapage count,
-             * so it must use the same WAL-enabled update strategy as INSERT.
+             * Create index manager. VACUUM mutates the section existence
+             * bitsets and metapage count, so use the WAL-enabled update path.
              */
             BingoPgIndex bingo_index(index_rel);
             bingo_index.updateBegin();
 
+            /*
+             * Iterate through all the sections and search for removed tuples
+             */
             for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
             {
                 bingo_index.getSectionBitset(section_idx, section_bitset);
+                /*
+                 * Iterate through section structures
+                 */
                 for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
                 {
                     bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
                     if (bulk_del_cb(item_ptr, cb_state))
                     {
+                        /*
+                         * Remove the structure from the bingo index
+                         */
                         bingo_index.removeStructure(section_idx, mol_idx);
+                        tuples_removed += 1;
                     }
                 }
             }
+            /*
+             * Always return null since no index values are removed
+             */
+            //      if (stats == NULL)
+            //         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
+            //
+            //      stats->estimated_count = false;
+            //      stats->tuples_removed = tuples_removed;
         }
         PG_BINGO_END
     }
@@ -169,6 +230,9 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
     PG_END_TRY();
     bingoUnlockIndexMutation(index_rel);
 
+    /*
+     * Always return null since no index values are removed
+     */
 #if PG_VERSION_NUM / 100 >= 906
     return NULL;
 #else
@@ -178,6 +242,8 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
 
 /*
  * Post-VACUUM cleanup.
+ *
+ * Result: a palloc'd struct containing statistical info for VACUUM displays.
  */
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBulkDeleteResult* bingo_vacuumcleanup(IndexVacuumInfo* info, IndexBulkDeleteResult* stats)
@@ -189,11 +255,32 @@ Datum bingo_vacuumcleanup(PG_FUNCTION_ARGS)
     IndexBulkDeleteResult* stats = (IndexBulkDeleteResult*)PG_GETARG_POINTER(1);
 #endif
 
-    elog(NOTICE, "bingo.index: start post-vacuum");
+    Relation rel = info->index;
+    BlockNumber num_pages = 0;
 
+    elog(NOTICE, "bingo.index: start post-vacuum");
+    /*
+     * Always return null since no index values are removed
+     */
 #if PG_VERSION_NUM / 100 >= 906
     return NULL;
 #else
     PG_RETURN_POINTER(NULL);
 #endif
+    //   /*
+    //    * If bulkdelete wasn't called, return NULL signifying no change
+    //    * Note: this covers the analyze_only case too
+    //    */
+    //   if (stats == NULL) {
+    //      PG_RETURN_POINTER(NULL);
+    //   }
+    //   /*
+    //    * update statistics
+    //    */
+    //   num_pages = RelationGetNumberOfBlocks(rel);
+    //   stats->num_pages = num_pages;
+    //   stats->num_index_tuples = 1;
+    //   stats->estimated_count = false;
+    //
+    //   PG_RETURN_POINTER(stats);
 }

--- a/bingo/postgres/src/pg_am/pg_bingo_update.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_update.cpp
@@ -70,53 +70,57 @@ static bool bingoInsertStructureLocked(Relation index, ItemPointer ht_ctid, Datu
     return result;
 }
 
-static void bingoBulkDeleteLocked(Relation index_rel, IndexBulkDeleteCallback bulk_del_cb, void* cb_state){PG_BINGO_BEGIN{/*
-                                                                                                                           * Initialize local variables
-                                                                                                                           */
-                                                                                                                          double tuples_removed = 0;
-ItemPointerData item_data;
-ItemPointer item_ptr = &item_data;
-BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
-
-/*
- * Create index manager. VACUUM mutates the section existence
- * bitsets and metapage count, so use the WAL-enabled update path.
- */
-BingoPgIndex bingo_index(index_rel);
-bingo_index.updateBegin();
-
-/*
- * Iterate through all the sections and search for removed tuples
- */
-for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
+static void bingoBulkDeleteLocked(Relation index_rel, IndexBulkDeleteCallback bulk_del_cb, void* cb_state)
 {
-    bingo_index.getSectionBitset(section_idx, section_bitset);
-    /*
-     * Iterate through section structures
-     */
-    for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
-    {
-        bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
-        if (bulk_del_cb(item_ptr, cb_state))
+    PG_BINGO_BEGIN
+    { /*
+       * Initialize local variables
+       */
+        double tuples_removed = 0;
+        ItemPointerData item_data;
+        ItemPointer item_ptr = &item_data;
+        BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
+
+        /*
+         * Create index manager. VACUUM mutates the section existence
+         * bitsets and metapage count, so use the WAL-enabled update path.
+         */
+        BingoPgIndex bingo_index(index_rel);
+        bingo_index.updateBegin();
+
+        /*
+         * Iterate through all the sections and search for removed tuples
+         */
+        for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
         {
+            bingo_index.getSectionBitset(section_idx, section_bitset);
             /*
-             * Remove the structure from the bingo index
+             * Iterate through section structures
              */
-            bingo_index.removeStructure(section_idx, mol_idx);
-            tuples_removed += 1;
+            for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
+            {
+                bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
+                if (bulk_del_cb(item_ptr, cb_state))
+                {
+                    /*
+                     * Remove the structure from the bingo index
+                     */
+                    bingo_index.removeStructure(section_idx, mol_idx);
+                    tuples_removed += 1;
+                }
+            }
         }
+        /*
+         * Always return null since no index values are removed
+         */
+        //      if (stats == NULL)
+        //         stats = (IndexBulkDeleteResult *) palloc0(sizeof
+        //         (IndexBulkDeleteResult));
+        //
+        //      stats->estimated_count = false;
+        //      stats->tuples_removed = tuples_removed;
     }
-}
-/*
- * Always return null since no index values are removed
- */
-//      if (stats == NULL)
-//         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
-//
-//      stats->estimated_count = false;
-//      stats->tuples_removed = tuples_removed;
-}
-PG_BINGO_END
+    PG_BINGO_END
 }
 
 /*
@@ -184,7 +188,8 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     //	 * returns null if either A or B is null.  This means that no
     //	 * qualification used in an index scan could ever return true on a null
     //	 * attribute.  It also means that indices can't be used by ISNULL or
-    //	 * NOTNULL scans, but that's an artifact of the strategy map architecture
+    //	 * NOTNULL scans, but that's an artifact of the strategy map
+    // architecture
     //	 * chosen in 1986, not of the way nulls are handled here.
     //	 */
     //	if (IndexTupleHasNulls(itup))

--- a/bingo/postgres/src/pg_am/pg_bingo_update.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_update.cpp
@@ -51,8 +51,7 @@ static void bingoUnlockIndexMutation(Relation index)
 }
 
 /*
- *	Insert an index tuple into a bingo table.
- *
+ * Insert an index tuple into a bingo table.
  */
 #if PG_VERSION_NUM / 100 >= 1400
 CEXPORT bool bingo_insert(Relation index, Datum* values, bool* isnull, ItemPointer ht_ctid, Relation heapRelation, IndexUniqueCheck checkUnique,
@@ -74,9 +73,6 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     ItemPointer ht_ctid = (ItemPointer)PG_GETARG_POINTER(3);
 #endif
 
-    /*
-     * Skip inserting null tuples
-     */
     if (*isnull)
 #if PG_VERSION_NUM / 100 >= 906
         return false;
@@ -95,9 +91,6 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
             const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
 
             BingoPgBuild build_engine(index, 0, index_schema, false);
-            /*
-             * Insert a new structure
-             */
             result = build_engine.insertStructureSingle(ht_ctid, values[0]);
         }
         PG_BINGO_END
@@ -110,35 +103,6 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     PG_END_TRY();
     bingoUnlockIndexMutation(index);
 
-    // #ifdef NOT_USED
-    //	Relation	heapRel = (Relation) PG_GETARG_POINTER(4);
-    //	IndexUniqueCheck checkUnique = (IndexUniqueCheck) PG_GETARG_INT32(5);
-    // #endif
-    //	IndexTuple	itup;
-    //
-    //	/* generate an index tuple */
-    //	itup = _hash_form_tuple(rel, values, isnull);
-    //	itup->t_tid = *ht_ctid;
-    //
-    //	/*
-    //	 * If the single index key is null, we don't insert it into the index.
-    //	 * Hash tables support scans on '='. Relational algebra says that A = B
-    //	 * returns null if either A or B is null.  This means that no
-    //	 * qualification used in an index scan could ever return true on a null
-    //	 * attribute.  It also means that indices can't be used by ISNULL or
-    //	 * NOTNULL scans, but that's an artifact of the strategy map architecture
-    //	 * chosen in 1986, not of the way nulls are handled here.
-    //	 */
-    //	if (IndexTupleHasNulls(itup))
-    //	{
-    //		pfree(itup);
-    //		PG_RETURN_BOOL(false);
-    //	}
-    //
-    //	_hash_doinsert(rel, itup);
-    //
-    //	pfree(itup);
-
 #if PG_VERSION_NUM / 100 >= 906
     return result;
 #else
@@ -150,10 +114,7 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
  * Bulk deletion of all index entries pointing to a set of heap tuples.
  * The set of target tuples is specified via a callback routine that tells
  * whether any given heap tuple (identified by ItemPointer) is being deleted.
- *
- * Result: a palloc'd struct containing statistical info for VACUUM displays.
  */
-
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBulkDeleteResult* bingo_bulkdelete(IndexVacuumInfo* info, IndexBulkDeleteResult* stats, IndexBulkDeleteCallback bulk_del_cb, void* cb_state)
 {
@@ -174,54 +135,29 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
     {
         PG_BINGO_BEGIN
         {
-            /*
-             * Initialize local variables
-             */
-            double tuples_removed = 0;
             ItemPointerData item_data;
             ItemPointer item_ptr = &item_data;
             BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
 
             /*
-             * Create index manager
+             * VACUUM mutates the section existence bitsets and metapage count,
+             * so it must use the same WAL-enabled update strategy as INSERT.
              */
             BingoPgIndex bingo_index(index_rel);
+            bingo_index.updateBegin();
 
-            /*
-             * Iterate through all the sections and search for removed tuples
-             */
-            int section_idx = bingo_index.readBegin();
-            for (; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
+            for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
             {
                 bingo_index.getSectionBitset(section_idx, section_bitset);
-                /*
-                 * Iterate through section structures
-                 */
                 for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
                 {
                     bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
                     if (bulk_del_cb(item_ptr, cb_state))
                     {
-                        /*
-                         * Remove the structure from the bingo index
-                         */
                         bingo_index.removeStructure(section_idx, mol_idx);
-                        tuples_removed += 1;
                     }
                 }
             }
-            /*
-             * Write new structures number
-             */
-            bingo_index.writeMetaInfo();
-            /*
-             * Always return null since no index values are removed
-             */
-            //      if (stats == NULL)
-            //         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
-            //
-            //      stats->estimated_count = false;
-            //      stats->tuples_removed = tuples_removed;
         }
         PG_BINGO_END
     }
@@ -233,9 +169,6 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
     PG_END_TRY();
     bingoUnlockIndexMutation(index_rel);
 
-    /*
-     * Always return null since no index values are removed
-     */
 #if PG_VERSION_NUM / 100 >= 906
     return NULL;
 #else
@@ -245,8 +178,6 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
 
 /*
  * Post-VACUUM cleanup.
- *
- * Result: a palloc'd struct containing statistical info for VACUUM displays.
  */
 #if PG_VERSION_NUM / 100 >= 906
 CEXPORT IndexBulkDeleteResult* bingo_vacuumcleanup(IndexVacuumInfo* info, IndexBulkDeleteResult* stats)
@@ -258,32 +189,11 @@ Datum bingo_vacuumcleanup(PG_FUNCTION_ARGS)
     IndexBulkDeleteResult* stats = (IndexBulkDeleteResult*)PG_GETARG_POINTER(1);
 #endif
 
-    Relation rel = info->index;
-    BlockNumber num_pages = 0;
-
     elog(NOTICE, "bingo.index: start post-vacuum");
-    /*
-     * Always return null since no index values are removed
-     */
+
 #if PG_VERSION_NUM / 100 >= 906
     return NULL;
 #else
     PG_RETURN_POINTER(NULL);
 #endif
-    //   /*
-    //    * If bulkdelete wasn't called, return NULL signifying no change
-    //    * Note: this covers the analyze_only case too
-    //    */
-    //   if (stats == NULL) {
-    //      PG_RETURN_POINTER(NULL);
-    //   }
-    //   /*
-    //    * update statistics
-    //    */
-    //   num_pages = RelationGetNumberOfBlocks(rel);
-    //   stats->num_pages = num_pages;
-    //   stats->num_index_tuples = 1;
-    //   stats->estimated_count = false;
-    //
-    //   PG_RETURN_POINTER(stats);
 }

--- a/bingo/postgres/src/pg_am/pg_bingo_update.cpp
+++ b/bingo/postgres/src/pg_am/pg_bingo_update.cpp
@@ -50,6 +50,75 @@ static void bingoUnlockIndexMutation(Relation index)
     UnlockRelationForExtension(index, ExclusiveLock);
 }
 
+static bool bingoInsertStructureLocked(Relation index, ItemPointer ht_ctid, Datum value)
+{
+    bool result = false;
+
+    PG_BINGO_BEGIN
+    {
+        BingoPgWrapper rel_namespace;
+        const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
+
+        BingoPgBuild build_engine(index, 0, index_schema, false);
+        /*
+         * Insert a new structure
+         */
+        result = build_engine.insertStructureSingle(ht_ctid, value);
+    }
+    PG_BINGO_END
+
+    return result;
+}
+
+static void bingoBulkDeleteLocked(Relation index_rel, IndexBulkDeleteCallback bulk_del_cb, void* cb_state){PG_BINGO_BEGIN{/*
+                                                                                                                           * Initialize local variables
+                                                                                                                           */
+                                                                                                                          double tuples_removed = 0;
+ItemPointerData item_data;
+ItemPointer item_ptr = &item_data;
+BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
+
+/*
+ * Create index manager. VACUUM mutates the section existence
+ * bitsets and metapage count, so use the WAL-enabled update path.
+ */
+BingoPgIndex bingo_index(index_rel);
+bingo_index.updateBegin();
+
+/*
+ * Iterate through all the sections and search for removed tuples
+ */
+for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
+{
+    bingo_index.getSectionBitset(section_idx, section_bitset);
+    /*
+     * Iterate through section structures
+     */
+    for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
+    {
+        bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
+        if (bulk_del_cb(item_ptr, cb_state))
+        {
+            /*
+             * Remove the structure from the bingo index
+             */
+            bingo_index.removeStructure(section_idx, mol_idx);
+            tuples_removed += 1;
+        }
+    }
+}
+/*
+ * Always return null since no index values are removed
+ */
+//      if (stats == NULL)
+//         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
+//
+//      stats->estimated_count = false;
+//      stats->tuples_removed = tuples_removed;
+}
+PG_BINGO_END
+}
+
 /*
  *	Insert an index tuple into a bingo table.
  *
@@ -89,18 +158,7 @@ Datum bingo_insert(PG_FUNCTION_ARGS)
     bingoLockIndexMutation(index);
     PG_TRY();
     {
-        PG_BINGO_BEGIN
-        {
-            BingoPgWrapper rel_namespace;
-            const char* index_schema = rel_namespace.getRelNameSpace(index->rd_id);
-
-            BingoPgBuild build_engine(index, 0, index_schema, false);
-            /*
-             * Insert a new structure
-             */
-            result = build_engine.insertStructureSingle(ht_ctid, values[0]);
-        }
-        PG_BINGO_END
+        result = bingoInsertStructureLocked(index, ht_ctid, values[0]);
     }
     PG_CATCH();
     {
@@ -172,55 +230,7 @@ Datum bingo_bulkdelete(PG_FUNCTION_ARGS)
     bingoLockIndexMutation(index_rel);
     PG_TRY();
     {
-        PG_BINGO_BEGIN
-        {
-            /*
-             * Initialize local variables
-             */
-            double tuples_removed = 0;
-            ItemPointerData item_data;
-            ItemPointer item_ptr = &item_data;
-            BingoPgExternalBitset section_bitset(BINGO_MOLS_PER_SECTION);
-
-            /*
-             * Create index manager. VACUUM mutates the section existence
-             * bitsets and metapage count, so use the WAL-enabled update path.
-             */
-            BingoPgIndex bingo_index(index_rel);
-            bingo_index.updateBegin();
-
-            /*
-             * Iterate through all the sections and search for removed tuples
-             */
-            for (int section_idx = 0; section_idx != bingo_index.readEnd(); section_idx = bingo_index.readNext(section_idx))
-            {
-                bingo_index.getSectionBitset(section_idx, section_bitset);
-                /*
-                 * Iterate through section structures
-                 */
-                for (int mol_idx = section_bitset.begin(); mol_idx != section_bitset.end(); mol_idx = section_bitset.next(mol_idx))
-                {
-                    bingo_index.readTidItem(section_idx, mol_idx, item_ptr);
-                    if (bulk_del_cb(item_ptr, cb_state))
-                    {
-                        /*
-                         * Remove the structure from the bingo index
-                         */
-                        bingo_index.removeStructure(section_idx, mol_idx);
-                        tuples_removed += 1;
-                    }
-                }
-            }
-            /*
-             * Always return null since no index values are removed
-             */
-            //      if (stats == NULL)
-            //         stats = (IndexBulkDeleteResult *) palloc0(sizeof (IndexBulkDeleteResult));
-            //
-            //      stats->estimated_count = false;
-            //      stats->tuples_removed = tuples_removed;
-        }
-        PG_BINGO_END
+        bingoBulkDeleteLocked(index_rel, bulk_del_cb, cb_state);
     }
     PG_CATCH();
     {

--- a/bingo/postgres/src/pg_am/pg_mango_utils.cpp
+++ b/bingo/postgres/src/pg_am/pg_mango_utils.cpp
@@ -5,6 +5,7 @@ extern "C"
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "utils/memutils.h"
 }
 
 #include "bingo_pg_fix_post.h"
@@ -42,6 +43,33 @@ extern "C"
 
     BINGO_FUNCTION_EXPORT(standardize);
 }
+
+namespace
+{
+void destroyCheckMoleculeHandler(void* arg)
+{
+    delete static_cast<BingoPgCommon::BingoSessionHandler*>(arg);
+}
+
+BingoPgCommon::BingoSessionHandler& getCheckMoleculeHandler(FunctionCallInfo fcinfo)
+{
+    auto* bingo_handler = static_cast<BingoPgCommon::BingoSessionHandler*>(fcinfo->flinfo->fn_extra);
+    if (bingo_handler != nullptr)
+        return *bingo_handler;
+
+    bingo_handler = new BingoPgCommon::BingoSessionHandler(fcinfo->flinfo->fn_oid);
+
+    MemoryContextCallback* reset_callback =
+        static_cast<MemoryContextCallback*>(MemoryContextAlloc(fcinfo->flinfo->fn_mcxt, sizeof(MemoryContextCallback)));
+    reset_callback->func = destroyCheckMoleculeHandler;
+    reset_callback->arg = bingo_handler;
+    MemoryContextRegisterResetCallback(fcinfo->flinfo->fn_mcxt, reset_callback);
+
+    fcinfo->flinfo->fn_extra = bingo_handler;
+    bingo_handler->setFunctionName("checkmolecule");
+    return *bingo_handler;
+}
+} // namespace
 
 Datum smiles(PG_FUNCTION_ARGS)
 {
@@ -176,8 +204,7 @@ Datum checkmolecule(PG_FUNCTION_ARGS)
     void* result = 0;
     PG_BINGO_BEGIN
     {
-        BingoPgCommon::BingoSessionHandler bingo_handler(fcinfo->flinfo->fn_oid);
-        bingo_handler.setFunctionName("checkmolecule");
+        BingoPgCommon::BingoSessionHandler& bingo_handler = getCheckMoleculeHandler(fcinfo);
         auto& bingoCore = bingo_handler.bingoCore;
 
         BingoPgText mol_text(mol_datum);

--- a/bingo/postgres/src/pg_am/pg_mango_utils.cpp
+++ b/bingo/postgres/src/pg_am/pg_mango_utils.cpp
@@ -46,29 +46,28 @@ extern "C"
 
 namespace
 {
-void destroyCheckMoleculeHandler(void* arg)
-{
-    delete static_cast<BingoPgCommon::BingoSessionHandler*>(arg);
-}
+    void destroyCheckMoleculeHandler(void* arg)
+    {
+        delete static_cast<BingoPgCommon::BingoSessionHandler*>(arg);
+    }
 
-BingoPgCommon::BingoSessionHandler& getCheckMoleculeHandler(FunctionCallInfo fcinfo)
-{
-    auto* bingo_handler = static_cast<BingoPgCommon::BingoSessionHandler*>(fcinfo->flinfo->fn_extra);
-    if (bingo_handler != nullptr)
+    BingoPgCommon::BingoSessionHandler& getCheckMoleculeHandler(FunctionCallInfo fcinfo)
+    {
+        auto* bingo_handler = static_cast<BingoPgCommon::BingoSessionHandler*>(fcinfo->flinfo->fn_extra);
+        if (bingo_handler != nullptr)
+            return *bingo_handler;
+
+        bingo_handler = new BingoPgCommon::BingoSessionHandler(fcinfo->flinfo->fn_oid);
+
+        MemoryContextCallback* reset_callback = static_cast<MemoryContextCallback*>(MemoryContextAlloc(fcinfo->flinfo->fn_mcxt, sizeof(MemoryContextCallback)));
+        reset_callback->func = destroyCheckMoleculeHandler;
+        reset_callback->arg = bingo_handler;
+        MemoryContextRegisterResetCallback(fcinfo->flinfo->fn_mcxt, reset_callback);
+
+        fcinfo->flinfo->fn_extra = bingo_handler;
+        bingo_handler->setFunctionName("checkmolecule");
         return *bingo_handler;
-
-    bingo_handler = new BingoPgCommon::BingoSessionHandler(fcinfo->flinfo->fn_oid);
-
-    MemoryContextCallback* reset_callback =
-        static_cast<MemoryContextCallback*>(MemoryContextAlloc(fcinfo->flinfo->fn_mcxt, sizeof(MemoryContextCallback)));
-    reset_callback->func = destroyCheckMoleculeHandler;
-    reset_callback->arg = bingo_handler;
-    MemoryContextRegisterResetCallback(fcinfo->flinfo->fn_mcxt, reset_callback);
-
-    fcinfo->flinfo->fn_extra = bingo_handler;
-    bingo_handler->setFunctionName("checkmolecule");
-    return *bingo_handler;
-}
+    }
 } // namespace
 
 Datum smiles(PG_FUNCTION_ARGS)

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
@@ -58,7 +58,20 @@ BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock
  */
 BingoPgBuffer::~BingoPgBuffer()
 {
-    clear();
+    try
+    {
+        if (_lock == BINGO_PG_WRITE)
+            _abortWrite();
+        clear();
+    }
+    catch (Exception& e)
+    {
+        elog(WARNING, "internal error while cleaning up bingo block %u: %s", _blockIdx, e.message());
+    }
+    catch (...)
+    {
+        elog(WARNING, "internal error while cleaning up bingo block %u", _blockIdx);
+    }
 }
 
 void BingoPgBuffer::setWalEnabled(bool enabled)
@@ -495,7 +508,7 @@ void BingoPgBuffer::formIndexTuple(void* map_data, int size)
     }
     BINGO_PG_HANDLE({
         _abortWrite();
-        throw Error("internal error: can not form index tuple: %s", message));
+        throw Error("internal error: can not form index tuple: %s", message);
     });
 
     if (add_failed)

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
@@ -4,8 +4,11 @@ extern "C"
 {
 #include "postgres.h"
 
+#include "access/generic_xlog.h"
 #include "access/itup.h"
+#include "access/xloginsert.h"
 #include "fmgr.h"
+#include "miscadmin.h"
 #include "storage/bufmgr.h"
 #include "storage/bufpage.h"
 #include "storage/lock.h"
@@ -24,41 +27,116 @@ using namespace indigo;
 
 IMPL_ERROR(BingoPgBuffer, "bingo buffer");
 
-/*
- * Empty buffer constructor
- */
-BingoPgBuffer::BingoPgBuffer() : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0)
+BingoPgBuffer::BingoPgBuffer()
+    : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
+      _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
 }
-/*
- * New buffer constructor
- */
-BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num) : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0)
+
+BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
+    : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
+      _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
     writeNewBuffer(rel_ptr, block_num);
 }
-/*
- * Existing buffer constructor
- */
-BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock) : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0)
+
+BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock)
+    : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
+      _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
     readBuffer(rel_ptr, block_num, lock);
 }
-/*
- * Destructor
- */
+
 BingoPgBuffer::~BingoPgBuffer()
 {
     clear();
 }
-/*
- * Changes an access for the buffer
- */
-void BingoPgBuffer::changeAccess(int lock)
+
+void BingoPgBuffer::setWalEnabled(bool enabled)
+{
+    if (_lock == BINGO_PG_WRITE || _walState != nullptr)
+        throw Error("internal error: can not change WAL mode while a bingo buffer is being written");
+    _walEnabled = enabled;
+}
+
+void BingoPgBuffer::setRawPageWal(bool enabled)
+{
+    if (_lock == BINGO_PG_WRITE || _walState != nullptr)
+        throw Error("internal error: can not change raw-page WAL mode while a bingo buffer is being written");
+    _rawPageWal = enabled;
+}
+
+void BingoPgBuffer::setReusableTailStart(unsigned int block_num)
+{
+    if (_buffer != InvalidBuffer || _walState != nullptr)
+        throw Error("internal error: can not change reusable tail boundary while a bingo buffer is active");
+    _reusableTailStart = block_num;
+}
+
+void BingoPgBuffer::_beginWrite(bool full_image)
 {
     if (_buffer == InvalidBuffer)
+        throw Error("internal error: can not begin writing an invalid bingo buffer");
+
+    _writeAborted = false;
+    if (!_walEnabled || _rawPageWal)
+    {
+        _writePage = BufferGetPage(_buffer);
         return;
-    if (_lock == BINGO_PG_WRITE)
+    }
+
+    Relation rel = (Relation)_relation;
+    GenericXLogState* state = nullptr;
+    Page page = nullptr;
+    BINGO_PG_TRY
+    {
+        state = GenericXLogStart(rel);
+        page = GenericXLogRegisterBuffer(state, _buffer, full_image ? GENERIC_XLOG_FULL_IMAGE : 0);
+    }
+    BINGO_PG_HANDLE(throw Error("internal error: can not start WAL for bingo block %u: %s", _blockIdx, message));
+
+    _walState = state;
+    _writePage = page;
+}
+
+void BingoPgBuffer::_finishWrite()
+{
+    if (_buffer == InvalidBuffer || _writePage == nullptr)
+        return;
+
+    if (_writeAborted)
+    {
+        _writePage = nullptr;
+        _writeAborted = false;
+        return;
+    }
+
+    if (_walState != nullptr)
+    {
+        GenericXLogState* state = (GenericXLogState*)_walState;
+        BINGO_PG_TRY
+        {
+            GenericXLogFinish(state);
+        }
+        BINGO_PG_HANDLE(throw Error("internal error: can not finish WAL for bingo block %u: %s", _blockIdx, message));
+        _walState = nullptr;
+    }
+    else if (_rawPageWal && _walEnabled)
+    {
+        Relation rel = (Relation)_relation;
+        if (RelationNeedsWAL(rel))
+        {
+            START_CRIT_SECTION();
+            MarkBufferDirty(_buffer);
+            log_newpage_buffer(_buffer, false);
+            END_CRIT_SECTION();
+        }
+        else
+        {
+            MarkBufferDirty(_buffer);
+        }
+    }
+    else
     {
         BINGO_PG_TRY
         {
@@ -66,28 +144,63 @@ void BingoPgBuffer::changeAccess(int lock)
         }
         BINGO_PG_HANDLE(throw Error("internal error: can not set buffer dirty %d: %s", _buffer, message));
     }
+    _writePage = nullptr;
+}
+
+void BingoPgBuffer::_abortWrite()
+{
+    if (_walState != nullptr)
+    {
+        GenericXLogState* state = (GenericXLogState*)_walState;
+        BINGO_PG_TRY
+        {
+            GenericXLogAbort(state);
+        }
+        BINGO_PG_HANDLE(throw Error("internal error: can not abort WAL for bingo block %u: %s", _blockIdx, message));
+        _walState = nullptr;
+    }
+    _writePage = nullptr;
+    _writeAborted = true;
+}
+
+void* BingoPgBuffer::_getPage() const
+{
+    if (_writePage != nullptr)
+        return _writePage;
+    return BufferGetPage(_buffer);
+}
+
+void* BingoPgBuffer::getPage() const
+{
+    return _getPage();
+}
+
+void BingoPgBuffer::changeAccess(int lock)
+{
+    if (_buffer == InvalidBuffer)
+        return;
+    if (_lock == lock)
+        return;
+
+    if (_lock == BINGO_PG_WRITE)
+        _finishWrite();
+
     BINGO_PG_TRY
     {
         if (_lock != BINGO_PG_NOLOCK)
-        {
             LockBuffer(_buffer, BUFFER_LOCK_UNLOCK);
-        }
         if (lock != BINGO_PG_NOLOCK)
-        {
             LockBuffer(_buffer, _getAccess(lock));
-        }
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not lock the buffer %d: %s", _buffer, message));
     _lock = lock;
+
+    if (_lock == BINGO_PG_WRITE)
+        _beginWrite(false);
 }
-/*
- * Writes a new buffer with WRITE lock
- */
+
 int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
 {
-    /*
-     * Clear if it is a new buffer
-     */
     if (_buffer != InvalidBuffer)
     {
         if (_blockIdx != block_num)
@@ -104,23 +217,14 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not get number of blocks: %s", message));
 
-    /*
-     * Bingo forbids noncontiguous access. A block below the relation size is
-     * only reusable when PostgreSQL still considers it uninitialized. This
-     * can happen after an interrupted extension. Never PageInit an existing
-     * populated block: doing so destroys another writer's index data.
-     */
     if (block_num > nblocks)
-    {
         throw Error("internal error: access to noncontiguous page in bingo index");
-    }
 
     if (block_num == nblocks)
     {
         int buffer_block_num = 0;
         BINGO_PG_TRY
         {
-            /* smgr insists we use P_NEW to extend the relation */
             _buffer = ReadBuffer(rel, P_NEW);
             buffer_block_num = BufferGetBlockNumber(_buffer);
         }
@@ -142,9 +246,6 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         BINGO_PG_HANDLE(throw Error("internal error: can not read the existing buffer: %s", message));
     }
 
-    /*
-     * Lock buffer on writing
-     */
     BINGO_PG_TRY
     {
         LockBuffer(_buffer, BUFFER_LOCK_EXCLUSIVE);
@@ -152,48 +253,41 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     BINGO_PG_HANDLE(throw Error("internal error: can not lock the buffer: %s", message));
     _lock = BINGO_PG_WRITE;
     _blockIdx = block_num;
+    _relation = rel_ptr;
 
-    Page page = BufferGetPage(_buffer);
-    if (block_num < nblocks && !PageIsNew(page))
+    Page disk_page = BufferGetPage(_buffer);
+    const bool existing_page = block_num < nblocks;
+    const bool proven_orphan_tail = existing_page && block_num >= _reusableTailStart;
+    if (existing_page && !PageIsNew(disk_page) && !proven_orphan_tail)
     {
-        /*
-         * Do not rely on the destructor here: this method is also called from
-         * a constructor, whose destructor will not run when construction
-         * throws.
-         */
         UnlockReleaseBuffer(_buffer);
         _buffer = InvalidBuffer;
         _lock = BINGO_PG_NOLOCK;
         _blockIdx = 0;
-        throw Error("internal error: refusing to initialize existing bingo index block %u", block_num);
+        _relation = 0;
+        throw Error("internal error: refusing to initialize published bingo index block %u", block_num);
     }
 
-    /*
-     * Initialize either a newly extended page or an uninitialized page left
-     * behind by an interrupted extension.
-     */
+    _beginWrite(true);
     BINGO_PG_TRY
     {
-        PageInit(page, BufferGetPageSize(_buffer), 0);
+        PageInit((Page)_getPage(), BufferGetPageSize(_buffer), 0);
     }
     BINGO_PG_HANDLE({
+        _abortWrite();
         UnlockReleaseBuffer(_buffer);
         _buffer = InvalidBuffer;
         _lock = BINGO_PG_NOLOCK;
         _blockIdx = 0;
+        _relation = 0;
         throw Error("internal error: can not initialize the page: %s", message);
     });
 
     return _buffer;
 }
-/*
- * Reads a buffer
- */
+
 int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock)
 {
-    /*
-     * Clear a buffer if it is different
-     */
     if (_buffer != InvalidBuffer)
     {
         if (_blockIdx != block_num)
@@ -213,9 +307,6 @@ int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int loc
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not read the buffer %d: %s", block_num, message));
 
-    /*
-     * Lock buffer
-     */
     if (lock != BINGO_PG_NOLOCK)
     {
         BINGO_PG_TRY
@@ -227,28 +318,26 @@ int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int loc
 
     _lock = lock;
     _buffer = buf;
-    /*
-     * Store block index
-     */
     _blockIdx = block_num;
+    _relation = rel_ptr;
+    if (_lock == BINGO_PG_WRITE)
+        _beginWrite(false);
     return _buffer;
 }
 
-/*
- * Clears and releases the buffer
- */
 void BingoPgBuffer::clear()
 {
     if (_buffer == InvalidBuffer)
         return;
+
+    if (_lock == BINGO_PG_WRITE)
+        _finishWrite();
+
     BINGO_PG_TRY
     {
         switch (_lock)
         {
         case BINGO_PG_WRITE:
-            MarkBufferDirty(_buffer);
-            UnlockReleaseBuffer(_buffer);
-            break;
         case BINGO_PG_READ:
             UnlockReleaseBuffer(_buffer);
             break;
@@ -264,6 +353,10 @@ void BingoPgBuffer::clear()
     _buffer = InvalidBuffer;
     _lock = BINGO_PG_NOLOCK;
     _blockIdx = 0;
+    _relation = 0;
+    _walState = nullptr;
+    _writePage = nullptr;
+    _writeAborted = false;
 }
 
 int BingoPgBuffer::_getAccess(int lock)
@@ -280,12 +373,7 @@ int BingoPgBuffer::_getAccess(int lock)
 
 void* BingoPgBuffer::getIndexData(int& data_len)
 {
-    Page page = 0;
-    BINGO_PG_TRY
-    {
-        page = BufferGetPage(getBuffer());
-    }
-    BINGO_PG_HANDLE(throw Error("internal error: can not get index page from the block %d: %s", _blockIdx, message));
+    Page page = (Page)_getPage();
 
     if (PageIsNew(page))
         throw Error("internal error: uninitialized bingo index block %d", _blockIdx);
@@ -315,9 +403,10 @@ void* BingoPgBuffer::getIndexData(int& data_len)
 
 void BingoPgBuffer::formIndexTuple(void* map_data, int size)
 {
+    bool add_failed = false;
     BINGO_PG_TRY
     {
-        Page page = BufferGetPage(getBuffer());
+        Page page = (Page)_getPage();
         Datum map_datum = PointerGetDatum(map_data);
 #if PG_VERSION_NUM / 100 >= 1200
         TupleDesc index_desc = CreateTemplateTupleDesc(1);
@@ -345,16 +434,21 @@ void BingoPgBuffer::formIndexTuple(void* map_data, int size)
         itemsz = MAXALIGN(itemsz);
 
         if (PageAddItem(page, (Item)itup, itemsz, 0, false, false) == InvalidOffsetNumber)
-        {
-            pfree(itup);
-            FreeTupleDesc(index_desc);
-            throw Error("internal error: failed to add index item");
-        }
+            add_failed = true;
 
         pfree(itup);
         FreeTupleDesc(index_desc);
     }
-    BINGO_PG_HANDLE(throw Error("internal error: can not form index tuple: %s", message));
+    BINGO_PG_HANDLE({
+        _abortWrite();
+        throw Error("internal error: can not form index tuple: %s", message);
+    });
+
+    if (add_failed)
+    {
+        _abortWrite();
+        throw Error("internal error: failed to add index item");
+    }
 }
 
 using namespace indigo;
@@ -365,6 +459,17 @@ void BingoPgBuffer::formEmptyIndexTuple(int size)
     buf.resize(size);
     buf.zerofill();
     formIndexTuple(buf.ptr(), buf.sizeInBytes());
+}
+
+void BingoPgBuffer::replaceIndexData(const void* data, int size)
+{
+    int data_len = 0;
+    void* target = getIndexData(data_len);
+    if (size > data_len)
+        throw Error("internal error: replacement data size %d exceeds bingo block %u capacity %d", size, _blockIdx, data_len);
+    memcpy(target, data, size);
+    if (size < data_len)
+        memset((char*)target + size, 0, data_len - size);
 }
 
 bool BingoPgBuffer::isReady() const

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
@@ -77,21 +77,24 @@ BingoPgBuffer::~BingoPgBuffer()
 void BingoPgBuffer::setWalEnabled(bool enabled)
 {
     if (_lock == BINGO_PG_WRITE || _walState != nullptr)
-        throw Error("internal error: can not change WAL mode while a bingo buffer is being written");
+        throw Error("internal error: can not change WAL mode while a bingo buffer "
+                    "is being written");
     _walEnabled = enabled;
 }
 
 void BingoPgBuffer::setRawPageWal(bool enabled)
 {
     if (_lock == BINGO_PG_WRITE || _walState != nullptr)
-        throw Error("internal error: can not change raw-page WAL mode while a bingo buffer is being written");
+        throw Error("internal error: can not change raw-page WAL mode while a "
+                    "bingo buffer is being written");
     _rawPageWal = enabled;
 }
 
 void BingoPgBuffer::setReusableTailStart(unsigned int block_num)
 {
     if (_buffer != InvalidBuffer || _walState != nullptr)
-        throw Error("internal error: can not change reusable tail boundary while a bingo buffer is active");
+        throw Error("internal error: can not change reusable tail boundary while a "
+                    "bingo buffer is active");
     _reusableTailStart = block_num;
 }
 
@@ -259,7 +262,8 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         throw Error("internal error: access to noncontiguous page in bingo index");
     }
     //   if(block_num < nblocks)
-    //      throw Error("internal error: access to already pinned block in bingo index");
+    //      throw Error("internal error: access to already pinned block in bingo
+    //      index");
 
     /*
      * smgr insists we use P_NEW to extend the relation
@@ -320,7 +324,8 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     /*
      * initialize the page
      */
-    //   PageInit(BufferGetPage(buf), BufferGetPageSize(buf), sizeof (HashPageOpaqueData));
+    //   PageInit(BufferGetPage(buf), BufferGetPageSize(buf), sizeof
+    //   (HashPageOpaqueData));
     _beginWrite(true);
     BINGO_PG_TRY
     {
@@ -533,7 +538,9 @@ void BingoPgBuffer::replaceIndexData(const void* data, int size)
     int data_len = 0;
     void* target = getIndexData(data_len);
     if (size > data_len)
-        throw Error("internal error: replacement data size %d exceeds bingo block %u capacity %d", size, _blockIdx, data_len);
+        throw Error("internal error: replacement data size %d exceeds bingo block "
+                    "%u capacity %d",
+                    size, _blockIdx, data_len);
     memcpy(target, data, size);
     if (size < data_len)
         memset((char*)target + size, 0, data_len - size);

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
@@ -7,6 +7,7 @@ extern "C"
 #include "access/itup.h"
 #include "fmgr.h"
 #include "storage/bufmgr.h"
+#include "storage/bufpage.h"
 #include "storage/lock.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
@@ -104,30 +105,33 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     BINGO_PG_HANDLE(throw Error("internal error: can not get number of blocks: %s", message));
 
     /*
-     * Bingo forbids noncontiguous access
+     * Bingo forbids noncontiguous access. A block below the relation size is
+     * only reusable when PostgreSQL still considers it uninitialized. This
+     * can happen after an interrupted extension. Never PageInit an existing
+     * populated block: doing so destroys another writer's index data.
      */
     if (block_num > nblocks)
     {
         throw Error("internal error: access to noncontiguous page in bingo index");
     }
-    //   if(block_num < nblocks)
-    //      throw Error("internal error: access to already pinned block in bingo index");
 
-    /*
-     * smgr insists we use P_NEW to extend the relation
-     */
     if (block_num == nblocks)
     {
         int buffer_block_num = 0;
         BINGO_PG_TRY
         {
+            /* smgr insists we use P_NEW to extend the relation */
             _buffer = ReadBuffer(rel, P_NEW);
             buffer_block_num = BufferGetBlockNumber(_buffer);
         }
         BINGO_PG_HANDLE(throw Error("internal error: can not create a new buffer %s", message));
 
         if (buffer_block_num != block_num)
+        {
+            ReleaseBuffer(_buffer);
+            _buffer = InvalidBuffer;
             throw Error("internal error: unexpected relation size: %u, should be %u", buffer_block_num, block_num);
+        }
     }
     else
     {
@@ -135,8 +139,9 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         {
             _buffer = ReadBufferExtended(rel, MAIN_FORKNUM, block_num, RBM_NORMAL, NULL);
         }
-        BINGO_PG_HANDLE(throw Error("internal error: can not extend the existing buffer: %s", message));
+        BINGO_PG_HANDLE(throw Error("internal error: can not read the existing buffer: %s", message));
     }
+
     /*
      * Lock buffer on writing
      */
@@ -145,21 +150,40 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         LockBuffer(_buffer, BUFFER_LOCK_EXCLUSIVE);
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not lock the buffer: %s", message));
+    _lock = BINGO_PG_WRITE;
+    _blockIdx = block_num;
+
+    Page page = BufferGetPage(_buffer);
+    if (block_num < nblocks && !PageIsNew(page))
+    {
+        /*
+         * Do not rely on the destructor here: this method is also called from
+         * a constructor, whose destructor will not run when construction
+         * throws.
+         */
+        UnlockReleaseBuffer(_buffer);
+        _buffer = InvalidBuffer;
+        _lock = BINGO_PG_NOLOCK;
+        _blockIdx = 0;
+        throw Error("internal error: refusing to initialize existing bingo index block %u", block_num);
+    }
 
     /*
-     * initialize the page
+     * Initialize either a newly extended page or an uninitialized page left
+     * behind by an interrupted extension.
      */
-    //   PageInit(BufferGetPage(buf), BufferGetPageSize(buf), sizeof (HashPageOpaqueData));
     BINGO_PG_TRY
     {
-        PageInit(BufferGetPage(_buffer), BufferGetPageSize(_buffer), 0);
+        PageInit(page, BufferGetPageSize(_buffer), 0);
     }
-    BINGO_PG_HANDLE(throw Error("internal error: can not initialize the page %d: %s", _buffer, message));
-    _lock = BINGO_PG_WRITE;
-    /*
-     * Store block index
-     */
-    _blockIdx = block_num;
+    BINGO_PG_HANDLE({
+        UnlockReleaseBuffer(_buffer);
+        _buffer = InvalidBuffer;
+        _lock = BINGO_PG_NOLOCK;
+        _blockIdx = 0;
+        throw Error("internal error: can not initialize the page: %s", message);
+    });
+
     return _buffer;
 }
 /*
@@ -256,25 +280,36 @@ int BingoPgBuffer::_getAccess(int lock)
 
 void* BingoPgBuffer::getIndexData(int& data_len)
 {
-    char* data_ptr = 0;
+    Page page = 0;
     BINGO_PG_TRY
     {
-        Page page = BufferGetPage(getBuffer());
-        IndexTuple itup = (IndexTuple)PageGetItem(page, PageGetItemId(page, BINGO_TUPLE_OFFSET));
-
-        int hoff = IndexInfoFindDataOffset(itup->t_info);
-        data_ptr = (char*)itup + hoff;
-
-        data_len = IndexTupleSize(itup) - hoff;
+        page = BufferGetPage(getBuffer());
     }
-    BINGO_PG_HANDLE(throw Error("internal error: can not get index data from the block %d: %s", _blockIdx, message));
+    BINGO_PG_HANDLE(throw Error("internal error: can not get index page from the block %d: %s", _blockIdx, message));
 
+    if (PageIsNew(page))
+        throw Error("internal error: uninitialized bingo index block %d", _blockIdx);
+
+    OffsetNumber max_offset = PageGetMaxOffsetNumber(page);
+    if (max_offset < BINGO_TUPLE_OFFSET)
+        throw Error("internal error: bingo index block %d has no index tuple", _blockIdx);
+
+    ItemId item_id = PageGetItemId(page, BINGO_TUPLE_OFFSET);
+    if (!ItemIdIsNormal(item_id))
+        throw Error("internal error: bingo index block %d has an invalid index tuple", _blockIdx);
+
+    IndexTuple itup = (IndexTuple)PageGetItem(page, item_id);
+    int hoff = IndexInfoFindDataOffset(itup->t_info);
+    int tuple_size = IndexTupleSize(itup);
+
+    if (tuple_size < hoff)
+        throw Error("internal error: corrupted block %d data len is %d", _blockIdx, tuple_size - hoff);
+
+    char* data_ptr = (char*)itup + hoff;
     if (data_ptr == 0)
         throw Error("internal error: empty ptr data for the block %d", _blockIdx);
 
-    if (data_len < 0)
-        throw Error("internal error: corrupted block %d data len is %d", _blockIdx, data_len);
-
+    data_len = tuple_size - hoff;
     return data_ptr;
 }
 

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.cpp
@@ -27,26 +27,35 @@ using namespace indigo;
 
 IMPL_ERROR(BingoPgBuffer, "bingo buffer");
 
+/*
+ * Empty buffer constructor
+ */
 BingoPgBuffer::BingoPgBuffer()
     : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
       _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
 }
-
+/*
+ * New buffer constructor
+ */
 BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
       _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
     writeNewBuffer(rel_ptr, block_num);
 }
-
+/*
+ * Existing buffer constructor
+ */
 BingoPgBuffer::BingoPgBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock)
     : _buffer(InvalidBuffer), _lock(BINGO_PG_NOLOCK), _blockIdx(0), _relation(0), _walState(nullptr), _writePage(nullptr), _walEnabled(true),
       _rawPageWal(false), _writeAborted(false), _reusableTailStart(UINT_MAX)
 {
     readBuffer(rel_ptr, block_num, lock);
 }
-
+/*
+ * Destructor
+ */
 BingoPgBuffer::~BingoPgBuffer()
 {
     clear();
@@ -175,6 +184,9 @@ void* BingoPgBuffer::getPage() const
     return _getPage();
 }
 
+/*
+ * Changes an access for the buffer
+ */
 void BingoPgBuffer::changeAccess(int lock)
 {
     if (_buffer == InvalidBuffer)
@@ -188,9 +200,13 @@ void BingoPgBuffer::changeAccess(int lock)
     BINGO_PG_TRY
     {
         if (_lock != BINGO_PG_NOLOCK)
+        {
             LockBuffer(_buffer, BUFFER_LOCK_UNLOCK);
+        }
         if (lock != BINGO_PG_NOLOCK)
+        {
             LockBuffer(_buffer, _getAccess(lock));
+        }
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not lock the buffer %d: %s", _buffer, message));
     _lock = lock;
@@ -198,9 +214,14 @@ void BingoPgBuffer::changeAccess(int lock)
     if (_lock == BINGO_PG_WRITE)
         _beginWrite(false);
 }
-
+/*
+ * Writes a new buffer with WRITE lock
+ */
 int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
 {
+    /*
+     * Clear if it is a new buffer
+     */
     if (_buffer != InvalidBuffer)
     {
         if (_blockIdx != block_num)
@@ -217,9 +238,19 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not get number of blocks: %s", message));
 
+    /*
+     * Bingo forbids noncontiguous access
+     */
     if (block_num > nblocks)
+    {
         throw Error("internal error: access to noncontiguous page in bingo index");
+    }
+    //   if(block_num < nblocks)
+    //      throw Error("internal error: access to already pinned block in bingo index");
 
+    /*
+     * smgr insists we use P_NEW to extend the relation
+     */
     if (block_num == nblocks)
     {
         int buffer_block_num = 0;
@@ -245,13 +276,18 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         }
         BINGO_PG_HANDLE(throw Error("internal error: can not read the existing buffer: %s", message));
     }
-
+    /*
+     * Lock buffer on writing
+     */
     BINGO_PG_TRY
     {
         LockBuffer(_buffer, BUFFER_LOCK_EXCLUSIVE);
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not lock the buffer: %s", message));
     _lock = BINGO_PG_WRITE;
+    /*
+     * Store block index
+     */
     _blockIdx = block_num;
     _relation = rel_ptr;
 
@@ -268,6 +304,10 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
         throw Error("internal error: refusing to initialize published bingo index block %u", block_num);
     }
 
+    /*
+     * initialize the page
+     */
+    //   PageInit(BufferGetPage(buf), BufferGetPageSize(buf), sizeof (HashPageOpaqueData));
     _beginWrite(true);
     BINGO_PG_TRY
     {
@@ -285,9 +325,14 @@ int BingoPgBuffer::writeNewBuffer(PG_OBJECT rel_ptr, unsigned int block_num)
 
     return _buffer;
 }
-
+/*
+ * Reads a buffer
+ */
 int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int lock)
 {
+    /*
+     * Clear a buffer if it is different
+     */
     if (_buffer != InvalidBuffer)
     {
         if (_blockIdx != block_num)
@@ -307,6 +352,9 @@ int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int loc
     }
     BINGO_PG_HANDLE(throw Error("internal error: can not read the buffer %d: %s", block_num, message));
 
+    /*
+     * Lock buffer
+     */
     if (lock != BINGO_PG_NOLOCK)
     {
         BINGO_PG_TRY
@@ -318,6 +366,9 @@ int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int loc
 
     _lock = lock;
     _buffer = buf;
+    /*
+     * Store block index
+     */
     _blockIdx = block_num;
     _relation = rel_ptr;
     if (_lock == BINGO_PG_WRITE)
@@ -325,6 +376,9 @@ int BingoPgBuffer::readBuffer(PG_OBJECT rel_ptr, unsigned int block_num, int loc
     return _buffer;
 }
 
+/*
+ * Clears and releases the buffer
+ */
 void BingoPgBuffer::clear()
 {
     if (_buffer == InvalidBuffer)
@@ -441,7 +495,7 @@ void BingoPgBuffer::formIndexTuple(void* map_data, int size)
     }
     BINGO_PG_HANDLE({
         _abortWrite();
-        throw Error("internal error: can not form index tuple: %s", message);
+        throw Error("internal error: can not form index tuple: %s", message));
     });
 
     if (add_failed)

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.h
@@ -11,12 +11,30 @@
 class BingoPgBuffer
 {
 public:
+    /*
+     * Empty buffer constructor
+     */
     BingoPgBuffer();
+    /*
+     * New buffer constructor
+     */
     BingoPgBuffer(PG_OBJECT rel, unsigned int block_num);
+    /*
+     * Existing buffer constructor
+     */
     BingoPgBuffer(PG_OBJECT rel, unsigned int block_num, int lock);
+    /*
+     * Destructor
+     */
     ~BingoPgBuffer();
 
+    /*
+     * Changes an access for the buffer
+     */
     void changeAccess(int lock);
+    /*
+     * Buffer getter
+     */
     int getBuffer() const
     {
         return _buffer;
@@ -35,9 +53,18 @@ public:
      */
     void setReusableTailStart(unsigned int block_num);
 
+    /*
+     * Writes a new buffer with WRITE lock
+     */
     int writeNewBuffer(PG_OBJECT rel, unsigned int block_num);
+    /*
+     * Reads a buffer
+     */
     int readBuffer(PG_OBJECT rel, unsigned int block_num, int lock);
 
+    /*
+     * Clears and releases the buffer
+     */
     void clear();
 
     void* getIndexData(int& data_len);

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer.h
@@ -1,6 +1,8 @@
 #ifndef _BINGO_PG_BUFFER_H__
 #define _BINGO_PG_BUFFER_H__
 
+#include <climits>
+
 #include "base_cpp/exception.h"
 #include "bingo_postgres.h"
 /*
@@ -9,52 +11,39 @@
 class BingoPgBuffer
 {
 public:
-    /*
-     * Empty buffer constructor
-     */
     BingoPgBuffer();
-    /*
-     * New buffer constructor
-     */
     BingoPgBuffer(PG_OBJECT rel, unsigned int block_num);
-    /*
-     * Existing buffer constructor
-     */
     BingoPgBuffer(PG_OBJECT rel, unsigned int block_num, int lock);
-    /*
-     * Destructor
-     */
     ~BingoPgBuffer();
 
-    /*
-     * Changes an access for the buffer
-     */
     void changeAccess(int lock);
-    /*
-     * Buffer getter
-     */
     int getBuffer() const
     {
         return _buffer;
     }
 
-    /*
-     * Writes a new buffer with WRITE lock
-     */
-    int writeNewBuffer(PG_OBJECT rel, unsigned int block_num);
-    /*
-     * Reads a buffer
-     */
-    int readBuffer(PG_OBJECT rel, unsigned int block_num, int lock);
+    void* getPage() const;
+
+    void setWalEnabled(bool enabled);
+    void setRawPageWal(bool enabled);
 
     /*
-     * Clears and releases the buffer
+     * Set the first block that higher-level Bingo metadata proves is not yet
+     * published. Existing pages at or after this boundary may be overwritten
+     * while recovering an interrupted tail extension. Existing pages before
+     * it remain protected from PageInit().
      */
+    void setReusableTailStart(unsigned int block_num);
+
+    int writeNewBuffer(PG_OBJECT rel, unsigned int block_num);
+    int readBuffer(PG_OBJECT rel, unsigned int block_num, int lock);
+
     void clear();
 
     void* getIndexData(int& data_len);
     void formIndexTuple(void* map_data, int size);
     void formEmptyIndexTuple(int size);
+    void replaceIndexData(const void* data, int size);
 
     bool isReady() const;
 
@@ -64,10 +53,21 @@ private:
     BingoPgBuffer(const BingoPgBuffer&); // no implicit copy
 
     int _getAccess(int lock);
+    void _beginWrite(bool full_image);
+    void _finishWrite();
+    void _abortWrite();
+    void* _getPage() const;
 
     int _buffer;
     int _lock;
     unsigned int _blockIdx;
+    PG_OBJECT _relation;
+    void* _walState;
+    void* _writePage;
+    bool _walEnabled;
+    bool _rawPageWal;
+    bool _writeAborted;
+    unsigned int _reusableTailStart;
 };
 
 #endif /* BINGO_PG_BUFFER_H */

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
@@ -42,11 +42,12 @@ BingoPgBufferCacheMap::BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, 
 
 BingoPgBufferCacheMap::~BingoPgBufferCacheMap()
 {
+}
+
+void BingoPgBufferCacheMap::flush()
+{
     if (_write)
     {
-        /*
-         * Write the cache only in the end
-         */
         if (!_buffer.isReady())
         {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
@@ -198,11 +199,12 @@ BingoPgBufferCacheFp::BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bo
 
 BingoPgBufferCacheFp::~BingoPgBufferCacheFp()
 {
+}
+
+void BingoPgBufferCacheFp::flush()
+{
     if (_write)
     {
-        /*
-         * Write the cache only in the end
-         */
         if (!_buffer.isReady())
         {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
@@ -321,13 +323,12 @@ BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, 
 
 BingoPgBufferCacheBin::~BingoPgBufferCacheBin()
 {
+}
+
+void BingoPgBufferCacheBin::flush()
+{
     if (_write)
-    {
-        /*
-         * Write the cache only in the end
-         */
         _writeCache();
-    }
 }
 
 bool BingoPgBufferCacheBin::isEnoughSpace(int size)

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
@@ -349,10 +349,12 @@ unsigned short BingoPgBufferCacheBin::addBin(indigo::Array<char>& bin_buf)
 {
 
     /*
-     * If read strategy then it is an update so read the buffer in this function also
+     * If read strategy then it is an update so read the buffer in this function
+     * also
      */
     if (!isEnoughSpace(bin_buf.sizeInBytes()))
-        throw Error("internal error: can not add cmf to the cache because is not enough space");
+        throw Error("internal error: can not add cmf to the cache because is not "
+                    "enough space");
 
     /*
      * Prepare output offset
@@ -382,10 +384,12 @@ unsigned short BingoPgBufferCacheBin::addBin(indigo::Array<char>& bin_buf)
 unsigned short BingoPgBufferCacheBin::writeBin(indigo::Array<char>& bin_buf)
 {
     /*
-     * If read strategy then it is an update so read the buffer in this function also
+     * If read strategy then it is an update so read the buffer in this function
+     * also
      */
     if (bin_buf.sizeInBytes() > MAX_SIZE)
-        throw Error("internal error: can not add bin to the cache because is not enough space");
+        throw Error("internal error: can not add bin to the cache because is not "
+                    "enough space");
 
     /*
      * Prepare output offset

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
@@ -9,32 +9,28 @@
 
 using namespace indigo;
 
-BingoPgBufferCache::BingoPgBufferCache(int block_id, PG_OBJECT index_ptr, bool write) : _blockId(block_id), _index(index_ptr), _write(write)
+BingoPgBufferCache::BingoPgBufferCache(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
+    : _blockId(block_id), _index(index_ptr), _write(write), _walEnabled(wal_enabled)
 {
-    /*
-     * Create a new buffer if the write strategy
-     */
+    _buffer.setWalEnabled(_walEnabled);
+    _buffer.setReusableTailStart(reusable_tail_start);
     if (_write)
     {
         _buffer.writeNewBuffer(_index, _blockId);
-        /*
-         * Release pin on buffer
-         */
-        _buffer.clear();
     }
 }
 
 IMPL_ERROR(BingoPgBufferCacheMap, "bingo buffer cache");
 
-BingoPgBufferCacheMap::BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write) : BingoPgBufferCache(block_id, index_ptr, write)
+BingoPgBufferCacheMap::BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
+    : BingoPgBufferCache(block_id, index_ptr, write, wal_enabled, reusable_tail_start)
 {
-    /*
-     * Prepare cache
-     */
     if (_write)
     {
         _cache.resize(BINGO_MOLS_PER_MAPBLOCK);
         _cache.zerofill();
+        _buffer.formIndexTuple(_cache.ptr(), _cache.sizeInBytes());
+        _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
 
@@ -42,15 +38,10 @@ BingoPgBufferCacheMap::~BingoPgBufferCacheMap()
 {
     if (_write)
     {
-        /*
-         * Write the cache only in the end
-         */
         if (!_buffer.isReady())
-        {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
-        }
         _buffer.changeAccess(BINGO_PG_WRITE);
-        _buffer.formIndexTuple(_cache.ptr(), _cache.sizeInBytes());
+        _buffer.replaceIndexData(_cache.ptr(), _cache.sizeInBytes());
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
@@ -64,9 +55,6 @@ void BingoPgBufferCacheMap::setTidItem(int map_idx, ItemPointerData& tid_item)
     }
     else
     {
-        /*
-         * If read strategy then it is an update, so add data directly to the buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -84,9 +72,6 @@ void BingoPgBufferCacheMap::setCmfItem(int map_idx, ItemPointerData& cmf_item)
     }
     else
     {
-        /*
-         * If read strategy then it is an update, so add data directly to the buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -104,9 +89,6 @@ void BingoPgBufferCacheMap::setXyzItem(int map_idx, ItemPointerData& xyz_item)
     }
     else
     {
-        /*
-         * If read strategy then it is an update, so add data directly to the buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -122,9 +104,6 @@ void BingoPgBufferCacheMap::getTidItem(int map_idx, ItemPointerData& tid_item)
         tid_item = _cache[map_idx].tid_map;
     else
     {
-        /*
-         * Read data for a buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -140,9 +119,6 @@ void BingoPgBufferCacheMap::getCmfItem(int map_idx, ItemPointerData& cmf_item)
         cmf_item = _cache[map_idx].cmf_map;
     else
     {
-        /*
-         * Read data for a buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -158,9 +134,6 @@ void BingoPgBufferCacheMap::getXyzItem(int map_idx, ItemPointerData& xyz_item)
         xyz_item = _cache[map_idx].xyz_map;
     else
     {
-        /*
-         * Read data for a buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -175,18 +148,18 @@ void BingoPgBufferCacheMap::_checkMapIdx(int map_idx)
         throw Error("internal error: map index %d is out of range %d", map_idx, BINGO_MOLS_PER_MAPBLOCK);
 }
 
-// Revview IMPL_ERROR
 IMPL_ERROR(BingoPgBufferCacheFp, "bingo buffer cache fingerprints");
 
-BingoPgBufferCacheFp::BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write)
-    : BingoPgBufferCache(block_id, index_ptr, write), _cache(BINGO_MOLS_PER_FINGERBLOCK)
+BingoPgBufferCacheFp::BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
+    : BingoPgBufferCache(block_id, index_ptr, write, wal_enabled, reusable_tail_start), _cache(BINGO_MOLS_PER_FINGERBLOCK)
 {
-    /*
-     * Cache already prepared. Clean it
-     */
     if (_write)
     {
         _cache.zeroFill();
+        int data_len;
+        void* data = _cache.serialize(data_len);
+        _buffer.formIndexTuple(data, data_len);
+        _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
 
@@ -194,17 +167,12 @@ BingoPgBufferCacheFp::~BingoPgBufferCacheFp()
 {
     if (_write)
     {
-        /*
-         * Write the cache only in the end
-         */
         if (!_buffer.isReady())
-        {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
-        }
         _buffer.changeAccess(BINGO_PG_WRITE);
         int data_len;
         void* data = _cache.serialize(data_len);
-        _buffer.formIndexTuple(data, data_len);
+        _buffer.replaceIndexData(data, data_len);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
@@ -217,9 +185,6 @@ void BingoPgBufferCacheFp::setBit(int str_idx, bool value)
     }
     else
     {
-        /*
-         * If read strategy then it is an update, so add data directly to the buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
@@ -238,10 +203,7 @@ bool BingoPgBufferCacheFp::getBit(int str_idx)
     }
     else
     {
-        /*
-         * If read strategy then it is an update, so add data directly to the buffer
-         */
-        _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
+        _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
         _cache.deserialize(data, data_len, true);
@@ -259,16 +221,10 @@ void BingoPgBufferCacheFp::andWithBitset(BingoPgExternalBitset& ext_bitset)
     }
     else
     {
-        /*
-         * Read data for a buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
         _cache.deserialize(data, data_len, true);
-        /*
-         * And with bitset
-         */
         ext_bitset.andWith(_cache);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
@@ -282,139 +238,78 @@ void BingoPgBufferCacheFp::getCopy(BingoPgExternalBitset& other)
     }
     else
     {
-        /*
-         * Read data for a buffer
-         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
         _cache.deserialize(data, data_len, true);
-        /*
-         * And with bitset
-         */
         other.copy(_cache);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
 
-// Revview IMPL_ERROR
 IMPL_ERROR(BingoPgBufferCacheBin, "bingo buffer cache binary data");
 
-BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write) : BingoPgBufferCache(block_id, index_ptr, write)
+BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
+    : BingoPgBufferCache(block_id, index_ptr, write, wal_enabled, reusable_tail_start)
 {
+    if (_write)
+    {
+        _buffer.formEmptyIndexTuple(BUFFER_SIZE);
+        _buffer.changeAccess(BINGO_PG_NOLOCK);
+    }
 }
 
 BingoPgBufferCacheBin::~BingoPgBufferCacheBin()
 {
     if (_write)
-    {
-        /*
-         * Write the cache only in the end
-         */
-        if (!_buffer.isReady())
-        {
-            _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
-        }
-        /*
-         * Store max size always
-         */
-        _buffer.changeAccess(BINGO_PG_WRITE);
-        _buffer.formEmptyIndexTuple(BUFFER_SIZE);
-        _buffer.changeAccess(BINGO_PG_NOLOCK);
         _writeCache();
-    }
 }
 
 bool BingoPgBufferCacheBin::isEnoughSpace(int size)
 {
     bool result;
     if (!_write)
-    {
-        /*
-         * Read cache size from a buffer
-         */
         _readCache();
-    }
     result = (size + _cache.size()) < MAX_SIZE;
     return result;
 }
 
 unsigned short BingoPgBufferCacheBin::addBin(indigo::Array<char>& bin_buf)
 {
-
-    /*
-     * If read strategy then it is an update so read the buffer in this function also
-     */
     if (!isEnoughSpace(bin_buf.sizeInBytes()))
         throw Error("internal error: can not add cmf to the cache because is not enough space");
 
-    /*
-     * Prepare output offset
-     */
     unsigned short result = _cache.size();
 
-    /*
-     * Prepare new array = size + buf
-     */
     indigo::Array<char> out_arr;
     indigo::ArrayOutput ao(out_arr);
     BingoPgCommon::DataProcessing::handleArray(bin_buf, 0, &ao);
-    /*
-     * Store data with it size
-     */
     _cache.concat(out_arr);
-    /*
-     * If read strategy then it is an update so write the buffer
-     */
     if (!_write)
-    {
         _writeCache();
-    }
     return result;
 }
 
 unsigned short BingoPgBufferCacheBin::writeBin(indigo::Array<char>& bin_buf)
 {
-    /*
-     * If read strategy then it is an update so read the buffer in this function also
-     */
     if (bin_buf.sizeInBytes() > MAX_SIZE)
         throw Error("internal error: can not add bin to the cache because is not enough space");
 
-    /*
-     * Prepare output offset
-     */
     unsigned short result = 0;
 
-    /*
-     * Prepare new array = size + buf
-     */
     indigo::Array<char> out_arr;
     indigo::ArrayOutput ao(out_arr);
     BingoPgCommon::DataProcessing::handleArray(bin_buf, 0, &ao);
-    /*
-     * Store data with it size
-     */
     _cache.copy(out_arr);
-    /*
-     * If read strategy then it is an update so write the buffer
-     */
     if (!_write)
-    {
         _writeCache();
-    }
     return result;
 }
 
 void BingoPgBufferCacheBin::readBin(unsigned short offset, indigo::Array<char>& result)
 {
     if (!_write)
-    {
         _readCache();
-    }
-    /*
-     * Read buffer from the given offset
-     */
     const char* data = _cache.ptr();
     int data_len = _cache.sizeInBytes();
     BufferScanner sc(data + offset, data_len - offset);
@@ -423,9 +318,6 @@ void BingoPgBufferCacheBin::readBin(unsigned short offset, indigo::Array<char>& 
 
 void BingoPgBufferCacheBin::_writeCache()
 {
-    /*
-     * Write size and cache itself
-     */
     if (!_buffer.isReady())
         _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
 
@@ -433,40 +325,26 @@ void BingoPgBufferCacheBin::_writeCache()
     int data_len;
     char* buf_data = (char*)_buffer.getIndexData(data_len);
     int cache_size = _cache.sizeInBytes();
-    /*
-     * Store size
-     */
     memcpy(buf_data, &cache_size, sizeof(int));
-    /*
-     * Store cache data
-     */
     memcpy(buf_data + sizeof(int), _cache.ptr(), cache_size);
+    if ((int)sizeof(int) + cache_size < data_len)
+        memset(buf_data + sizeof(int) + cache_size, 0, data_len - sizeof(int) - cache_size);
     _buffer.changeAccess(BINGO_PG_NOLOCK);
 }
 
 void BingoPgBufferCacheBin::_readCache()
 {
-    /*
-     * If buffer was readed then cache is already fulfiled
-     */
     if (_buffer.isReady())
         return;
-    /*
-     * Read size and cache itself
-     */
     _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
     int data_len;
     const char* data = (const char*)_buffer.getIndexData(data_len);
     int cache_size;
-    /*
-     * Read size
-     */
     memcpy(&cache_size, data, sizeof(int));
+    if (cache_size < 0 || cache_size > data_len - (int)sizeof(int))
+        throw Error("internal error: invalid binary cache size %d in bingo block %d", cache_size, _blockId);
     _cache.clear();
     _cache.resize(cache_size);
-    /*
-     * Read cache data
-     */
     memcpy(_cache.ptr(), data + sizeof(int), cache_size);
     _buffer.changeAccess(BINGO_PG_NOLOCK);
 }

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.cpp
@@ -14,6 +14,9 @@ BingoPgBufferCache::BingoPgBufferCache(int block_id, PG_OBJECT index_ptr, bool w
 {
     _buffer.setWalEnabled(_walEnabled);
     _buffer.setReusableTailStart(reusable_tail_start);
+    /*
+     * Create a new buffer if the write strategy
+     */
     if (_write)
     {
         _buffer.writeNewBuffer(_index, _blockId);
@@ -25,6 +28,9 @@ IMPL_ERROR(BingoPgBufferCacheMap, "bingo buffer cache");
 BingoPgBufferCacheMap::BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
     : BingoPgBufferCache(block_id, index_ptr, write, wal_enabled, reusable_tail_start)
 {
+    /*
+     * Prepare cache
+     */
     if (_write)
     {
         _cache.resize(BINGO_MOLS_PER_MAPBLOCK);
@@ -38,8 +44,13 @@ BingoPgBufferCacheMap::~BingoPgBufferCacheMap()
 {
     if (_write)
     {
+        /*
+         * Write the cache only in the end
+         */
         if (!_buffer.isReady())
+        {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
+        }
         _buffer.changeAccess(BINGO_PG_WRITE);
         _buffer.replaceIndexData(_cache.ptr(), _cache.sizeInBytes());
         _buffer.changeAccess(BINGO_PG_NOLOCK);
@@ -55,6 +66,9 @@ void BingoPgBufferCacheMap::setTidItem(int map_idx, ItemPointerData& tid_item)
     }
     else
     {
+        /*
+         * If read strategy then it is an update, so add data directly to the buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -72,6 +86,9 @@ void BingoPgBufferCacheMap::setCmfItem(int map_idx, ItemPointerData& cmf_item)
     }
     else
     {
+        /*
+         * If read strategy then it is an update, so add data directly to the buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -89,6 +106,9 @@ void BingoPgBufferCacheMap::setXyzItem(int map_idx, ItemPointerData& xyz_item)
     }
     else
     {
+        /*
+         * If read strategy then it is an update, so add data directly to the buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -104,6 +124,9 @@ void BingoPgBufferCacheMap::getTidItem(int map_idx, ItemPointerData& tid_item)
         tid_item = _cache[map_idx].tid_map;
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -119,6 +142,9 @@ void BingoPgBufferCacheMap::getCmfItem(int map_idx, ItemPointerData& cmf_item)
         cmf_item = _cache[map_idx].cmf_map;
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -134,6 +160,9 @@ void BingoPgBufferCacheMap::getXyzItem(int map_idx, ItemPointerData& xyz_item)
         xyz_item = _cache[map_idx].xyz_map;
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         BingoMapData* map_data = (BingoMapData*)_buffer.getIndexData(data_len);
@@ -148,11 +177,15 @@ void BingoPgBufferCacheMap::_checkMapIdx(int map_idx)
         throw Error("internal error: map index %d is out of range %d", map_idx, BINGO_MOLS_PER_MAPBLOCK);
 }
 
+// Revview IMPL_ERROR
 IMPL_ERROR(BingoPgBufferCacheFp, "bingo buffer cache fingerprints");
 
 BingoPgBufferCacheFp::BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
     : BingoPgBufferCache(block_id, index_ptr, write, wal_enabled, reusable_tail_start), _cache(BINGO_MOLS_PER_FINGERBLOCK)
 {
+    /*
+     * Cache already prepared. Clean it
+     */
     if (_write)
     {
         _cache.zeroFill();
@@ -167,8 +200,13 @@ BingoPgBufferCacheFp::~BingoPgBufferCacheFp()
 {
     if (_write)
     {
+        /*
+         * Write the cache only in the end
+         */
         if (!_buffer.isReady())
+        {
             _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
+        }
         _buffer.changeAccess(BINGO_PG_WRITE);
         int data_len;
         void* data = _cache.serialize(data_len);
@@ -185,6 +223,9 @@ void BingoPgBufferCacheFp::setBit(int str_idx, bool value)
     }
     else
     {
+        /*
+         * If read strategy then it is an update, so add data directly to the buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_WRITE);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
@@ -203,6 +244,9 @@ bool BingoPgBufferCacheFp::getBit(int str_idx)
     }
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
@@ -221,10 +265,16 @@ void BingoPgBufferCacheFp::andWithBitset(BingoPgExternalBitset& ext_bitset)
     }
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
         _cache.deserialize(data, data_len, true);
+        /*
+         * And with bitset
+         */
         ext_bitset.andWith(_cache);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
@@ -238,15 +288,22 @@ void BingoPgBufferCacheFp::getCopy(BingoPgExternalBitset& other)
     }
     else
     {
+        /*
+         * Read data for a buffer
+         */
         _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
         int data_len;
         void* data = _buffer.getIndexData(data_len);
         _cache.deserialize(data, data_len, true);
+        /*
+         * And with bitset
+         */
         other.copy(_cache);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
 }
 
+// Revview IMPL_ERROR
 IMPL_ERROR(BingoPgBufferCacheBin, "bingo buffer cache binary data");
 
 BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled, unsigned int reusable_tail_start)
@@ -254,6 +311,9 @@ BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, 
 {
     if (_write)
     {
+        /*
+         * Store max size always
+         */
         _buffer.formEmptyIndexTuple(BUFFER_SIZE);
         _buffer.changeAccess(BINGO_PG_NOLOCK);
     }
@@ -262,54 +322,104 @@ BingoPgBufferCacheBin::BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, 
 BingoPgBufferCacheBin::~BingoPgBufferCacheBin()
 {
     if (_write)
+    {
+        /*
+         * Write the cache only in the end
+         */
         _writeCache();
+    }
 }
 
 bool BingoPgBufferCacheBin::isEnoughSpace(int size)
 {
     bool result;
     if (!_write)
+    {
+        /*
+         * Read cache size from a buffer
+         */
         _readCache();
+    }
     result = (size + _cache.size()) < MAX_SIZE;
     return result;
 }
 
 unsigned short BingoPgBufferCacheBin::addBin(indigo::Array<char>& bin_buf)
 {
+
+    /*
+     * If read strategy then it is an update so read the buffer in this function also
+     */
     if (!isEnoughSpace(bin_buf.sizeInBytes()))
         throw Error("internal error: can not add cmf to the cache because is not enough space");
 
+    /*
+     * Prepare output offset
+     */
     unsigned short result = _cache.size();
 
+    /*
+     * Prepare new array = size + buf
+     */
     indigo::Array<char> out_arr;
     indigo::ArrayOutput ao(out_arr);
     BingoPgCommon::DataProcessing::handleArray(bin_buf, 0, &ao);
+    /*
+     * Store data with it size
+     */
     _cache.concat(out_arr);
+    /*
+     * If read strategy then it is an update so write the buffer
+     */
     if (!_write)
+    {
         _writeCache();
+    }
     return result;
 }
 
 unsigned short BingoPgBufferCacheBin::writeBin(indigo::Array<char>& bin_buf)
 {
+    /*
+     * If read strategy then it is an update so read the buffer in this function also
+     */
     if (bin_buf.sizeInBytes() > MAX_SIZE)
         throw Error("internal error: can not add bin to the cache because is not enough space");
 
+    /*
+     * Prepare output offset
+     */
     unsigned short result = 0;
 
+    /*
+     * Prepare new array = size + buf
+     */
     indigo::Array<char> out_arr;
     indigo::ArrayOutput ao(out_arr);
     BingoPgCommon::DataProcessing::handleArray(bin_buf, 0, &ao);
+    /*
+     * Store data with it size
+     */
     _cache.copy(out_arr);
+    /*
+     * If read strategy then it is an update so write the buffer
+     */
     if (!_write)
+    {
         _writeCache();
+    }
     return result;
 }
 
 void BingoPgBufferCacheBin::readBin(unsigned short offset, indigo::Array<char>& result)
 {
     if (!_write)
+    {
         _readCache();
+    }
+    /*
+     * Read buffer from the given offset
+     */
     const char* data = _cache.ptr();
     int data_len = _cache.sizeInBytes();
     BufferScanner sc(data + offset, data_len - offset);
@@ -318,6 +428,9 @@ void BingoPgBufferCacheBin::readBin(unsigned short offset, indigo::Array<char>& 
 
 void BingoPgBufferCacheBin::_writeCache()
 {
+    /*
+     * Write size and cache itself
+     */
     if (!_buffer.isReady())
         _buffer.readBuffer(_index, _blockId, BINGO_PG_NOLOCK);
 
@@ -325,7 +438,13 @@ void BingoPgBufferCacheBin::_writeCache()
     int data_len;
     char* buf_data = (char*)_buffer.getIndexData(data_len);
     int cache_size = _cache.sizeInBytes();
+    /*
+     * Store size
+     */
     memcpy(buf_data, &cache_size, sizeof(int));
+    /*
+     * Store cache data
+     */
     memcpy(buf_data + sizeof(int), _cache.ptr(), cache_size);
     if ((int)sizeof(int) + cache_size < data_len)
         memset(buf_data + sizeof(int) + cache_size, 0, data_len - sizeof(int) - cache_size);
@@ -334,17 +453,29 @@ void BingoPgBufferCacheBin::_writeCache()
 
 void BingoPgBufferCacheBin::_readCache()
 {
+    /*
+     * If buffer was readed then cache is already fulfiled
+     */
     if (_buffer.isReady())
         return;
+    /*
+     * Read size and cache itself
+     */
     _buffer.readBuffer(_index, _blockId, BINGO_PG_READ);
     int data_len;
     const char* data = (const char*)_buffer.getIndexData(data_len);
     int cache_size;
+    /*
+     * Read size
+     */
     memcpy(&cache_size, data, sizeof(int));
     if (cache_size < 0 || cache_size > data_len - (int)sizeof(int))
         throw Error("internal error: invalid binary cache size %d in bingo block %d", cache_size, _blockId);
     _cache.clear();
     _cache.resize(cache_size);
+    /*
+     * Read cache data
+     */
     memcpy(_cache.ptr(), data + sizeof(int), cache_size);
     _buffer.changeAccess(BINGO_PG_NOLOCK);
 }

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
@@ -65,6 +65,8 @@ public:
     BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheMap() override;
 
+    void flush();
+
     /*
      * Setters
      */
@@ -95,6 +97,8 @@ class BingoPgBufferCacheFp : public BingoPgBufferCache
 public:
     BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheFp() override;
+
+    void flush();
 
     void setBit(int str_idx, bool value);
     bool getBit(int str_idx);
@@ -129,6 +133,8 @@ public:
 
     BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheBin() override;
+
+    void flush();
 
     /*
      * Returns true if enough space for adding a new structure with given size

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
@@ -123,7 +123,8 @@ class BingoPgBufferCacheBin : public BingoPgBufferCache
 {
 public:
     /*
-     * Max size is rewrite BLCKSZ because there is int for keeping data length (stored in the begining of the buffer)
+     * Max size is rewrite BLCKSZ because there is int for keeping data length
+     * (stored in the begining of the buffer)
      */
     enum
     {

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
@@ -52,6 +52,9 @@ protected:
 class BingoPgBufferCacheMap : public BingoPgBufferCache
 {
 public:
+    /*
+     * Tid mapping = tid + cmf + xyz
+     */
     typedef struct BingoMapData
     {
         ItemPointerData tid_map;
@@ -62,9 +65,15 @@ public:
     BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheMap() override;
 
+    /*
+     * Setters
+     */
     void setTidItem(int map_idx, ItemPointerData& tid_item);
     void setCmfItem(int map_idx, ItemPointerData& cmf_item);
     void setXyzItem(int map_idx, ItemPointerData& xyz_item);
+    /*
+     * Getters
+     */
     void getTidItem(int map_idx, ItemPointerData& tid_item);
     void getCmfItem(int map_idx, ItemPointerData& cmf_item);
     void getXyzItem(int map_idx, ItemPointerData& xyz_item);
@@ -89,7 +98,11 @@ public:
 
     void setBit(int str_idx, bool value);
     bool getBit(int str_idx);
+    /*
+     * Main bit processing
+     */
     void andWithBitset(BingoPgExternalBitset& ext_bitset);
+
     void getCopy(BingoPgExternalBitset& other);
 
     DECL_ERROR;
@@ -100,11 +113,14 @@ private:
     BingoPgExternalBitset _cache;
 };
 /*
- * Binary buffers handling
+ * Biniary buffers handling
  */
 class BingoPgBufferCacheBin : public BingoPgBufferCache
 {
 public:
+    /*
+     * Max size is rewrite BLCKSZ because there is int for keeping data length (stored in the begining of the buffer)
+     */
     enum
     {
         MAX_SIZE = 8140,
@@ -114,9 +130,19 @@ public:
     BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheBin() override;
 
+    /*
+     * Returns true if enough space for adding a new structure with given size
+     */
     bool isEnoughSpace(int size);
+    /*
+     * Add cmf to the buffer. Returns offset for a added cmf
+     */
     unsigned short addBin(indigo::Array<char>& bin_buf);
     unsigned short writeBin(indigo::Array<char>& bin_buf);
+
+    /*
+     * Get cmf from a buffer
+     */
     void readBin(unsigned short offset, indigo::Array<char>& result);
 
     DECL_ERROR;

--- a/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_buffer_cache.h
@@ -22,7 +22,7 @@ extern "C"
 class BingoPgBufferCache
 {
 public:
-    BingoPgBufferCache(int block_id, PG_OBJECT index_ptr, bool write);
+    BingoPgBufferCache(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     virtual ~BingoPgBufferCache()
     {
     }
@@ -43,6 +43,7 @@ protected:
     int _blockId;
     PG_OBJECT _index;
     bool _write;
+    bool _walEnabled;
     BingoPgBuffer _buffer;
 };
 /*
@@ -51,9 +52,6 @@ protected:
 class BingoPgBufferCacheMap : public BingoPgBufferCache
 {
 public:
-    /*
-     * Tid mapping = tid + cmf + xyz
-     */
     typedef struct BingoMapData
     {
         ItemPointerData tid_map;
@@ -61,18 +59,12 @@ public:
         ItemPointerData xyz_map;
     } BingoMapData;
 
-    BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write);
+    BingoPgBufferCacheMap(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheMap() override;
 
-    /*
-     * Setters
-     */
     void setTidItem(int map_idx, ItemPointerData& tid_item);
     void setCmfItem(int map_idx, ItemPointerData& cmf_item);
     void setXyzItem(int map_idx, ItemPointerData& xyz_item);
-    /*
-     * Getters
-     */
     void getTidItem(int map_idx, ItemPointerData& tid_item);
     void getCmfItem(int map_idx, ItemPointerData& cmf_item);
     void getXyzItem(int map_idx, ItemPointerData& xyz_item);
@@ -92,16 +84,12 @@ private:
 class BingoPgBufferCacheFp : public BingoPgBufferCache
 {
 public:
-    BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write);
+    BingoPgBufferCacheFp(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheFp() override;
 
     void setBit(int str_idx, bool value);
     bool getBit(int str_idx);
-    /*
-     * Main bit processing
-     */
     void andWithBitset(BingoPgExternalBitset& ext_bitset);
-
     void getCopy(BingoPgExternalBitset& other);
 
     DECL_ERROR;
@@ -112,36 +100,23 @@ private:
     BingoPgExternalBitset _cache;
 };
 /*
- * Biniary buffers handling
+ * Binary buffers handling
  */
 class BingoPgBufferCacheBin : public BingoPgBufferCache
 {
 public:
-    /*
-     * Max size is rewrite BLCKSZ because there is int for keeping data length (stored in the begining of the buffer)
-     */
     enum
     {
         MAX_SIZE = 8140,
         BUFFER_SIZE = 8150
     };
 
-    BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write);
+    BingoPgBufferCacheBin(int block_id, PG_OBJECT index_ptr, bool write, bool wal_enabled = true, unsigned int reusable_tail_start = UINT_MAX);
     ~BingoPgBufferCacheBin() override;
 
-    /*
-     * Returns true if enough space for adding a new structure with given size
-     */
     bool isEnoughSpace(int size);
-    /*
-     * Add cmf to the buffer. Returns offset for a added cmf
-     */
     unsigned short addBin(indigo::Array<char>& bin_buf);
     unsigned short writeBin(indigo::Array<char>& bin_buf);
-
-    /*
-     * Get cmf from a buffer
-     */
     void readBin(unsigned short offset, indigo::Array<char>& result);
 
     DECL_ERROR;

--- a/bingo/postgres/src/pg_common/bingo_pg_common.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_common.h
@@ -409,9 +409,12 @@ private:
     PG_CATCH();                                                                                                                                                \
     {                                                                                                                                                          \
         ErrorData* err = CopyErrorData();                                                                                                                      \
+        bool pg_query_canceled = (err->sqlerrcode == ERRCODE_QUERY_CANCELED);                                                                                  \
         pg_message.readString(err->message, true);                                                                                                             \
         FreeErrorData(err);                                                                                                                                    \
         FlushErrorState();                                                                                                                                     \
+        if (pg_query_canceled)                                                                                                                                 \
+            throw BingoPgCanceled("%s", pg_message.ptr());                                                                                                     \
         pg_error_raised = true;                                                                                                                                \
     }                                                                                                                                                          \
     PG_END_TRY();                                                                                                                                              \
@@ -439,6 +442,13 @@ private:
 
 #if PG_VERSION_NUM / 100 > 1200
 #define PG_BINGO_END                                                                                                                                           \
+    catch (BingoPgCanceled & e)                                                                                                                                \
+    {                                                                                                                                                          \
+        pg_raise_error = true;                                                                                                                                 \
+        errstart(ERROR, TEXTDOMAIN);                                                                                                                           \
+        (void)errcode(ERRCODE_QUERY_CANCELED);                                                                                                                 \
+        pg_err_mess = errmsg("error: %s", e.message());                                                                                                        \
+    }                                                                                                                                                          \
     catch (indigo::Exception & e)                                                                                                                              \
     {                                                                                                                                                          \
         pg_raise_error = true;                                                                                                                                 \
@@ -458,23 +468,28 @@ private:
     }
 #else
 #define PG_BINGO_END                                                                                                                                           \
+    catch (BingoPgCanceled & e)                                                                                                                                \
+    {                                                                                                                                                          \
+        pg_raise_error = true;                                                                                                                                 \
+        errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN);                                                                                    \
+        pg_err_mess = errmsg("error: %s", e.message());                                                                                                        \
+        errfinish((errcode(ERRCODE_QUERY_CANCELED), pg_err_mess));                                                                                             \
+    }                                                                                                                                                          \
     catch (indigo::Exception & e)                                                                                                                              \
     {                                                                                                                                                          \
         pg_raise_error = true;                                                                                                                                 \
         errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN);                                                                                    \
         pg_err_mess = errmsg("error: %s", e.message());                                                                                                        \
+        errfinish((errcode(ERRCODE_INTERNAL_ERROR), pg_err_mess));                                                                                             \
     }                                                                                                                                                          \
     catch (...)                                                                                                                                                \
     {                                                                                                                                                          \
         pg_raise_error = true;                                                                                                                                 \
         errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN);                                                                                    \
         pg_err_mess = errmsg("bingo unknown error");                                                                                                           \
-    }                                                                                                                                                          \
-    if (pg_raise_error)                                                                                                                                        \
-    {                                                                                                                                                          \
         errfinish((errcode(ERRCODE_INTERNAL_ERROR), pg_err_mess));                                                                                             \
     }                                                                                                                                                          \
-    }
+    (void)pg_raise_error;
 #endif
 
 #if PG_VERSION_NUM / 100 > 1200
@@ -532,7 +547,30 @@ public:
     }
 };
 
+/*
+ * PostgreSQL statement cancellation (SQLSTATE 57014) must never be masked by
+ * intermediate error conversions. Every BINGO_PG_HANDLE site throws this type
+ * for QUERY_CANCELED, and every broad catcher rethrows it untouched, so the
+ * AM entry points can report the original SQLSTATE instead of XX000.
+ */
+class DLLEXPORT BingoPgCanceled : public indigo::Exception
+{
+public:
+    explicit BingoPgCanceled(const char* format, ...) : indigo::Exception("bingo-postgres: canceled: ")
+    {
+        va_list args;
+        va_start(args, format);
+        const size_t len = strlen(_message);
+        vsnprintf(_message + len, sizeof(_message) - len, format, args);
+        va_end(args);
+    }
+};
+
 #define CORE_CATCH_ERROR(suffix)                                                                                                                               \
+    catch (BingoPgCanceled & e)                                                                                                                                \
+    {                                                                                                                                                          \
+        throw;                                                                                                                                                 \
+    }                                                                                                                                                          \
     catch (indigo::Exception & e)                                                                                                                              \
     {                                                                                                                                                          \
         throw BingoPgError("%s: %s", suffix, e.message());                                                                                                     \
@@ -543,6 +581,10 @@ public:
     }
 
 #define CORE_CATCH_ERROR_TID_NO_INDEX(suffix, block, offset)                                                                                                   \
+    catch (BingoPgCanceled & e)                                                                                                                                \
+    {                                                                                                                                                          \
+        throw;                                                                                                                                                 \
+    }                                                                                                                                                          \
     catch (indigo::Exception & e)                                                                                                                              \
     {                                                                                                                                                          \
         throw BingoPgError("%s with ctid='(%d,%d)'::tid: %s", suffix, block, offset, e.message());                                                             \
@@ -553,6 +595,10 @@ public:
     }
 
 #define CORE_CATCH_ERROR_TID(suffix, section_idx, structure_idx)                                                                                               \
+    catch (BingoPgCanceled & e)                                                                                                                                \
+    {                                                                                                                                                          \
+        throw;                                                                                                                                                 \
+    }                                                                                                                                                          \
     catch (indigo::Exception & e)                                                                                                                              \
     {                                                                                                                                                          \
         ItemPointerData target_item;                                                                                                                           \

--- a/bingo/postgres/src/pg_common/bingo_pg_common.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_common.h
@@ -47,8 +47,9 @@ public:
 
     //   static float getBingoSim(char*, int, char*, int);
 
-    //   static void formIndexTuple(BingoPgBuffer& buffer, void* map_data, int size);
-    //   static void* getIndexData(BingoPgBuffer& pg_buffer, int& data_len);
+    //   static void formIndexTuple(BingoPgBuffer& buffer, void* map_data, int
+    //   size); static void* getIndexData(BingoPgBuffer& pg_buffer, int&
+    //   data_len);
 
     static void printBitset(const char* name, BingoPgExternalBitset& bitset);
     static void printFPBitset(const char* name, unsigned char* bitset, int size);
@@ -56,8 +57,8 @@ public:
     //   static char* getTextData(PG_OBJECT text_datum, int& size);
 
     // static void setDefaultOptions(bingo_core::BingoCore& bingoCore);
-    //   static dword getFunctionOid(const char* name, indigo::Array<dword>& types);
-    //   static dword getFunctionOid1(const char* name, dword type1);
+    //   static dword getFunctionOid(const char* name, indigo::Array<dword>&
+    //   types); static dword getFunctionOid1(const char* name, dword type1);
 
     //   static dword callFunction(dword oid, indigo::Array<dword>& args);
     //   static dword callFunction1(dword oid, dword arg1);

--- a/bingo/postgres/src/pg_common/bingo_pg_cursor.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_cursor.cpp
@@ -29,7 +29,7 @@ static void bingoPgCursorXactCallback(XactEvent event, void* arg);
 static bool callbackRegistered = false;
 static int cursorsToFinish = 0;
 
-BingoPgCursor::BingoPgCursor(const char* format, ...)
+BingoPgCursor::BingoPgCursor(const char* format, ...) : _finishOnTransactionEnd(false)
 {
     Array<char> buf;
     va_list args;
@@ -38,12 +38,11 @@ BingoPgCursor::BingoPgCursor(const char* format, ...)
     output.vprintf(format, args);
     output.writeChar(0);
     va_end(args);
-    _finishOnTransactionEnd = false;
 
     _init(buf);
 }
 
-BingoPgCursor::BingoPgCursor(indigo::Array<char>& query_str)
+BingoPgCursor::BingoPgCursor(indigo::Array<char>& query_str) : _finishOnTransactionEnd(false)
 {
     _init(query_str);
 }
@@ -55,16 +54,16 @@ BingoPgCursor::~BingoPgCursor()
      */
     BINGO_PG_TRY
     {
-        if (!callbackRegistered)
-        {
-            callbackRegistered = false;
-            RegisterXactCallback(bingoPgCursorXactCallback, NULL);
-        }
         Portal cur_ptr = SPI_cursor_find(_cursorName.ptr());
         if (cur_ptr != NULL)
             SPI_cursor_close((Portal)_cursorPtr);
         if (_finishOnTransactionEnd)
         {
+            if (!callbackRegistered)
+            {
+                RegisterXactCallback(bingoPgCursorXactCallback, NULL);
+                callbackRegistered = true;
+            }
             ++cursorsToFinish;
         }
         else

--- a/bingo/postgres/src/pg_common/bingo_pg_ext_bitset.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_ext_bitset.cpp
@@ -6,6 +6,7 @@
 #include "base_cpp/ptr_array.h"
 #include "bingo_pg_ext_bitset.h"
 #include <algorithm>
+#include <climits>
 
 BingoPgExternalBitset::BingoPgExternalBitset()
 {
@@ -29,10 +30,24 @@ void* BingoPgExternalBitset::serialize(int& size)
 
 void BingoPgExternalBitset::deserialize(void* data_ptr, int data_len, bool ext)
 {
+    if (data_ptr == nullptr || data_len < (int)(2 * sizeof(qword)))
+        throw indigo::Exception("invalid bingo bitset data length %d", data_len);
+
     qword* data = (qword*)data_ptr;
-    _bitsNumber = data[0];
+    if (data[0] == 0 || data[0] > INT_MAX)
+        throw indigo::Exception("invalid bingo bitset size %llu", (unsigned long long)data[0]);
+
+    const int bits_number = (int)data[0];
+    const int length = _wordIndex(bits_number - 1) + 1;
+    const size_t required_size = (size_t)(length + 2) * sizeof(qword);
+    if (length <= 0 || required_size > (size_t)data_len)
+        throw indigo::Exception("bingo bitset size %d exceeds serialized data length %d", bits_number, data_len);
+    if (data[1] > (qword)length)
+        throw indigo::Exception("invalid bingo bitset words-in-use value %llu for %d words", (unsigned long long)data[1], length);
+
+    _bitsNumber = bits_number;
     _lastWordPtr = &(data[1]);
-    _length = _wordIndex(_bitsNumber - 1) + 1;
+    _length = length;
     qword* words_ptr = &(data[2]);
     if (ext)
     {

--- a/bingo/postgres/src/pg_common/bingo_pg_ext_bitset.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_ext_bitset.cpp
@@ -496,7 +496,8 @@ bool BingoPgExternalBitset::hasBits() const
     return (*_lastWordPtr) != 0;
 }
 
-// some 64-bit compilators can not correctly work with big values shift. So it must be processed manually
+// some 64-bit compilators can not correctly work with big values shift. So it
+// must be processed manually
 
 qword BingoPgExternalBitset::shiftOne(int shiftNumber)
 {

--- a/bingo/postgres/src/pg_common/bingo_pg_section.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.cpp
@@ -102,8 +102,8 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
             throw Error("internal error: bingo section %d map block count %d does not match index count %d", _offset, _sectionInfo.n_blocks_for_map,
                         bingo_idx.getMapSize());
         if (_sectionInfo.n_blocks_for_fp != bingo_idx.getFpSize())
-            throw Error("internal error: bingo section %d fingerprint block count %d does not match index count %d", _offset,
-                        _sectionInfo.n_blocks_for_fp, bingo_idx.getFpSize());
+            throw Error("internal error: bingo section %d fingerprint block count %d does not match index count %d", _offset, _sectionInfo.n_blocks_for_fp,
+                        bingo_idx.getFpSize());
         if (_sectionInfo.n_blocks_for_bin < 0 || (BlockNumber)_sectionInfo.n_blocks_for_bin > relation_blocks)
             throw Error("internal error: bingo section %d has invalid binary block count %d", _offset, _sectionInfo.n_blocks_for_bin);
 

--- a/bingo/postgres/src/pg_common/bingo_pg_section.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.cpp
@@ -20,39 +20,44 @@ using namespace indigo;
 
 IMPL_ERROR(BingoPgSection, "bingo postgres section");
 
-BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int offset)
+BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int offset, bool create_new)
     : _index(bingo_idx.getIndexPtr()), _offset(offset), _idxStrategy(idx_strategy)
 {
-
-    /*
-     * Clear section metainfo
-     */
     clear();
 
-    /*
-     * Prepare section strategy
-     */
-    bool write = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
-    if (write)
+    const bool building = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
+    const bool creating = building || create_new;
+    const bool wal_enabled = !building;
+    const unsigned int reusable_tail_start = (!building && create_new) ? (unsigned int)offset : UINT_MAX;
+    _sectionInfoBuffer.setWalEnabled(wal_enabled);
+    _sectionInfoBuffer.setReusableTailStart(reusable_tail_start);
+
+    if (creating)
     {
-        /*
-         * If write then create new buffers
-         */
-        _sectionInfoBuffer.writeNewBuffer(_index, offset);
-        _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
         _sectionInfo.n_blocks_for_map = bingo_idx.getMapSize();
         _sectionInfo.n_blocks_for_fp = bingo_idx.getFpSize();
-        /*
-         * Initialize existing structures fingerprint
-         */
-        _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, true);
 
-        /*
-         * Initialize bits number buffers
-         */
+        _sectionInfoBuffer.writeNewBuffer(_index, offset);
+        _sectionInfoBuffer.formIndexTuple(&_sectionInfo, sizeof(_sectionInfo));
+        _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
+
+        if (building)
+        {
+            _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, true, wal_enabled);
+        }
+        else
+        {
+            {
+                BingoPgBufferCacheFp initial_exists(offset + 1, _index, true, wal_enabled, reusable_tail_start);
+            }
+            _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, false, wal_enabled);
+        }
+
         for (int idx = 0; idx < SECTION_BITSNUMBER_PAGES; ++idx)
         {
             BingoPgBuffer& bits_buffer = _bitsCountBuffers.push();
+            bits_buffer.setWalEnabled(wal_enabled);
+            bits_buffer.setReusableTailStart(reusable_tail_start);
             bits_buffer.writeNewBuffer(_index, offset + idx + SECTION_META_PAGES);
             bits_buffer.formEmptyIndexTuple(SECTION_BITS_PER_BLOCK * sizeof(unsigned short));
             bits_buffer.changeAccess(BINGO_PG_NOLOCK);
@@ -60,35 +65,27 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     }
     else
     {
-        /*
-         * Read section meta info
-         */
         _sectionInfoBuffer.readBuffer(_index, _offset, BINGO_PG_READ);
         int data_len;
         BingoSectionInfoData* data = (BingoSectionInfoData*)_sectionInfoBuffer.getIndexData(data_len);
         _sectionInfo = *data;
         _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
 
-        _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, false);
+        _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, false, wal_enabled);
     }
+
     int map_count = _sectionInfo.n_blocks_for_map;
     int fp_count = _sectionInfo.n_blocks_for_fp;
     int bin_count = _sectionInfo.n_blocks_for_bin;
-    /*
-     * Prepare cache arrays
-     */
+
     _buffersMap.expand(map_count);
     _buffersFp.expand(fp_count);
     _buffersBin.expand(bin_count);
-    /*
-     * Prepare offset arrays
-     */
+
     _offsetMap.expand(map_count);
     _offsetFp.expand(fp_count);
     _offsetBin.expand(bin_count);
-    /*
-     * Prepare for reading or writing all the data buffers
-     */
+
     int block_offset = offset + SECTION_META_PAGES + SECTION_BITSNUMBER_PAGES;
     for (int i = 0; i < map_count; ++i)
     {
@@ -105,43 +102,48 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
         _offsetBin[i] = block_offset;
         ++block_offset;
     }
-    if (_idxStrategy != BingoPgIndex::READING_STRATEGY)
+
+    if (building)
+    {
+        for (int i = 0; i < map_count; ++i)
+            getMapBufferCache(i);
+        for (int i = 0; i < fp_count; ++i)
+            getFpBufferCache(i);
+        for (int i = 0; i < bin_count; ++i)
+            getBinBufferCache(i);
+    }
+    else if (create_new)
     {
         for (int i = 0; i < map_count; ++i)
         {
-            getMapBufferCache(i);
+            BingoPgBufferCacheMap initial_map(_offsetMap[i], _index, true, wal_enabled, reusable_tail_start);
         }
         for (int i = 0; i < fp_count; ++i)
         {
-            getFpBufferCache(i);
+            BingoPgBufferCacheFp initial_fp(_offsetFp[i], _index, true, wal_enabled, reusable_tail_start);
         }
+    }
+    else if (_idxStrategy == BingoPgIndex::UPDATING_STRATEGY)
+    {
         for (int i = 0; i < bin_count; ++i)
-        {
             getBinBufferCache(i);
-        }
+    }
+
+    if (creating)
+    {
+        _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+        _sectionInfo.section_size = getPagesCount();
+        _flushSectionInfo();
     }
 }
 
 BingoPgSection::~BingoPgSection()
 {
-    /*
-     * Write meta info
-     */
-    _sectionInfo.n_blocks_for_bin = _buffersBin.size();
-    _sectionInfo.section_size = getPagesCount();
-    if (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY)
+    if (_idxStrategy != BingoPgIndex::READING_STRATEGY)
     {
-        _sectionInfoBuffer.changeAccess(BINGO_PG_WRITE);
-        _sectionInfoBuffer.formIndexTuple(&_sectionInfo, sizeof(_sectionInfo));
-        _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
-    }
-    else if (_idxStrategy == BingoPgIndex::UPDATING_STRATEGY)
-    {
-        _sectionInfoBuffer.changeAccess(BINGO_PG_WRITE);
-        int data_len;
-        BingoSectionInfoData* data = (BingoSectionInfoData*)_sectionInfoBuffer.getIndexData(data_len);
-        *data = _sectionInfo;
-        _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
+        _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+        _sectionInfo.section_size = getPagesCount();
+        _flushSectionInfo();
     }
 }
 
@@ -165,6 +167,17 @@ void BingoPgSection::clear()
     _offsetMap.clear();
 }
 
+void BingoPgSection::_flushSectionInfo()
+{
+    _sectionInfoBuffer.changeAccess(BINGO_PG_WRITE);
+    int data_len;
+    BingoSectionInfoData* data = (BingoSectionInfoData*)_sectionInfoBuffer.getIndexData(data_len);
+    if (data_len < (int)sizeof(_sectionInfo))
+        throw Error("internal error: section metadata block is too small");
+    *data = _sectionInfo;
+    _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
+}
+
 bool BingoPgSection::isExtended()
 {
     return _sectionInfo.n_structures < BINGO_MOLS_PER_SECTION;
@@ -172,11 +185,12 @@ bool BingoPgSection::isExtended()
 
 void BingoPgSection::addStructure(BingoPgFpData& item_data)
 {
-    int current_str = _sectionInfo.n_structures;
-    elog(DEBUG1, "bingo: section: insert a structure %d", current_str);
-    /*
-     * Set fp bits
-     */
+    const int current_str = _sectionInfo.n_structures;
+    elog(DEBUG1, "bingo: section: reserve structure %d", current_str);
+
+    ++_sectionInfo.n_structures;
+    _flushSectionInfo();
+
     for (int idx = item_data.bitBegin(); idx != item_data.bitEnd(); idx = item_data.bitNext(idx))
     {
         int bit_idx = item_data.getBit(idx);
@@ -186,40 +200,22 @@ void BingoPgSection::addStructure(BingoPgFpData& item_data)
 
     int map_buf_idx = current_str / BINGO_MOLS_PER_MAPBLOCK;
     int map_idx = current_str % BINGO_MOLS_PER_MAPBLOCK;
-    /*
-     * Set tid map
-     */
+
     elog(DEBUG1, "bingo: section: set tid map: map buffer idx = %d offset = %d", map_buf_idx, map_idx);
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setTidItem(map_idx, item_data.getTidItem());
 
-    /*
-     * Prepare and set cmf map
-     */
     _setCmfData(item_data.getCmfBuf(), map_buf_idx, map_idx);
-    /*
-     * Prepare and set xyz map
-     */
     _setXyzData(item_data.getXyzBuf(), map_buf_idx, map_idx);
-
-    /*
-     * Set bits number
-     */
     _setBitsCountData(item_data.getBitsCount());
-    /*
-     * Set structure index
-     */
-    item_data.setStructureIdx(_sectionInfo.n_structures);
 
-    /*
-     * Set structure bit
-     */
+    item_data.setStructureIdx(current_str);
+
+    _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+    _sectionInfo.section_size = getPagesCount();
+    _flushSectionInfo();
+
     _existStructures->setBit(current_str, true);
-
-    /*
-     * Increment structures number
-     */
-    ++_sectionInfo.n_structures;
 }
 
 int BingoPgSection::getPagesCount() const
@@ -234,8 +230,9 @@ void BingoPgSection::getSectionStructures(BingoPgExternalBitset& section_bitset)
 
 void BingoPgSection::removeStructure(int mol_idx)
 {
-    _existStructures->setBit(mol_idx, false);
     _sectionInfo.has_removed = 1;
+    _flushSectionInfo();
+    _existStructures->setBit(mol_idx, false);
 }
 
 bool BingoPgSection::isStructureRemoved(int mol_idx)
@@ -251,8 +248,9 @@ BingoPgBufferCacheFp& BingoPgSection::getFpBufferCache(int fp_idx)
     if (elem == 0)
     {
         bool write = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
+        bool wal_enabled = (_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
         int block_offset = _offsetFp[fp_idx];
-        elem = new BingoPgBufferCacheFp(block_offset, _index, write);
+        elem = new BingoPgBufferCacheFp(block_offset, _index, write, wal_enabled);
         _buffersFp.set(fp_idx, elem);
     }
     return *elem;
@@ -264,8 +262,9 @@ BingoPgBufferCacheMap& BingoPgSection::getMapBufferCache(int map_idx)
     if (elem == 0)
     {
         bool write = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
+        bool wal_enabled = (_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
         int block_offset = _offsetMap[map_idx];
-        elem = new BingoPgBufferCacheMap(block_offset, _index, write);
+        elem = new BingoPgBufferCacheMap(block_offset, _index, write, wal_enabled);
         _buffersMap.set(map_idx, elem);
     }
     return *elem;
@@ -292,6 +291,7 @@ void BingoPgSection::readSectionBitsCount(indigo::Array<int>& bits_number)
             break;
 
         BingoPgBuffer& bits_buffer = _bitsCountBuffers[buf_idx];
+        bits_buffer.setWalEnabled(_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
         bits_buffer.readBuffer(_index, _offset + buf_idx + SECTION_META_PAGES, BINGO_PG_READ);
         buffer_data = (unsigned short*)bits_buffer.getIndexData(data_len);
         for (int page_str_idx = 0; page_str_idx < SECTION_BITS_PER_BLOCK; ++page_str_idx)
@@ -307,14 +307,8 @@ void BingoPgSection::readSectionBitsCount(indigo::Array<int>& bits_number)
 
 void BingoPgSection::_setCmfData(indigo::Array<char>& cmf_buf, int map_buf_idx, int map_idx)
 {
-    /*
-     * Set binary info
-     */
     ItemPointerData cmf_item;
     _setBinData(cmf_buf, _sectionInfo.last_cmf, cmf_item);
-    /*
-     * Set mappings
-     */
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setCmfItem(map_idx, cmf_item);
 
@@ -323,14 +317,8 @@ void BingoPgSection::_setCmfData(indigo::Array<char>& cmf_buf, int map_buf_idx, 
 
 void BingoPgSection::_setXyzData(indigo::Array<char>& xyz_buf, int map_buf_idx, int map_idx)
 {
-    /*
-     * Set binary info
-     */
     ItemPointerData xyz_item;
     _setBinData(xyz_buf, _sectionInfo.last_xyz, xyz_item);
-    /*
-     * Set mappings
-     */
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setXyzItem(map_idx, xyz_item);
 
@@ -348,39 +336,55 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
         BINGO_PG_HANDLE(throw Error("internal error: can not set block data: %s", message));
         return;
     }
-    /*
-     * Dynamic binary buffers
-     */
+
+    const bool building = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
 
     if (last_buf == -1)
     {
         int block_off = _offset + getPagesCount();
-        _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, true));
+        if (building)
+        {
+            _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, true, false));
+        }
+        else
+        {
+            {
+                BingoPgBufferCacheBin initial_bin(block_off, _index, true, true, (unsigned int)block_off);
+            }
+            _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, false, true));
+        }
         last_buf = _buffersBin.size() - 1;
         _offsetBin.push(block_off);
+        _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+        _sectionInfo.section_size = getPagesCount();
+        _flushSectionInfo();
     }
 
     BingoPgBufferCacheBin* cache_bin = _getBufferBin(last_buf);
-    /*
-     * If not enough space for inserting a new structure - then create and new buffer
-     */
     if (!cache_bin->isEnoughSpace(buf.sizeInBytes()))
     {
         int block_off = _offset + getPagesCount();
-        _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, true));
+        if (building)
+        {
+            _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, true, false));
+        }
+        else
+        {
+            {
+                BingoPgBufferCacheBin initial_bin(block_off, _index, true, true, (unsigned int)block_off);
+            }
+            _buffersBin.add(new BingoPgBufferCacheBin(block_off, _index, false, true));
+        }
         last_buf = _buffersBin.size() - 1;
         _offsetBin.push(block_off);
+        _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+        _sectionInfo.section_size = getPagesCount();
+        _flushSectionInfo();
     }
     cache_bin = _getBufferBin(last_buf);
 
-    /*
-     * Get cmf offset for storing cmf mapping
-     */
     unsigned short bin_offset = cache_bin->addBin(buf);
 
-    /*
-     * Set mappings
-     */
     BINGO_PG_TRY
     {
         ItemPointerSet(&item_data, last_buf, bin_offset);
@@ -390,15 +394,15 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
 
 void BingoPgSection::_setBitsCountData(unsigned short bits_count)
 {
-
     if (_bitsCountBuffers.size() == 0)
         _bitsCountBuffers.resize(SECTION_BITSNUMBER_PAGES);
 
     int data_len;
-    int buf_idx = _sectionInfo.n_structures / SECTION_BITS_PER_BLOCK;
-    int page_str_idx = _sectionInfo.n_structures % SECTION_BITS_PER_BLOCK;
+    int buf_idx = (_sectionInfo.n_structures - 1) / SECTION_BITS_PER_BLOCK;
+    int page_str_idx = (_sectionInfo.n_structures - 1) % SECTION_BITS_PER_BLOCK;
 
     BingoPgBuffer& bits_buffer = _bitsCountBuffers[buf_idx];
+    bits_buffer.setWalEnabled(_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
     bits_buffer.readBuffer(_index, _offset + buf_idx + SECTION_META_PAGES, BINGO_PG_WRITE);
     unsigned short* buffer_data = (unsigned short*)bits_buffer.getIndexData(data_len);
     buffer_data[page_str_idx] = bits_count;
@@ -411,8 +415,9 @@ BingoPgBufferCacheBin* BingoPgSection::_getBufferBin(int idx)
     if (elem == 0)
     {
         bool write = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
+        bool wal_enabled = (_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
         int block_offset = _offsetBin[idx];
-        elem = new BingoPgBufferCacheBin(block_offset, _index, write);
+        elem = new BingoPgBufferCacheBin(block_offset, _index, write, wal_enabled);
         _buffersBin.set(idx, elem);
     }
     return elem;

--- a/bingo/postgres/src/pg_common/bingo_pg_section.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.cpp
@@ -23,8 +23,14 @@ IMPL_ERROR(BingoPgSection, "bingo postgres section");
 BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int offset, bool create_new)
     : _index(bingo_idx.getIndexPtr()), _offset(offset), _idxStrategy(idx_strategy)
 {
+    /*
+     * Clear section metainfo
+     */
     clear();
 
+    /*
+     * Prepare section strategy
+     */
     const bool building = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
     const bool creating = building || create_new;
     const bool wal_enabled = !building;
@@ -34,6 +40,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
 
     if (creating)
     {
+        /*
+         * If creating then create new buffers
+         */
         _sectionInfo.n_blocks_for_map = bingo_idx.getMapSize();
         _sectionInfo.n_blocks_for_fp = bingo_idx.getFpSize();
 
@@ -41,6 +50,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
         _sectionInfoBuffer.formIndexTuple(&_sectionInfo, sizeof(_sectionInfo));
         _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
 
+        /*
+         * Initialize existing structures fingerprint
+         */
         if (building)
         {
             _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, true, wal_enabled);
@@ -53,6 +65,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
             _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, false, wal_enabled);
         }
 
+        /*
+         * Initialize bits number buffers
+         */
         for (int idx = 0; idx < SECTION_BITSNUMBER_PAGES; ++idx)
         {
             BingoPgBuffer& bits_buffer = _bitsCountBuffers.push();
@@ -65,6 +80,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     }
     else
     {
+        /*
+         * Read section meta info
+         */
         _sectionInfoBuffer.readBuffer(_index, _offset, BINGO_PG_READ);
         int data_len;
         BingoSectionInfoData* data = (BingoSectionInfoData*)_sectionInfoBuffer.getIndexData(data_len);
@@ -77,15 +95,21 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     int map_count = _sectionInfo.n_blocks_for_map;
     int fp_count = _sectionInfo.n_blocks_for_fp;
     int bin_count = _sectionInfo.n_blocks_for_bin;
-
+    /*
+     * Prepare cache arrays
+     */
     _buffersMap.expand(map_count);
     _buffersFp.expand(fp_count);
     _buffersBin.expand(bin_count);
-
+    /*
+     * Prepare offset arrays
+     */
     _offsetMap.expand(map_count);
     _offsetFp.expand(fp_count);
     _offsetBin.expand(bin_count);
-
+    /*
+     * Prepare for reading or writing all the data buffers
+     */
     int block_offset = offset + SECTION_META_PAGES + SECTION_BITSNUMBER_PAGES;
     for (int i = 0; i < map_count; ++i)
     {
@@ -106,11 +130,17 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     if (building)
     {
         for (int i = 0; i < map_count; ++i)
+        {
             getMapBufferCache(i);
+        }
         for (int i = 0; i < fp_count; ++i)
+        {
             getFpBufferCache(i);
+        }
         for (int i = 0; i < bin_count; ++i)
+        {
             getBinBufferCache(i);
+        }
     }
     else if (create_new)
     {
@@ -126,7 +156,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     else if (_idxStrategy == BingoPgIndex::UPDATING_STRATEGY)
     {
         for (int i = 0; i < bin_count; ++i)
+        {
             getBinBufferCache(i);
+        }
     }
 
     if (creating)
@@ -139,6 +171,9 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
 
 BingoPgSection::~BingoPgSection()
 {
+    /*
+     * Write meta info
+     */
     if (_idxStrategy != BingoPgIndex::READING_STRATEGY)
     {
         _sectionInfo.n_blocks_for_bin = _buffersBin.size();
@@ -188,9 +223,15 @@ void BingoPgSection::addStructure(BingoPgFpData& item_data)
     const int current_str = _sectionInfo.n_structures;
     elog(DEBUG1, "bingo: section: reserve structure %d", current_str);
 
+    /*
+     * Reserve the logical structure slot before writing payload pages
+     */
     ++_sectionInfo.n_structures;
     _flushSectionInfo();
 
+    /*
+     * Set fp bits
+     */
     for (int idx = item_data.bitBegin(); idx != item_data.bitEnd(); idx = item_data.bitNext(idx))
     {
         int bit_idx = item_data.getBit(idx);
@@ -200,21 +241,38 @@ void BingoPgSection::addStructure(BingoPgFpData& item_data)
 
     int map_buf_idx = current_str / BINGO_MOLS_PER_MAPBLOCK;
     int map_idx = current_str % BINGO_MOLS_PER_MAPBLOCK;
-
+    /*
+     * Set tid map
+     */
     elog(DEBUG1, "bingo: section: set tid map: map buffer idx = %d offset = %d", map_buf_idx, map_idx);
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setTidItem(map_idx, item_data.getTidItem());
 
+    /*
+     * Prepare and set cmf map
+     */
     _setCmfData(item_data.getCmfBuf(), map_buf_idx, map_idx);
+    /*
+     * Prepare and set xyz map
+     */
     _setXyzData(item_data.getXyzBuf(), map_buf_idx, map_idx);
-    _setBitsCountData(item_data.getBitsCount());
 
+    /*
+     * Set bits number
+     */
+    _setBitsCountData(item_data.getBitsCount());
+    /*
+     * Set structure index
+     */
     item_data.setStructureIdx(current_str);
 
     _sectionInfo.n_blocks_for_bin = _buffersBin.size();
     _sectionInfo.section_size = getPagesCount();
     _flushSectionInfo();
 
+    /*
+     * Set structure bit
+     */
     _existStructures->setBit(current_str, true);
 }
 
@@ -307,8 +365,14 @@ void BingoPgSection::readSectionBitsCount(indigo::Array<int>& bits_number)
 
 void BingoPgSection::_setCmfData(indigo::Array<char>& cmf_buf, int map_buf_idx, int map_idx)
 {
+    /*
+     * Set binary info
+     */
     ItemPointerData cmf_item;
     _setBinData(cmf_buf, _sectionInfo.last_cmf, cmf_item);
+    /*
+     * Set mappings
+     */
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setCmfItem(map_idx, cmf_item);
 
@@ -317,8 +381,14 @@ void BingoPgSection::_setCmfData(indigo::Array<char>& cmf_buf, int map_buf_idx, 
 
 void BingoPgSection::_setXyzData(indigo::Array<char>& xyz_buf, int map_buf_idx, int map_idx)
 {
+    /*
+     * Set binary info
+     */
     ItemPointerData xyz_item;
     _setBinData(xyz_buf, _sectionInfo.last_xyz, xyz_item);
+    /*
+     * Set mappings
+     */
     BingoPgBufferCacheMap& buffer_map = getMapBufferCache(map_buf_idx);
     buffer_map.setXyzItem(map_idx, xyz_item);
 
@@ -336,6 +406,9 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
         BINGO_PG_HANDLE(throw Error("internal error: can not set block data: %s", message));
         return;
     }
+    /*
+     * Dynamic binary buffers
+     */
 
     const bool building = (_idxStrategy == BingoPgIndex::BUILDING_STRATEGY);
 
@@ -361,6 +434,9 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
     }
 
     BingoPgBufferCacheBin* cache_bin = _getBufferBin(last_buf);
+    /*
+     * If not enough space for inserting a new structure - then create and new buffer
+     */
     if (!cache_bin->isEnoughSpace(buf.sizeInBytes()))
     {
         int block_off = _offset + getPagesCount();
@@ -383,8 +459,14 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
     }
     cache_bin = _getBufferBin(last_buf);
 
+    /*
+     * Get cmf offset for storing cmf mapping
+     */
     unsigned short bin_offset = cache_bin->addBin(buf);
 
+    /*
+     * Set mappings
+     */
     BINGO_PG_TRY
     {
         ItemPointerSet(&item_data, last_buf, bin_offset);
@@ -394,6 +476,7 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
 
 void BingoPgSection::_setBitsCountData(unsigned short bits_count)
 {
+
     if (_bitsCountBuffers.size() == 0)
         _bitsCountBuffers.resize(SECTION_BITSNUMBER_PAGES);
 

--- a/bingo/postgres/src/pg_common/bingo_pg_section.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.cpp
@@ -99,19 +99,22 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
         if (_sectionInfo.n_structures < 0 || _sectionInfo.n_structures > BINGO_MOLS_PER_SECTION)
             throw Error("internal error: bingo section %d has invalid structure count %d", _offset, _sectionInfo.n_structures);
         if (_sectionInfo.n_blocks_for_map != bingo_idx.getMapSize())
-            throw Error("internal error: bingo section %d map block count %d does not match index count %d", _offset, _sectionInfo.n_blocks_for_map,
-                        bingo_idx.getMapSize());
+            throw Error("internal error: bingo section %d map block count %d does "
+                        "not match index count %d",
+                        _offset, _sectionInfo.n_blocks_for_map, bingo_idx.getMapSize());
         if (_sectionInfo.n_blocks_for_fp != bingo_idx.getFpSize())
-            throw Error("internal error: bingo section %d fingerprint block count %d does not match index count %d", _offset, _sectionInfo.n_blocks_for_fp,
-                        bingo_idx.getFpSize());
+            throw Error("internal error: bingo section %d fingerprint block count %d "
+                        "does not match index count %d",
+                        _offset, _sectionInfo.n_blocks_for_fp, bingo_idx.getFpSize());
         if (_sectionInfo.n_blocks_for_bin < 0 || (BlockNumber)_sectionInfo.n_blocks_for_bin > relation_blocks)
             throw Error("internal error: bingo section %d has invalid binary block count %d", _offset, _sectionInfo.n_blocks_for_bin);
 
         const long long expected_section_size = (long long)SECTION_META_PAGES + SECTION_BITSNUMBER_PAGES + _sectionInfo.n_blocks_for_map +
                                                 _sectionInfo.n_blocks_for_fp + _sectionInfo.n_blocks_for_bin;
         if (_sectionInfo.section_size != expected_section_size)
-            throw Error("internal error: bingo section %d size %d does not match expected size %lld", _offset, _sectionInfo.section_size,
-                        expected_section_size);
+            throw Error("internal error: bingo section %d size %d does not match "
+                        "expected size %lld",
+                        _offset, _sectionInfo.section_size, expected_section_size);
         if (_offset < 0 || expected_section_size <= 0 || (long long)_offset + expected_section_size > relation_blocks)
             throw Error("internal error: bingo section %d range exceeds relation size %u", _offset, (unsigned int)relation_blocks);
         if (_sectionInfo.last_cmf < -1 || _sectionInfo.last_cmf >= _sectionInfo.n_blocks_for_bin)
@@ -496,7 +499,8 @@ void BingoPgSection::_setBinData(indigo::Array<char>& buf, int& last_buf, ItemPo
 
     BingoPgBufferCacheBin* cache_bin = _getBufferBin(last_buf);
     /*
-     * If not enough space for inserting a new structure - then create and new buffer
+     * If not enough space for inserting a new structure - then create and new
+     * buffer
      */
     if (!cache_bin->isEnoughSpace(buf.sizeInBytes()))
     {

--- a/bingo/postgres/src/pg_common/bingo_pg_section.cpp
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.cpp
@@ -4,7 +4,9 @@ extern "C"
 {
 #include "postgres.h"
 #include "storage/block.h"
+#include "storage/bufmgr.h"
 #include "storage/itemptr.h"
+#include "utils/rel.h"
 }
 
 #include "bingo_pg_fix_post.h"
@@ -81,13 +83,43 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
     else
     {
         /*
-         * Read section meta info
+         * Read and validate section meta info before using persisted counts to
+         * size cache arrays or calculate physical block offsets.
          */
         _sectionInfoBuffer.readBuffer(_index, _offset, BINGO_PG_READ);
         int data_len;
         BingoSectionInfoData* data = (BingoSectionInfoData*)_sectionInfoBuffer.getIndexData(data_len);
+        if (data_len < (int)sizeof(BingoSectionInfoData))
+            throw Error("internal error: bingo section %d metadata is too small", _offset);
         _sectionInfo = *data;
         _sectionInfoBuffer.changeAccess(BINGO_PG_NOLOCK);
+
+        Relation index = (Relation)_index;
+        const BlockNumber relation_blocks = RelationGetNumberOfBlocks(index);
+        if (_sectionInfo.n_structures < 0 || _sectionInfo.n_structures > BINGO_MOLS_PER_SECTION)
+            throw Error("internal error: bingo section %d has invalid structure count %d", _offset, _sectionInfo.n_structures);
+        if (_sectionInfo.n_blocks_for_map != bingo_idx.getMapSize())
+            throw Error("internal error: bingo section %d map block count %d does not match index count %d", _offset, _sectionInfo.n_blocks_for_map,
+                        bingo_idx.getMapSize());
+        if (_sectionInfo.n_blocks_for_fp != bingo_idx.getFpSize())
+            throw Error("internal error: bingo section %d fingerprint block count %d does not match index count %d", _offset,
+                        _sectionInfo.n_blocks_for_fp, bingo_idx.getFpSize());
+        if (_sectionInfo.n_blocks_for_bin < 0 || (BlockNumber)_sectionInfo.n_blocks_for_bin > relation_blocks)
+            throw Error("internal error: bingo section %d has invalid binary block count %d", _offset, _sectionInfo.n_blocks_for_bin);
+
+        const long long expected_section_size = (long long)SECTION_META_PAGES + SECTION_BITSNUMBER_PAGES + _sectionInfo.n_blocks_for_map +
+                                                _sectionInfo.n_blocks_for_fp + _sectionInfo.n_blocks_for_bin;
+        if (_sectionInfo.section_size != expected_section_size)
+            throw Error("internal error: bingo section %d size %d does not match expected size %lld", _offset, _sectionInfo.section_size,
+                        expected_section_size);
+        if (_offset < 0 || expected_section_size <= 0 || (long long)_offset + expected_section_size > relation_blocks)
+            throw Error("internal error: bingo section %d range exceeds relation size %u", _offset, (unsigned int)relation_blocks);
+        if (_sectionInfo.last_cmf < -1 || _sectionInfo.last_cmf >= _sectionInfo.n_blocks_for_bin)
+            throw Error("internal error: bingo section %d has invalid last CMF block %d", _offset, _sectionInfo.last_cmf);
+        if (_sectionInfo.last_xyz < -1 || _sectionInfo.last_xyz >= _sectionInfo.n_blocks_for_bin)
+            throw Error("internal error: bingo section %d has invalid last XYZ block %d", _offset, _sectionInfo.last_xyz);
+        if (_sectionInfo.has_removed != 0 && _sectionInfo.has_removed != 1)
+            throw Error("internal error: bingo section %d has invalid removed flag %d", _offset, (int)_sectionInfo.has_removed);
 
         _existStructures = std::make_unique<BingoPgBufferCacheFp>(offset + 1, _index, false, wal_enabled);
     }
@@ -171,15 +203,6 @@ BingoPgSection::BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int of
 
 BingoPgSection::~BingoPgSection()
 {
-    /*
-     * Write meta info
-     */
-    if (_idxStrategy != BingoPgIndex::READING_STRATEGY)
-    {
-        _sectionInfo.n_blocks_for_bin = _buffersBin.size();
-        _sectionInfo.section_size = getPagesCount();
-        _flushSectionInfo();
-    }
 }
 
 void BingoPgSection::clear()
@@ -200,6 +223,39 @@ void BingoPgSection::clear()
     _offsetBin.clear();
     _offsetFp.clear();
     _offsetMap.clear();
+}
+
+void BingoPgSection::finish()
+{
+    if (_idxStrategy == BingoPgIndex::READING_STRATEGY)
+        return;
+
+    _sectionInfo.n_blocks_for_bin = _buffersBin.size();
+    _sectionInfo.section_size = getPagesCount();
+
+    for (int i = 0; i < _buffersBin.size(); ++i)
+    {
+        BingoPgBufferCacheBin* cache = _buffersBin.getPtr(i);
+        if (cache != 0)
+            cache->flush();
+    }
+    for (int i = 0; i < _buffersMap.size(); ++i)
+    {
+        BingoPgBufferCacheMap* cache = _buffersMap.getPtr(i);
+        if (cache != 0)
+            cache->flush();
+    }
+    for (int i = 0; i < _buffersFp.size(); ++i)
+    {
+        BingoPgBufferCacheFp* cache = _buffersFp.getPtr(i);
+        if (cache != 0)
+            cache->flush();
+    }
+
+    _flushSectionInfo();
+
+    if (_existStructures.get() != 0)
+        _existStructures->flush();
 }
 
 void BingoPgSection::_flushSectionInfo()
@@ -352,6 +408,11 @@ void BingoPgSection::readSectionBitsCount(indigo::Array<int>& bits_number)
         bits_buffer.setWalEnabled(_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
         bits_buffer.readBuffer(_index, _offset + buf_idx + SECTION_META_PAGES, BINGO_PG_READ);
         buffer_data = (unsigned short*)bits_buffer.getIndexData(data_len);
+        if (data_len < SECTION_BITS_PER_BLOCK * (int)sizeof(unsigned short))
+        {
+            bits_buffer.changeAccess(BINGO_PG_NOLOCK);
+            throw Error("internal error: bingo section %d bits-count block %d is too small", _offset, buf_idx);
+        }
         for (int page_str_idx = 0; page_str_idx < SECTION_BITS_PER_BLOCK; ++page_str_idx)
         {
             str_idx = buf_idx * SECTION_BITS_PER_BLOCK + page_str_idx;
@@ -488,6 +549,8 @@ void BingoPgSection::_setBitsCountData(unsigned short bits_count)
     bits_buffer.setWalEnabled(_idxStrategy != BingoPgIndex::BUILDING_STRATEGY);
     bits_buffer.readBuffer(_index, _offset + buf_idx + SECTION_META_PAGES, BINGO_PG_WRITE);
     unsigned short* buffer_data = (unsigned short*)bits_buffer.getIndexData(data_len);
+    if (data_len < SECTION_BITS_PER_BLOCK * (int)sizeof(unsigned short))
+        throw Error("internal error: bingo section %d bits-count block %d is too small", _offset, buf_idx);
     buffer_data[page_str_idx] = bits_count;
     bits_buffer.changeAccess(BINGO_PG_NOLOCK);
 }

--- a/bingo/postgres/src/pg_common/bingo_pg_section.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.h
@@ -36,6 +36,7 @@ public:
     ~BingoPgSection();
 
     void clear();
+    void finish();
 
     /*
      * Returns true if section can be extended

--- a/bingo/postgres/src/pg_common/bingo_pg_section.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.h
@@ -32,7 +32,7 @@ public:
         SECTION_BITSNUMBER_PAGES = 16,
         SECTION_BITS_PER_BLOCK = 4000 /* 4000 * sizeof(unsigned short) < 8K*/
     };
-    BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int offset);
+    BingoPgSection(BingoPgIndex& bingo_idx, int idx_strategy, int offset, bool create_new = false);
     ~BingoPgSection();
 
     void clear();
@@ -68,13 +68,14 @@ public:
     const BingoSectionInfoData& getSectionInfo() const
     {
         return _sectionInfo;
-    };
+    }
 
     DECL_ERROR;
 
 private:
     BingoPgSection(const BingoPgSection&); // no implicit copy
 
+    void _flushSectionInfo();
     void _setCmfData(indigo::Array<char>& cmf_buf, int map_buf_idx, int map_idx);
     void _setXyzData(indigo::Array<char>& xyz_buf, int map_buf_idx, int map_idx);
     void _setBinData(indigo::Array<char>& buf, int& last_buf, ItemPointerData& item_data);

--- a/bingo/postgres/src/pg_common/bingo_pg_section.h
+++ b/bingo/postgres/src/pg_common/bingo_pg_section.h
@@ -68,7 +68,7 @@ public:
     const BingoSectionInfoData& getSectionInfo() const
     {
         return _sectionInfo;
-    }
+    };
 
     DECL_ERROR;
 

--- a/bingo/postgres/src/pg_core/bingo_pg_build.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build.cpp
@@ -51,20 +51,60 @@ BingoPgBuild::BingoPgBuild(PG_OBJECT index_ptr, const char* schema_name, const c
 
 BingoPgBuild::~BingoPgBuild()
 {
+}
+
+void BingoPgBuild::finish()
+{
+    if (!_buildingState)
+        return;
+
     /*
-     * Finish building stage
+     * Process the final parallel batch before releasing the section caches.
      */
-    if (_buildingState)
+    flush();
+
+    /*
+     * Explicitly finalize and release the current section so all page caches
+     * are complete before the build publishes dictionary/meta state or logs
+     * the relation for WAL.
+     */
+    int final_section_offset = 0;
+    int final_section_pages = 0;
+    _bufferIndex.finishCurrentSection(final_section_offset, final_section_pages);
+
+    Relation index = (Relation)_index;
+    const BlockNumber physical_pages = RelationGetNumberOfBlocks(index);
+    const BlockNumber expected_pages = (BlockNumber)(final_section_offset + final_section_pages);
+    if (physical_pages != expected_pages)
+        throw Error("internal error: bingo index physical size %u does not match final logical end %u", (unsigned int)physical_pages,
+                    (unsigned int)expected_pages);
+
+    _validateBuiltSection(final_section_offset, final_section_pages);
+
+    /*
+     * Publish global build state only after the physical section is complete.
+     */
+    _bufferIndex.writeDictionary(*fp_engine);
+    _bufferIndex.writeMetaInfo();
+    fp_engine->finishShadowProcessing();
+
+    _buildingState = false;
+}
+
+void BingoPgBuild::_validateBuiltSection(int section_offset, int section_pages)
+{
+    if (section_offset < 0 || section_pages <= 0)
+        throw Error("internal error: invalid final bingo section range offset=%d pages=%d", section_offset, section_pages);
+
+    for (int page_idx = 0; page_idx < section_pages; ++page_idx)
     {
-        fp_engine->finishShadowProcessing();
-        /*
-         * Write dictionary and meta info after the bulk build is complete.
-         * Incremental writes persist this state before publishing structures.
-         */
-        _bufferIndex.writeDictionary(*fp_engine);
-        _bufferIndex.writeMetaInfo();
+        const unsigned int block_idx = (unsigned int)(section_offset + page_idx);
+        BingoPgBuffer buffer(_index, block_idx, BINGO_PG_READ);
+        int data_len = 0;
+        buffer.getIndexData(data_len);
     }
 }
+
 /*
  * Inserts a new structure into the index
  * Returns true if insertion was successfull
@@ -192,7 +232,7 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     }
 
     if (struct_cache.data.get() == 0)
-        return false;
+        throw Error("internal error: bingo build reported success without prepared data for ctid='(%d,%d)'::tid", block_number, offset_number);
 
     /*
      * The encoded CMF can depend on dictionary state changed while processing
@@ -251,10 +291,18 @@ void BingoPgBuild::flush()
     {
         // profTimerStart(t1, "bingo_pg.insert_idx");
         BingoPgBuildEngine::StructCache& struct_cache = _parrallelCache[c_idx];
+        ItemPointer item_ptr = &struct_cache.ptr;
+        int block_number = ItemPointerGetBlockNumber(item_ptr);
+        int offset_number = ItemPointerGetOffsetNumber(item_ptr);
+
         if (struct_cache.data.get() == 0)
         {
-            continue;
+            if (struct_cache.rejected)
+                continue;
+            throw Error("internal error: parallel bingo build did not resolve ctid='(%d,%d)'::tid as prepared or rejected", block_number, offset_number);
         }
+        if (struct_cache.rejected)
+            throw Error("internal error: parallel bingo build resolved ctid='(%d,%d)'::tid as both prepared and rejected", block_number, offset_number);
 
         BingoPgFpData& data_ref = *struct_cache.data;
         _bufferIndex.insertStructure(data_ref);

--- a/bingo/postgres/src/pg_core/bingo_pg_build.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build.cpp
@@ -32,6 +32,9 @@ IMPL_ERROR(BingoPgBuild, "build engine");
 BingoPgBuild::BingoPgBuild(PG_OBJECT index_ptr, const char* schema_name, const char* index_schema, bool new_index)
     : _index(index_ptr), _bufferIndex(index_ptr), _buildingState(new_index)
 {
+    /*
+     * Prepare buffer section for building or updating
+     */
     BingoPgCommon::appendPath(index_schema);
 
     if (_buildingState)
@@ -49,19 +52,23 @@ BingoPgBuild::BingoPgBuild(PG_OBJECT index_ptr, const char* schema_name, const c
 BingoPgBuild::~BingoPgBuild()
 {
     /*
-     * Bulk builds publish their shadow indexes, dictionary, and metapage when
-     * the build is complete. Incremental writes persist dictionary/meta state
-     * explicitly before/while publishing each structure and must not depend on
-     * destructor ordering for crash safety.
+     * Finish building stage
      */
     if (_buildingState)
     {
         fp_engine->finishShadowProcessing();
+        /*
+         * Write dictionary and meta info after the bulk build is complete.
+         * Incremental writes persist this state before publishing structures.
+         */
         _bufferIndex.writeDictionary(*fp_engine);
         _bufferIndex.writeMetaInfo();
     }
 }
-
+/*
+ * Inserts a new structure into the index
+ * Returns true if insertion was successfull
+ */
 void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_schema)
 {
     Relation index = (Relation)_index;
@@ -73,9 +80,15 @@ void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_s
 
     elog(DEBUG1, "bingo: index build: start create index '%s'", rel_name);
 
+    /*
+     * Safety check
+     */
     if (RelationGetNumberOfBlocks(index) != 0)
         throw Error("cannot initialize non-empty bingo index \"%s\"", RelationGetRelationName(index));
 
+    /*
+     * Define index type
+     */
     if (strcasecmp(func_name, "matchsub") == 0)
     {
         fp_engine = std::make_unique<MangoPgBuildEngine>(rel_name);
@@ -89,11 +102,21 @@ void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_s
         throw Error("internal error: unknown index build function %s", func_name);
     }
     BingoPgConfig bingo_config(fp_engine->bingoCore);
+    /*
+     * Set up configuration from postgres table
+     */
     bingo_config.readDefaultConfig(schema_name);
+    /*
+     * Update configuration from pg_class.reloptions
+     */
     bingo_config.updateByIndexConfig(index);
     fp_engine->setUpConfiguration(bingo_config);
 
+    /*
+     * If new build then create a metapage and initial section
+     */
     _bufferIndex.writeBegin(*fp_engine, bingo_config);
+
     fp_engine->prepareShadowInfo(schema_name, index_schema);
 }
 
@@ -107,6 +130,9 @@ void BingoPgBuild::_prepareUpdating()
 
     _bufferIndex.readMetaInfo();
 
+    /*
+     * Define index type
+     */
     if (_bufferIndex.getIndexType() == BINGO_INDEX_TYPE_MOLECULE)
         fp_engine = std::make_unique<MangoPgBuildEngine>(rel_name);
     else if (_bufferIndex.getIndexType() == BINGO_INDEX_TYPE_REACTION)
@@ -116,26 +142,43 @@ void BingoPgBuild::_prepareUpdating()
     auto& bingo_core = fp_engine->bingoCore;
     BingoPgConfig bingo_config(bingo_core);
     _bufferIndex.readConfigParameters(bingo_config);
+    /*
+     * Set up bingo configuration
+     */
     bingo_config.setUpBingoConfiguration();
     bingo_core.bingoTautomerRulesReady(0, 0, 0);
     bingo_core.bingoIndexBegin();
 
+    /*
+     * Prepare for an update
+     */
     _bufferIndex.updateBegin();
+    /*
+     * Load cmf dictionary
+     */
     fp_engine->loadDictionary(_bufferIndex);
 }
 
 void BingoPgBuild::insertStructure(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
     if (fp_engine->getNthreads() == 1)
+    {
         insertStructureSingle(item_ptr, text_ptr);
+    }
     else
+    {
         insertStructureParallel(item_ptr, text_ptr);
+    }
 }
 
 bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
+    /*
+     * Insert a new structure
+     */
     int block_number = ItemPointerGetBlockNumber((ItemPointer)item_ptr);
     int offset_number = ItemPointerGetOffsetNumber((ItemPointer)item_ptr);
+    // profTimerStart(t0, "bingo_pg.insert");
 
     BingoPgBuildEngine::StructCache struct_cache;
     struct_cache.text = std::make_unique<BingoPgText>(text_ptr);
@@ -144,7 +187,9 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     elog(DEBUG1, "bingo: insert structure: processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
 
     if (!fp_engine->processStructure(struct_cache))
+    {
         return false;
+    }
 
     if (struct_cache.data.get() == 0)
         return false;
@@ -161,27 +206,39 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     }
 
     BingoPgFpData& data_ref = *struct_cache.data;
+
     _bufferIndex.insertStructure(data_ref);
     fp_engine->insertShadowInfo(data_ref);
 
     elog(DEBUG1, "bingo: insert structure: finish processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
+
     return true;
 }
 
 void BingoPgBuild::insertStructureParallel(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
+    /*
+     * Insert a new structure
+     */
     BingoPgBuildEngine::StructCache& struct_cache = _parrallelCache.push();
     struct_cache.text = std::make_unique<BingoPgText>(text_ptr);
     struct_cache.ptr = *((ItemPointer)item_ptr);
+    /*
+     * Flush cache
+     */
     if (_parrallelCache.size() > MAX_CACHE_SIZE)
         flush();
 }
 
 void BingoPgBuild::flush()
 {
+    // profTimerStart(t0, "bingo_pg.flush");
+
     if (_parrallelCache.size() == 0)
         return;
-
+    /*
+     * Process cache structures
+     */
     fp_engine->processStructures(_parrallelCache);
 
     if (!_buildingState)
@@ -192,9 +249,12 @@ void BingoPgBuild::flush()
 
     for (int c_idx = 0; c_idx < _parrallelCache.size(); ++c_idx)
     {
+        // profTimerStart(t1, "bingo_pg.insert_idx");
         BingoPgBuildEngine::StructCache& struct_cache = _parrallelCache[c_idx];
         if (struct_cache.data.get() == 0)
+        {
             continue;
+        }
 
         BingoPgFpData& data_ref = *struct_cache.data;
         _bufferIndex.insertStructure(data_ref);

--- a/bingo/postgres/src/pg_core/bingo_pg_build.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build.cpp
@@ -76,8 +76,9 @@ void BingoPgBuild::finish()
     const BlockNumber physical_pages = RelationGetNumberOfBlocks(index);
     const BlockNumber expected_pages = (BlockNumber)(final_section_offset + final_section_pages);
     if (physical_pages != expected_pages)
-        throw Error("internal error: bingo index physical size %u does not match final logical end %u", (unsigned int)physical_pages,
-                    (unsigned int)expected_pages);
+        throw Error("internal error: bingo index physical size %u does not match "
+                    "final logical end %u",
+                    (unsigned int)physical_pages, (unsigned int)expected_pages);
 
     _validateBuiltSection(final_section_offset, final_section_pages);
 
@@ -224,7 +225,10 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     struct_cache.text = std::make_unique<BingoPgText>(text_ptr);
     struct_cache.ptr = *((ItemPointer)item_ptr);
 
-    elog(DEBUG1, "bingo: insert structure: processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
+    elog(DEBUG1,
+         "bingo: insert structure: processing the table entry with "
+         "ctid='(%d,%d)'::tid",
+         block_number, offset_number);
 
     if (!fp_engine->processStructure(struct_cache))
     {
@@ -232,7 +236,9 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     }
 
     if (struct_cache.data.get() == 0)
-        throw Error("internal error: bingo build reported success without prepared data for ctid='(%d,%d)'::tid", block_number, offset_number);
+        throw Error("internal error: bingo build reported success without prepared "
+                    "data for ctid='(%d,%d)'::tid",
+                    block_number, offset_number);
 
     /*
      * The encoded CMF can depend on dictionary state changed while processing
@@ -250,7 +256,10 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     _bufferIndex.insertStructure(data_ref);
     fp_engine->insertShadowInfo(data_ref);
 
-    elog(DEBUG1, "bingo: insert structure: finish processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
+    elog(DEBUG1,
+         "bingo: insert structure: finish processing the table entry with "
+         "ctid='(%d,%d)'::tid",
+         block_number, offset_number);
 
     return true;
 }
@@ -299,10 +308,14 @@ void BingoPgBuild::flush()
         {
             if (struct_cache.rejected)
                 continue;
-            throw Error("internal error: parallel bingo build did not resolve ctid='(%d,%d)'::tid as prepared or rejected", block_number, offset_number);
+            throw Error("internal error: parallel bingo build did not resolve "
+                        "ctid='(%d,%d)'::tid as prepared or rejected",
+                        block_number, offset_number);
         }
         if (struct_cache.rejected)
-            throw Error("internal error: parallel bingo build resolved ctid='(%d,%d)'::tid as both prepared and rejected", block_number, offset_number);
+            throw Error("internal error: parallel bingo build resolved "
+                        "ctid='(%d,%d)'::tid as both prepared and rejected",
+                        block_number, offset_number);
 
         BingoPgFpData& data_ref = *struct_cache.data;
         _bufferIndex.insertStructure(data_ref);

--- a/bingo/postgres/src/pg_core/bingo_pg_build.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build.cpp
@@ -32,9 +32,6 @@ IMPL_ERROR(BingoPgBuild, "build engine");
 BingoPgBuild::BingoPgBuild(PG_OBJECT index_ptr, const char* schema_name, const char* index_schema, bool new_index)
     : _index(index_ptr), _bufferIndex(index_ptr), _buildingState(new_index)
 {
-    /*
-     * Prepare buffer section for building or updating
-     */
     BingoPgCommon::appendPath(index_schema);
 
     if (_buildingState)
@@ -52,22 +49,19 @@ BingoPgBuild::BingoPgBuild(PG_OBJECT index_ptr, const char* schema_name, const c
 BingoPgBuild::~BingoPgBuild()
 {
     /*
-     * Finish building stage
+     * Bulk builds publish their shadow indexes, dictionary, and metapage when
+     * the build is complete. Incremental writes persist dictionary/meta state
+     * explicitly before/while publishing each structure and must not depend on
+     * destructor ordering for crash safety.
      */
     if (_buildingState)
     {
         fp_engine->finishShadowProcessing();
+        _bufferIndex.writeDictionary(*fp_engine);
+        _bufferIndex.writeMetaInfo();
     }
-    /*
-     * Write meta info in desctructor
-     */
-    _bufferIndex.writeDictionary(*fp_engine);
-    _bufferIndex.writeMetaInfo();
 }
-/*
- * Inserts a new structure into the index
- * Returns true if insertion was successfull
- */
+
 void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_schema)
 {
     Relation index = (Relation)_index;
@@ -79,15 +73,9 @@ void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_s
 
     elog(DEBUG1, "bingo: index build: start create index '%s'", rel_name);
 
-    /*
-     * Safety check
-     */
     if (RelationGetNumberOfBlocks(index) != 0)
         throw Error("cannot initialize non-empty bingo index \"%s\"", RelationGetRelationName(index));
 
-    /*
-     * Define index type
-     */
     if (strcasecmp(func_name, "matchsub") == 0)
     {
         fp_engine = std::make_unique<MangoPgBuildEngine>(rel_name);
@@ -101,21 +89,11 @@ void BingoPgBuild::_prepareBuilding(const char* schema_name, const char* index_s
         throw Error("internal error: unknown index build function %s", func_name);
     }
     BingoPgConfig bingo_config(fp_engine->bingoCore);
-    /*
-     * Set up configuration from postgres table
-     */
     bingo_config.readDefaultConfig(schema_name);
-    /*
-     * Update configuration from pg_class.reloptions
-     */
     bingo_config.updateByIndexConfig(index);
     fp_engine->setUpConfiguration(bingo_config);
 
-    /*
-     * If new build then create a metapage and initial section
-     */
     _bufferIndex.writeBegin(*fp_engine, bingo_config);
-
     fp_engine->prepareShadowInfo(schema_name, index_schema);
 }
 
@@ -129,9 +107,6 @@ void BingoPgBuild::_prepareUpdating()
 
     _bufferIndex.readMetaInfo();
 
-    /*
-     * Define index type
-     */
     if (_bufferIndex.getIndexType() == BINGO_INDEX_TYPE_MOLECULE)
         fp_engine = std::make_unique<MangoPgBuildEngine>(rel_name);
     else if (_bufferIndex.getIndexType() == BINGO_INDEX_TYPE_REACTION)
@@ -141,43 +116,26 @@ void BingoPgBuild::_prepareUpdating()
     auto& bingo_core = fp_engine->bingoCore;
     BingoPgConfig bingo_config(bingo_core);
     _bufferIndex.readConfigParameters(bingo_config);
-    /*
-     * Set up bingo configuration
-     */
     bingo_config.setUpBingoConfiguration();
     bingo_core.bingoTautomerRulesReady(0, 0, 0);
     bingo_core.bingoIndexBegin();
 
-    /*
-     * Prepare for an update
-     */
     _bufferIndex.updateBegin();
-    /*
-     * Load cmf dictionary
-     */
     fp_engine->loadDictionary(_bufferIndex);
 }
 
 void BingoPgBuild::insertStructure(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
     if (fp_engine->getNthreads() == 1)
-    {
         insertStructureSingle(item_ptr, text_ptr);
-    }
     else
-    {
         insertStructureParallel(item_ptr, text_ptr);
-    }
 }
 
 bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
-    /*
-     * Insert a new structure
-     */
     int block_number = ItemPointerGetBlockNumber((ItemPointer)item_ptr);
     int offset_number = ItemPointerGetOffsetNumber((ItemPointer)item_ptr);
-    // profTimerStart(t0, "bingo_pg.insert");
 
     BingoPgBuildEngine::StructCache struct_cache;
     struct_cache.text = std::make_unique<BingoPgText>(text_ptr);
@@ -186,57 +144,57 @@ bool BingoPgBuild::insertStructureSingle(PG_OBJECT item_ptr, uintptr_t text_ptr)
     elog(DEBUG1, "bingo: insert structure: processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
 
     if (!fp_engine->processStructure(struct_cache))
-    {
         return false;
-    }
 
     if (struct_cache.data.get() == 0)
         return false;
 
-    BingoPgFpData& data_ref = *struct_cache.data;
+    /*
+     * The encoded CMF can depend on dictionary state changed while processing
+     * this molecule. For a live index, WAL-persist that dictionary and its
+     * metapage count before any section existence bit can publish the molecule.
+     */
+    if (!_buildingState)
+    {
+        _bufferIndex.writeDictionary(*fp_engine);
+        _bufferIndex.writeMetaInfo();
+    }
 
+    BingoPgFpData& data_ref = *struct_cache.data;
     _bufferIndex.insertStructure(data_ref);
     fp_engine->insertShadowInfo(data_ref);
 
     elog(DEBUG1, "bingo: insert structure: finish processing the table entry with ctid='(%d,%d)'::tid", block_number, offset_number);
-
     return true;
 }
 
 void BingoPgBuild::insertStructureParallel(PG_OBJECT item_ptr, uintptr_t text_ptr)
 {
-    /*
-     * Insert a new structure
-     */
     BingoPgBuildEngine::StructCache& struct_cache = _parrallelCache.push();
     struct_cache.text = std::make_unique<BingoPgText>(text_ptr);
     struct_cache.ptr = *((ItemPointer)item_ptr);
-    /*
-     * Flush cache
-     */
     if (_parrallelCache.size() > MAX_CACHE_SIZE)
         flush();
 }
 
 void BingoPgBuild::flush()
 {
-    // profTimerStart(t0, "bingo_pg.flush");
-
     if (_parrallelCache.size() == 0)
         return;
-    /*
-     * Process cache structures
-     */
+
     fp_engine->processStructures(_parrallelCache);
+
+    if (!_buildingState)
+    {
+        _bufferIndex.writeDictionary(*fp_engine);
+        _bufferIndex.writeMetaInfo();
+    }
 
     for (int c_idx = 0; c_idx < _parrallelCache.size(); ++c_idx)
     {
-        // profTimerStart(t1, "bingo_pg.insert_idx");
         BingoPgBuildEngine::StructCache& struct_cache = _parrallelCache[c_idx];
         if (struct_cache.data.get() == 0)
-        {
             continue;
-        }
 
         BingoPgFpData& data_ref = *struct_cache.data;
         _bufferIndex.insertStructure(data_ref);

--- a/bingo/postgres/src/pg_core/bingo_pg_build.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_build.h
@@ -29,6 +29,12 @@ public:
     ~BingoPgBuild();
 
     /*
+     * Complete a bulk build after the heap scan succeeds. Build publication is
+     * explicit so error unwinding never performs successful-build finalization.
+     */
+    void finish();
+
+    /*
      * Inserts a new structure into the index
      * Returns true if insertion was successfull
      */
@@ -46,6 +52,7 @@ private:
 
     void _prepareBuilding(const char* schema_name, const char* index_schema);
     void _prepareUpdating();
+    void _validateBuiltSection(int section_offset, int section_pages);
 
     /*
      * Index relation

--- a/bingo/postgres/src/pg_core/bingo_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build_engine.cpp
@@ -20,6 +20,8 @@ extern "C"
 
 using namespace indigo;
 
+IMPL_ERROR(BingoPgBuildEngine, "build engine");
+
 BingoPgBuildEngine::BingoPgBuildEngine() : _bufferIndexPtr(0)
 {
     _bingoContext = std::make_unique<BingoContext>(0);
@@ -107,7 +109,15 @@ void BingoPgBuildEngine::_processErrorCb(int id, void* context)
 {
     BingoPgBuildEngine* engine = (BingoPgBuildEngine*)context;
     PtrArray<StructCache>& struct_caches = *(engine->_structCaches);
-    ItemPointer item_ptr = &(struct_caches[id].ptr);
+    if (id < 0 || id >= struct_caches.size())
+        throw Error("internal error: parallel bingo build returned invalid rejected record id %d", id);
+
+    StructCache& struct_cache = struct_caches[id];
+    if (struct_cache.data.get() != 0)
+        throw Error("internal error: parallel bingo build returned record %d as both prepared and rejected", id);
+    struct_cache.rejected = true;
+
+    ItemPointer item_ptr = &(struct_cache.ptr);
     int block_number = ItemPointerGetBlockNumber(item_ptr);
     int offset_number = ItemPointerGetOffsetNumber(item_ptr);
     elog(WARNING, "build engine: error while processing record with ctid='(%d,%d)'::tid: %s", block_number, offset_number, engine->bingoCore.warning.ptr());

--- a/bingo/postgres/src/pg_core/bingo_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_build_engine.cpp
@@ -110,15 +110,22 @@ void BingoPgBuildEngine::_processErrorCb(int id, void* context)
     BingoPgBuildEngine* engine = (BingoPgBuildEngine*)context;
     PtrArray<StructCache>& struct_caches = *(engine->_structCaches);
     if (id < 0 || id >= struct_caches.size())
-        throw Error("internal error: parallel bingo build returned invalid rejected record id %d", id);
+        throw Error("internal error: parallel bingo build returned invalid "
+                    "rejected record id %d",
+                    id);
 
     StructCache& struct_cache = struct_caches[id];
     if (struct_cache.data.get() != 0)
-        throw Error("internal error: parallel bingo build returned record %d as both prepared and rejected", id);
+        throw Error("internal error: parallel bingo build returned record %d as "
+                    "both prepared and rejected",
+                    id);
     struct_cache.rejected = true;
 
     ItemPointer item_ptr = &(struct_cache.ptr);
     int block_number = ItemPointerGetBlockNumber(item_ptr);
     int offset_number = ItemPointerGetOffsetNumber(item_ptr);
-    elog(WARNING, "build engine: error while processing record with ctid='(%d,%d)'::tid: %s", block_number, offset_number, engine->bingoCore.warning.ptr());
+    elog(WARNING,
+         "build engine: error while processing record with ctid='(%d,%d)'::tid: "
+         "%s",
+         block_number, offset_number, engine->bingoCore.warning.ptr());
 }

--- a/bingo/postgres/src/pg_core/bingo_pg_build_engine.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_build_engine.h
@@ -33,7 +33,7 @@ public:
     class StructCache
     {
     public:
-        StructCache()
+        StructCache() : rejected(false)
         {
         }
         ~StructCache()
@@ -42,6 +42,7 @@ public:
         ItemPointerData ptr;
         std::unique_ptr<BingoPgText> text;
         std::unique_ptr<BingoPgFpData> data;
+        bool rejected;
 
     private:
         StructCache(const StructCache&); // no implicit copy
@@ -83,6 +84,8 @@ public:
 
     int getNthreads();
     indigo::bingo_core::BingoCore bingoCore;
+
+    DECL_ERROR;
 
 private:
     BingoPgBuildEngine(const BingoPgBuildEngine&); // no implicit copy

--- a/bingo/postgres/src/pg_core/bingo_pg_config.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_config.cpp
@@ -152,7 +152,7 @@ void BingoPgConfig::updateByIndexConfig(PG_OBJECT index_ptr)
         name_key = _rawConfig.findOrInsert("sub_screening_max_bits");
         _toString(options.sub_screening_max_bits, _rawConfig.value(name_key));
     }
-    if (options.nthreads >= 0)
+    if (options.nthreads >= -1)
     {
         name_key = _rawConfig.findOrInsert("nthreads");
         _toString(options.nthreads, _rawConfig.value(name_key));

--- a/bingo/postgres/src/pg_core/bingo_pg_index.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.cpp
@@ -26,6 +26,9 @@ IMPL_ERROR(BingoPgIndex, "bingo index");
 
 BingoPgIndex::BingoPgIndex(PG_OBJECT index) : _index(index), _strategy(READING_STRATEGY)
 {
+    /*
+     * Clean meta info
+     */
     _metaInfo.bingo_index_version = 0;
     _metaInfo.n_blocks_for_fp = 0;
     _metaInfo.n_blocks_for_map = 0;
@@ -38,16 +41,30 @@ BingoPgIndex::BingoPgIndex(PG_OBJECT index) : _index(index), _strategy(READING_S
     _currentSectionIdx = -1;
 }
 
+/*
+ * Begins to write a sections
+ */
 void BingoPgIndex::writeBegin(BingoPgBuildEngine& fp_engine, BingoPgConfig& bingo_config)
 {
+    /*
+     * Set up write strategy before creating pages so build-mode WAL policy is active.
+     */
     setStrategy(BUILDING_STRATEGY);
 
+    /*
+     * Prepare meta info for writing
+     */
     _metaInfo.n_blocks_for_map = BINGO_MOLS_PER_FINGERBLOCK / BINGO_MOLS_PER_MAPBLOCK + 1;
     _metaInfo.n_blocks_for_fp = fp_engine.getFpSize();
     _metaInfo.index_type = fp_engine.getType();
     _metaInfo.n_pages = 0;
-
+    /*
+     * Prepare meta pages
+     */
     _initializeMetaPages(bingo_config);
+    /*
+     * Prepare the first section
+     */
     _metaInfo.n_sections = 0;
     _initializeNewSection();
 }
@@ -55,16 +72,32 @@ void BingoPgIndex::writeBegin(BingoPgBuildEngine& fp_engine, BingoPgConfig& bing
 void BingoPgIndex::updateBegin()
 {
     setStrategy(UPDATING_STRATEGY);
+    /*
+     * Read meta information
+     */
     readMetaInfo();
+    /*
+     * Jump to the last section
+     */
     _currentSectionIdx = -1;
     _jumpToSection(_metaInfo.n_sections - 1);
 }
 
+/*
+ * Begins to read sections
+ */
 int BingoPgIndex::readBegin()
 {
     setStrategy(READING_STRATEGY);
+    /*
+     * Read meta information
+     */
     readMetaInfo();
+    /*
+     * Jump to the first section
+     */
     _jumpToSection(0);
+
     return _currentSectionIdx;
 }
 
@@ -73,23 +106,49 @@ int BingoPgIndex::readNext(int section_idx)
     return section_idx + 1;
 }
 
+/*
+ * Reads meta information
+ */
 void BingoPgIndex::readMetaInfo()
 {
+    /*
+     * Read meta buffer
+     */
     _metaBuffer.readBuffer(_index, BINGO_METAPAGE, BINGO_PG_READ);
+    /*
+     * Copy meta info
+     */
     BingoMetaPage meta_page = BingoPageGetMeta((Page)_metaBuffer.getPage());
     _metaInfo = *meta_page;
+    /*
+     * Return buffer pin
+     */
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
+
+    /*
+     * Prepare section buffers
+     */
     _sectionOffsetBuffers.expand(BINGO_SECTION_OFFSET_BLOCKS_NUM);
 }
 
 void BingoPgIndex::readConfigParameters(BingoPgConfig& bingo_config)
 {
+    /*
+     * Read configuration page
+     */
     BingoPgBuffer config_buffer(_index, BINGO_CONFIG_PAGE, BINGO_PG_READ);
+
+    /*
+     * Deserialize binary stored parameters
+     */
     int data_len;
     void* data = config_buffer.getIndexData(data_len);
     bingo_config.deserialize(data, data_len);
 }
 
+/*
+ * Writes meta information
+ */
 void BingoPgIndex::writeMetaInfo()
 {
     _metaBuffer.changeAccess(BINGO_PG_WRITE);
@@ -100,12 +159,17 @@ void BingoPgIndex::writeMetaInfo()
 
 void BingoPgIndex::_initializeMetaPages(BingoPgConfig& bingo_config)
 {
+    /*
+     * Initialize meta buffer
+     */
     _metaBuffer.setWalEnabled(false);
     _metaBuffer.writeNewBuffer(_index, BINGO_METAPAGE);
     _metaBuffer.formIndexTuple(&_metaInfo, sizeof(_metaInfo));
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
     ++_metaInfo.n_pages;
-
+    /*
+     * Initialize config buffer
+     */
     indigo::Array<char> config_data;
     bingo_config.serialize(config_data);
     BingoPgBuffer config_buffer;
@@ -114,7 +178,10 @@ void BingoPgIndex::_initializeMetaPages(BingoPgConfig& bingo_config)
     config_buffer.formIndexTuple(config_data.ptr(), config_data.sizeInBytes());
     config_buffer.clear();
     ++_metaInfo.n_pages;
-
+    /*
+     * Write section mapping buffers
+     * Fulfil by max size
+     */
     for (int block_idx = 0; block_idx < BINGO_SECTION_OFFSET_BLOCKS_NUM; ++block_idx)
     {
         BingoPgBuffer buffer;
@@ -126,6 +193,10 @@ void BingoPgIndex::_initializeMetaPages(BingoPgConfig& bingo_config)
     }
     _sectionOffsetBuffers.expand(BINGO_SECTION_OFFSET_BLOCKS_NUM);
 
+    /*
+     * Write dictionary buffers
+     * Fulfil by max size
+     */
     _metaInfo.offset_dictionary = _metaInfo.n_pages;
     for (int block_idx = 0; block_idx < BINGO_DICTIONARY_BLOCKS_NUM; ++block_idx)
     {
@@ -147,6 +218,7 @@ void BingoPgIndex::writeDictionary(BingoPgBuildEngine& fp_engine)
     const char* dict_buf = fp_engine.getDictionary(dict_size);
 
     _metaInfo.n_blocks_for_dictionary = 0;
+
     elog(DEBUG1, "bingo: index: update dictionary with size = %d", dict_size);
 
     if (dict_size == 0)
@@ -155,13 +227,24 @@ void BingoPgIndex::writeDictionary(BingoPgBuildEngine& fp_engine)
     if (dict_size > BingoPgBufferCacheBin::MAX_SIZE * BINGO_DICTIONARY_BLOCKS_NUM)
         throw Error("can not insert a dictionary with size = %d", dict_size);
 
+    /*
+     * Fulfil dictionary buffers
+     */
     indigo::Array<char> buffer_dict;
     int dict_offset = 0;
-    int dict_buf_size = std::min(static_cast<int>(BingoPgBufferCacheBin::MAX_SIZE), dict_size - dict_offset);
+    int dict_buf_size;
+
+    /*
+     * Set offset
+     */
+    dict_buf_size = std::min(static_cast<int>(BingoPgBufferCacheBin::MAX_SIZE), dict_size - dict_offset);
     const bool wal_enabled = (_strategy != BUILDING_STRATEGY);
 
     while (dict_buf_size > 0)
     {
+        /*
+         * Write buffers immediately
+         */
         int blck_off = _metaInfo.offset_dictionary + _metaInfo.n_blocks_for_dictionary;
         BingoPgBufferCacheBin buffer_cache(blck_off, _index, false, wal_enabled);
         buffer_dict.copy(dict_buf + dict_offset, dict_buf_size);
@@ -183,24 +266,28 @@ void BingoPgIndex::clearAllBuffers()
     _currentSectionIdx = -1;
 }
 
+/*
+ * Initializes and fulfils a new section
+ */
 void BingoPgIndex::_initializeNewSection()
 {
-    if (_currentSection.get() != nullptr)
+    if (_currentSection.get() != 0)
     {
         _metaInfo.n_pages += _currentSection->getPagesCount();
         _currentSection.reset(nullptr);
     }
-
-    const int section_offset = _metaInfo.n_pages;
-    const int section_idx = _metaInfo.n_sections;
+    int section_offset = _metaInfo.n_pages;
+    int section_idx = _metaInfo.n_sections;
     _currentSectionIdx = section_idx;
 
     /*
-     * Create every fixed page first. For an incremental rollover those page
-     * creations are individually WAL-logged. Only after the section is fully
-     * initialized do we publish its offset and increment n_sections.
+     * Prepare a new section. Create every fixed page before publishing the
+     * section offset so an interrupted incremental extension remains orphaned.
      */
     _currentSection = std::make_unique<BingoPgSection>(*this, _strategy, section_offset, true);
+    /*
+     * Set up section offset mapping
+     */
     _setSectionOffset(section_idx, section_offset);
     ++_metaInfo.n_sections;
 
@@ -213,6 +300,9 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
     int data_len;
     int section_off_idx = section_idx % BINGO_SECTION_OFFSET_PER_BLOCK;
     BingoPgBuffer& off_buffer = _getOffsetBuffer(section_idx);
+    /*
+     * Update section offset mapping buffer
+     */
     off_buffer.changeAccess(BINGO_PG_WRITE);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
     section_offsets[section_off_idx] = section_offset;
@@ -222,11 +312,13 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
 BingoPgBuffer& BingoPgIndex::_getOffsetBuffer(int section_idx)
 {
     int section_buf_idx = section_idx / BINGO_SECTION_OFFSET_PER_BLOCK;
+    /*
+     * There is the maximum limit of sections
+     */
     if (section_buf_idx >= BINGO_SECTION_OFFSET_BLOCKS_NUM)
         throw Error("internal error: can not add new section, max limit reached: %d", section_idx * BINGO_MOLS_PER_SECTION);
-
-    BingoPgBuffer* buffer = nullptr;
-    if (_sectionOffsetBuffers.getPtr(section_buf_idx) == nullptr)
+    BingoPgBuffer* buffer = 0;
+    if (_sectionOffsetBuffers.getPtr(section_buf_idx) == 0)
     {
         _sectionOffsetBuffers.set(section_buf_idx, new BingoPgBuffer());
         buffer = _sectionOffsetBuffers.getPtr(section_buf_idx);
@@ -234,38 +326,65 @@ BingoPgBuffer& BingoPgIndex::_getOffsetBuffer(int section_idx)
         buffer->readBuffer(_index, section_buf_idx + BINGO_METABLOCKS_NUM, BINGO_PG_NOLOCK);
     }
     buffer = _sectionOffsetBuffers.getPtr(section_buf_idx);
+
     return *buffer;
 }
 
 BingoPgSection& BingoPgIndex::_jumpToSection(int section_idx)
 {
+
+    /*
+     * Return if current section is already set
+     */
     if (_currentSectionIdx == section_idx)
         return *_currentSection;
-
     if (section_idx >= getSectionNumber())
     {
         if (_strategy == READING_STRATEGY)
+        {
             throw Error("could not get the buffer: section %d is out of bounds %d", section_idx, getSectionNumber());
-
-        while (section_idx >= getSectionNumber())
-            _initializeNewSection();
-        return *_currentSection;
+        }
+        else
+        {
+            /*
+             * If strategy is writing or updating then append new sections
+             */
+            while (section_idx >= getSectionNumber())
+            {
+                _initializeNewSection();
+            }
+            return *_currentSection;
+        }
     }
-
+    // profTimerStart(t0, "bingo_pg.read_section");
+    /*
+     * Read the section using offset mapping
+     */
     _currentSectionIdx = section_idx;
+
+    // profTimerStart(t1, "bingo_pg.get_offset");
     int offset = _getSectionOffset(section_idx);
+    // profTimerStop(t1);
     _currentSection = std::make_unique<BingoPgSection>(*this, _strategy, offset);
+
     return *_currentSection;
 }
 
 int BingoPgIndex::_getSectionOffset(int section_idx)
 {
+    /*
+     * Prepare section offset mapping
+     */
     int section_off_idx = section_idx % BINGO_SECTION_OFFSET_PER_BLOCK;
     int data_len;
+    int result;
     BingoPgBuffer& off_buffer = _getOffsetBuffer(section_idx);
+    /*
+     * Read mapping
+     */
     off_buffer.changeAccess(BINGO_PG_READ);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
-    int result = section_offsets[section_off_idx];
+    result = section_offsets[section_off_idx];
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
     return result;
 }
@@ -278,9 +397,15 @@ void BingoPgIndex::readDictionary(indigo::Array<char>& dictionary)
 
     indigo::Array<char> buffer_dict;
     int block_size = _metaInfo.n_blocks_for_dictionary + _metaInfo.offset_dictionary;
+    /*
+     * Read all buffers for dictionary
+     */
     for (int block_idx = _metaInfo.offset_dictionary; block_idx < block_size; ++block_idx)
     {
         BingoPgBufferCacheBin buffer_cache(block_idx, _index, false);
+        /*
+         * Read and concat buffers
+         */
         buffer_cache.readBin(0, buffer_dict);
         dictionary.concat(buffer_dict);
     }
@@ -288,18 +413,47 @@ void BingoPgIndex::readDictionary(indigo::Array<char>& dictionary)
 
 void BingoPgIndex::insertStructure(BingoPgFpData& data_item)
 {
+
+    /*
+     * Assuming that insert only for a write strategy
+     */
     if (_strategy == READING_STRATEGY)
         throw Error("can not insert a structure while reading");
-
+    /*
+     * Jump to the last section
+     */
     _jumpToSection(getSectionNumber() - 1);
-    if (!_currentSection->isExtended())
-        _initializeNewSection();
 
+    /*
+     * If a structure can not be added to the current section then initialize the new
+     */
+    if (!_currentSection->isExtended())
+    {
+        _initializeNewSection();
+    }
     elog(DEBUG1, "bingo: index: start adding a structure to the section %d", _currentSectionIdx);
+    // #ifdef BINGO_PG_INTEGRITY_DIR
+    //    Relation index = (Relation) _index;
+    //
+    //    BingoPgWrapper rel_wr;
+    //    const char* rel_name = rel_wr.getRelName(index->rd_id);
+    //
+    //    indigo::FileOutput fout(false, "%s/insert/%s_%d_%d_%d", BINGO_PG_INTEGRITY_DIR, rel_name, _currentSectionIdx, );
+    // #endif
+    /*
+     * Add a structure
+     */
     _currentSection->addStructure(data_item);
+
     elog(DEBUG1, "bingo: index: finish adding a structure to the section %d", _currentSectionIdx);
 
+    /*
+     * Return cmf map to the output
+     */
     data_item.setSectionIdx(_currentSectionIdx);
+    /*
+     * Increment structures common number
+     */
     ++_metaInfo.n_molecules;
 
     /*
@@ -312,7 +466,9 @@ void BingoPgIndex::insertStructure(BingoPgFpData& data_item)
         writeMetaInfo();
 
     if (_metaInfo.n_molecules % 1000 == 0)
+    {
         elog(NOTICE, "bingo.index: %d structures processed", _metaInfo.n_molecules);
+    }
 }
 
 void BingoPgIndex::readTidItem(ItemPointerData& cmf_item, PG_OBJECT result_ptr)
@@ -322,18 +478,36 @@ void BingoPgIndex::readTidItem(ItemPointerData& cmf_item, PG_OBJECT result_ptr)
 
 void BingoPgIndex::readTidItem(int section_idx, int mol_idx, PG_OBJECT result_ptr)
 {
+    // profTimerStart(t0, "bingo_pg.read_tid");
+    /*
+     * Prepare info for reading
+     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
+
+    /*
+     * Prepare result item
+     */
     ItemPointerData& result_item = (ItemPointerData&)(*(ItemPointer)result_ptr);
     BingoPgBufferCacheMap& map_cache = current_section.getMapBufferCache(map_block_idx);
+    /*
+     * Read tid map
+     */
     map_cache.getTidItem(map_mol_idx, result_item);
 }
 
 void BingoPgIndex::andWithBitset(int section_idx, int fp_idx, BingoPgExternalBitset& ext_bitset)
 {
+    // profTimerStart(t0, "bingo_pg.read_fp_and_with");
+    /*
+     * Prepare info for reading
+     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     BingoPgBufferCacheFp& fp_buffer = current_section.getFpBufferCache(fp_idx);
+    /*
+     * And with a bitset
+     */
     fp_buffer.andWithBitset(ext_bitset);
 }
 
@@ -383,6 +557,10 @@ bool BingoPgIndex::isStructureRemoved(ItemPointerData& cmf_item)
 
 void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>& cmf_buf)
 {
+    // profTimerStart(t0, "bingo_pg.read_cmf");
+    /*
+     * Prepare info for reading
+     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
@@ -390,8 +568,14 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
 
     elog(DEBUG1, "bingo: index: read cmf: start read structure %d for section = %d", mol_idx, section_idx);
 
+    /*
+     * Get cmf item
+     */
     ItemPointerData cmf_item;
     map_cache.getCmfItem(map_mol_idx, cmf_item);
+    /*
+     * Check for correct block num
+     */
     dword block_num = ItemPointerGetBlockNumber(&cmf_item);
     if (block_num == InvalidBlockNumber)
     {
@@ -400,6 +584,9 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&cmf_item);
+    /*
+     * Read cmf buffer for a given offset
+     */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, cmf_buf);
     elog(DEBUG1, "bingo: index: read cmf: successfully read cmf of size %d for block %d offset %d", cmf_buf.size(), block_num, block_offset);
@@ -407,6 +594,9 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
 
 void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>& xyz_buf)
 {
+    /*
+     * Prepare info for reading
+     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
@@ -414,8 +604,14 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
 
     elog(DEBUG1, "bingo: index: read xyz: start read structure %d for section = %d", mol_idx, section_idx);
 
+    /*
+     * Get xyz item
+     */
     ItemPointerData xyz_item;
     map_cache.getXyzItem(map_mol_idx, xyz_item);
+    /*
+     * Check for correct block num
+     */
     dword block_num = ItemPointerGetBlockNumber(&xyz_item);
     if (block_num == InvalidBlockNumber)
     {
@@ -424,6 +620,9 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&xyz_item);
+    /*
+     * Read xyz buffer for a given offset
+     */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, xyz_buf);
     elog(DEBUG1, "bingo: index: read xyz: successfully read xyz of size %d for block %d offset %d", xyz_buf.size(), block_num, block_offset);

--- a/bingo/postgres/src/pg_core/bingo_pg_index.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.cpp
@@ -47,7 +47,8 @@ BingoPgIndex::BingoPgIndex(PG_OBJECT index) : _index(index), _strategy(READING_S
 void BingoPgIndex::writeBegin(BingoPgBuildEngine& fp_engine, BingoPgConfig& bingo_config)
 {
     /*
-     * Set up write strategy before creating pages so build-mode WAL policy is active.
+     * Set up write strategy before creating pages so build-mode WAL policy is
+     * active.
      */
     setStrategy(BUILDING_STRATEGY);
 
@@ -150,7 +151,9 @@ void BingoPgIndex::readMetaInfo()
     if (_metaInfo.offset_dictionary != dictionary_offset)
         throw Error("internal error: invalid bingo dictionary offset %d", _metaInfo.offset_dictionary);
     if (_metaInfo.n_pages < first_section_offset || (BlockNumber)_metaInfo.n_pages >= relation_blocks)
-        throw Error("internal error: invalid bingo final section offset %d for relation size %u", _metaInfo.n_pages, (unsigned int)relation_blocks);
+        throw Error("internal error: invalid bingo final section offset %d for "
+                    "relation size %u",
+                    _metaInfo.n_pages, (unsigned int)relation_blocks);
     if (_metaInfo.index_type != BINGO_INDEX_TYPE_MOLECULE && _metaInfo.index_type != BINGO_INDEX_TYPE_REACTION)
         throw Error("internal error: invalid bingo index type %d", _metaInfo.index_type);
 
@@ -163,11 +166,15 @@ void BingoPgIndex::readMetaInfo()
     {
         int section_offset = _getSectionOffset(section_idx);
         if (previous_offset >= 0 && section_offset <= previous_offset)
-            throw Error("internal error: bingo section %d offset %d is not after previous offset %d", section_idx, section_offset, previous_offset);
+            throw Error("internal error: bingo section %d offset %d is not after "
+                        "previous offset %d",
+                        section_idx, section_offset, previous_offset);
         previous_offset = section_offset;
     }
     if (previous_offset != _metaInfo.n_pages)
-        throw Error("internal error: bingo final section offset %d does not match metadata offset %d", previous_offset, _metaInfo.n_pages);
+        throw Error("internal error: bingo final section offset %d does not match "
+                    "metadata offset %d",
+                    previous_offset, _metaInfo.n_pages);
 }
 
 void BingoPgIndex::readConfigParameters(BingoPgConfig& bingo_config)
@@ -346,7 +353,9 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
     off_buffer.changeAccess(BINGO_PG_WRITE);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
     if (section_off_idx < 0 || data_len < (section_off_idx + 1) * (int)sizeof(int))
-        throw Error("internal error: bingo section offset block is too small for section %d", section_idx);
+        throw Error("internal error: bingo section offset block is too small for "
+                    "section %d",
+                    section_idx);
     section_offsets[section_off_idx] = section_offset;
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
 }
@@ -435,7 +444,9 @@ int BingoPgIndex::_getSectionOffset(int section_idx)
     if (data_len < (section_off_idx + 1) * (int)sizeof(int))
     {
         off_buffer.changeAccess(BINGO_PG_NOLOCK);
-        throw Error("internal error: bingo section offset block is too small for section %d", section_idx);
+        throw Error("internal error: bingo section offset block is too small for "
+                    "section %d",
+                    section_idx);
     }
     result = section_offsets[section_off_idx];
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
@@ -444,7 +455,9 @@ int BingoPgIndex::_getSectionOffset(int section_idx)
     const BlockNumber relation_blocks = RelationGetNumberOfBlocks(index);
     const int first_section_offset = BINGO_METABLOCKS_NUM + BINGO_SECTION_OFFSET_BLOCKS_NUM + BINGO_DICTIONARY_BLOCKS_NUM;
     if (result < first_section_offset || (BlockNumber)result >= relation_blocks)
-        throw Error("internal error: bingo section %d has invalid offset %d for relation size %u", section_idx, result, (unsigned int)relation_blocks);
+        throw Error("internal error: bingo section %d has invalid offset %d for "
+                    "relation size %u",
+                    section_idx, result, (unsigned int)relation_blocks);
     return result;
 }
 
@@ -484,7 +497,8 @@ void BingoPgIndex::insertStructure(BingoPgFpData& data_item)
     _jumpToSection(getSectionNumber() - 1);
 
     /*
-     * If a structure can not be added to the current section then initialize the new
+     * If a structure can not be added to the current section then initialize the
+     * new
      */
     if (!_currentSection->isExtended())
     {
@@ -497,7 +511,8 @@ void BingoPgIndex::insertStructure(BingoPgFpData& data_item)
     //    BingoPgWrapper rel_wr;
     //    const char* rel_name = rel_wr.getRelName(index->rd_id);
     //
-    //    indigo::FileOutput fout(false, "%s/insert/%s_%d_%d_%d", BINGO_PG_INTEGRITY_DIR, rel_name, _currentSectionIdx, );
+    //    indigo::FileOutput fout(false, "%s/insert/%s_%d_%d_%d",
+    //    BINGO_PG_INTEGRITY_DIR, rel_name, _currentSectionIdx, );
     // #endif
     /*
      * Add a structure
@@ -639,7 +654,10 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
     if (block_num == InvalidBlockNumber)
     {
         cmf_buf.clear();
-        elog(DEBUG1, "bingo: index: read cmf: cmf is empty for structure %d for section = %d", mol_idx, section_idx);
+        elog(DEBUG1,
+             "bingo: index: read cmf: cmf is empty for structure %d for section = "
+             "%d",
+             mol_idx, section_idx);
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&cmf_item);
@@ -648,7 +666,10 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
      */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, cmf_buf);
-    elog(DEBUG1, "bingo: index: read cmf: successfully read cmf of size %d for block %d offset %d", cmf_buf.size(), block_num, block_offset);
+    elog(DEBUG1,
+         "bingo: index: read cmf: successfully read cmf of size %d for block %d "
+         "offset %d",
+         cmf_buf.size(), block_num, block_offset);
 }
 
 void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>& xyz_buf)
@@ -675,7 +696,10 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
     if (block_num == InvalidBlockNumber)
     {
         xyz_buf.clear();
-        elog(DEBUG1, "bingo: index: read xyz: xyz is empty for structure %d for section = %d", mol_idx, section_idx);
+        elog(DEBUG1,
+             "bingo: index: read xyz: xyz is empty for structure %d for section = "
+             "%d",
+             mol_idx, section_idx);
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&xyz_item);
@@ -684,5 +708,8 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
      */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, xyz_buf);
-    elog(DEBUG1, "bingo: index: read xyz: successfully read xyz of size %d for block %d offset %d", xyz_buf.size(), block_num, block_offset);
+    elog(DEBUG1,
+         "bingo: index: read xyz: successfully read xyz of size %d for block %d "
+         "offset %d",
+         xyz_buf.size(), block_num, block_offset);
 }

--- a/bingo/postgres/src/pg_core/bingo_pg_index.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.cpp
@@ -111,24 +111,63 @@ int BingoPgIndex::readNext(int section_idx)
  */
 void BingoPgIndex::readMetaInfo()
 {
+    Relation index = (Relation)_index;
+    const BlockNumber relation_blocks = RelationGetNumberOfBlocks(index);
+    if (relation_blocks <= BINGO_METAPAGE)
+        throw Error("internal error: bingo index relation has no metapage");
+
     /*
      * Read meta buffer
      */
     _metaBuffer.readBuffer(_index, BINGO_METAPAGE, BINGO_PG_READ);
+    Page meta_buffer_page = (Page)_metaBuffer.getPage();
+    if (PageIsNew(meta_buffer_page))
+        throw Error("internal error: uninitialized bingo metapage");
     /*
      * Copy meta info
      */
-    BingoMetaPage meta_page = BingoPageGetMeta((Page)_metaBuffer.getPage());
+    BingoMetaPage meta_page = BingoPageGetMeta(meta_buffer_page);
     _metaInfo = *meta_page;
     /*
      * Return buffer pin
      */
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
 
+    const int max_sections = BINGO_SECTION_OFFSET_PER_BLOCK * BINGO_SECTION_OFFSET_BLOCKS_NUM;
+    const int dictionary_offset = BINGO_METABLOCKS_NUM + BINGO_SECTION_OFFSET_BLOCKS_NUM;
+    const int first_section_offset = dictionary_offset + BINGO_DICTIONARY_BLOCKS_NUM;
+
+    if (_metaInfo.n_sections <= 0 || _metaInfo.n_sections > max_sections)
+        throw Error("internal error: invalid bingo section count %d", _metaInfo.n_sections);
+    if (_metaInfo.n_molecules < 0 || (long long)_metaInfo.n_molecules > (long long)_metaInfo.n_sections * BINGO_MOLS_PER_SECTION)
+        throw Error("internal error: invalid bingo molecule count %d for %d sections", _metaInfo.n_molecules, _metaInfo.n_sections);
+    if (_metaInfo.n_blocks_for_map <= 0 || _metaInfo.n_blocks_for_map > (int)relation_blocks)
+        throw Error("internal error: invalid bingo map block count %d", _metaInfo.n_blocks_for_map);
+    if (_metaInfo.n_blocks_for_fp < 0 || _metaInfo.n_blocks_for_fp > (int)relation_blocks)
+        throw Error("internal error: invalid bingo fingerprint block count %d", _metaInfo.n_blocks_for_fp);
+    if (_metaInfo.n_blocks_for_dictionary < 0 || _metaInfo.n_blocks_for_dictionary > BINGO_DICTIONARY_BLOCKS_NUM)
+        throw Error("internal error: invalid bingo dictionary block count %d", _metaInfo.n_blocks_for_dictionary);
+    if (_metaInfo.offset_dictionary != dictionary_offset)
+        throw Error("internal error: invalid bingo dictionary offset %d", _metaInfo.offset_dictionary);
+    if (_metaInfo.n_pages < first_section_offset || (BlockNumber)_metaInfo.n_pages >= relation_blocks)
+        throw Error("internal error: invalid bingo final section offset %d for relation size %u", _metaInfo.n_pages, (unsigned int)relation_blocks);
+    if (_metaInfo.index_type != BINGO_INDEX_TYPE_MOLECULE && _metaInfo.index_type != BINGO_INDEX_TYPE_REACTION)
+        throw Error("internal error: invalid bingo index type %d", _metaInfo.index_type);
+
     /*
-     * Prepare section buffers
+     * Prepare section buffers and validate the compact section offset map.
      */
     _sectionOffsetBuffers.expand(BINGO_SECTION_OFFSET_BLOCKS_NUM);
+    int previous_offset = -1;
+    for (int section_idx = 0; section_idx < _metaInfo.n_sections; ++section_idx)
+    {
+        int section_offset = _getSectionOffset(section_idx);
+        if (previous_offset >= 0 && section_offset <= previous_offset)
+            throw Error("internal error: bingo section %d offset %d is not after previous offset %d", section_idx, section_offset, previous_offset);
+        previous_offset = section_offset;
+    }
+    if (previous_offset != _metaInfo.n_pages)
+        throw Error("internal error: bingo final section offset %d does not match metadata offset %d", previous_offset, _metaInfo.n_pages);
 }
 
 void BingoPgIndex::readConfigParameters(BingoPgConfig& bingo_config)
@@ -273,6 +312,7 @@ void BingoPgIndex::_initializeNewSection()
 {
     if (_currentSection.get() != 0)
     {
+        _currentSection->finish();
         _metaInfo.n_pages += _currentSection->getPagesCount();
         _currentSection.reset(nullptr);
     }
@@ -305,12 +345,17 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
      */
     off_buffer.changeAccess(BINGO_PG_WRITE);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
+    if (section_off_idx < 0 || data_len < (section_off_idx + 1) * (int)sizeof(int))
+        throw Error("internal error: bingo section offset block is too small for section %d", section_idx);
     section_offsets[section_off_idx] = section_offset;
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
 }
 
 BingoPgBuffer& BingoPgIndex::_getOffsetBuffer(int section_idx)
 {
+    if (section_idx < 0)
+        throw Error("internal error: bingo section index %d is out of bounds", section_idx);
+
     int section_buf_idx = section_idx / BINGO_SECTION_OFFSET_PER_BLOCK;
     /*
      * There is the maximum limit of sections
@@ -372,6 +417,9 @@ BingoPgSection& BingoPgIndex::_jumpToSection(int section_idx)
 
 int BingoPgIndex::_getSectionOffset(int section_idx)
 {
+    if (section_idx < 0 || section_idx >= _metaInfo.n_sections)
+        throw Error("internal error: bingo section index %d is out of bounds %d", section_idx, _metaInfo.n_sections);
+
     /*
      * Prepare section offset mapping
      */
@@ -384,8 +432,19 @@ int BingoPgIndex::_getSectionOffset(int section_idx)
      */
     off_buffer.changeAccess(BINGO_PG_READ);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
+    if (data_len < (section_off_idx + 1) * (int)sizeof(int))
+    {
+        off_buffer.changeAccess(BINGO_PG_NOLOCK);
+        throw Error("internal error: bingo section offset block is too small for section %d", section_idx);
+    }
     result = section_offsets[section_off_idx];
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
+
+    Relation index = (Relation)_index;
+    const BlockNumber relation_blocks = RelationGetNumberOfBlocks(index);
+    const int first_section_offset = BINGO_METABLOCKS_NUM + BINGO_SECTION_OFFSET_BLOCKS_NUM + BINGO_DICTIONARY_BLOCKS_NUM;
+    if (result < first_section_offset || (BlockNumber)result >= relation_blocks)
+        throw Error("internal error: bingo section %d has invalid offset %d for relation size %u", section_idx, result, (unsigned int)relation_blocks);
     return result;
 }
 

--- a/bingo/postgres/src/pg_core/bingo_pg_index.cpp
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.cpp
@@ -26,9 +26,6 @@ IMPL_ERROR(BingoPgIndex, "bingo index");
 
 BingoPgIndex::BingoPgIndex(PG_OBJECT index) : _index(index), _strategy(READING_STRATEGY)
 {
-    /*
-     * Clean meta info
-     */
     _metaInfo.bingo_index_version = 0;
     _metaInfo.n_blocks_for_fp = 0;
     _metaInfo.n_blocks_for_map = 0;
@@ -41,63 +38,33 @@ BingoPgIndex::BingoPgIndex(PG_OBJECT index) : _index(index), _strategy(READING_S
     _currentSectionIdx = -1;
 }
 
-/*
- * Begins to write a sections
- */
 void BingoPgIndex::writeBegin(BingoPgBuildEngine& fp_engine, BingoPgConfig& bingo_config)
 {
-    /*
-     * Prepare meta info for writing
-     */
+    setStrategy(BUILDING_STRATEGY);
+
     _metaInfo.n_blocks_for_map = BINGO_MOLS_PER_FINGERBLOCK / BINGO_MOLS_PER_MAPBLOCK + 1;
     _metaInfo.n_blocks_for_fp = fp_engine.getFpSize();
     _metaInfo.index_type = fp_engine.getType();
     _metaInfo.n_pages = 0;
-    /*
-     * Prepare meta pages
-     */
+
     _initializeMetaPages(bingo_config);
-    /*
-     * Prepare the first section
-     */
     _metaInfo.n_sections = 0;
     _initializeNewSection();
-
-    /*
-     * Set up write strategy
-     */
-    _strategy = BUILDING_STRATEGY;
 }
 
 void BingoPgIndex::updateBegin()
 {
-    _strategy = UPDATING_STRATEGY;
-    /*
-     * Read meta information
-     */
+    setStrategy(UPDATING_STRATEGY);
     readMetaInfo();
-    /*
-     * Jump to the last section
-     */
     _currentSectionIdx = -1;
     _jumpToSection(_metaInfo.n_sections - 1);
 }
 
-/*
- * Begins to read sections
- */
 int BingoPgIndex::readBegin()
 {
-    _strategy = READING_STRATEGY;
-    /*
-     * Read meta information
-     */
+    setStrategy(READING_STRATEGY);
     readMetaInfo();
-    /*
-     * Jump to the first section
-     */
     _jumpToSection(0);
-
     return _currentSectionIdx;
 }
 
@@ -106,83 +73,52 @@ int BingoPgIndex::readNext(int section_idx)
     return section_idx + 1;
 }
 
-/*
- * Reads meta information
- */
 void BingoPgIndex::readMetaInfo()
 {
-    /*
-     * Read meta buffer
-     */
     _metaBuffer.readBuffer(_index, BINGO_METAPAGE, BINGO_PG_READ);
-    /*
-     * Copy meta info
-     */
-    BingoMetaPage meta_page = BingoPageGetMeta(BufferGetPage(_metaBuffer.getBuffer()));
+    BingoMetaPage meta_page = BingoPageGetMeta((Page)_metaBuffer.getPage());
     _metaInfo = *meta_page;
-    /*
-     * Return buffer pin
-     */
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
-
-    /*
-     * Prepare section buffers
-     */
     _sectionOffsetBuffers.expand(BINGO_SECTION_OFFSET_BLOCKS_NUM);
 }
 
 void BingoPgIndex::readConfigParameters(BingoPgConfig& bingo_config)
 {
-    /*
-     * Read configuration page
-     */
     BingoPgBuffer config_buffer(_index, BINGO_CONFIG_PAGE, BINGO_PG_READ);
-
-    /*
-     * Deserialize binary stored parameters
-     */
     int data_len;
     void* data = config_buffer.getIndexData(data_len);
     bingo_config.deserialize(data, data_len);
 }
 
-/*
- * Writes meta information
- */
 void BingoPgIndex::writeMetaInfo()
 {
     _metaBuffer.changeAccess(BINGO_PG_WRITE);
-    BingoMetaPage meta_page = BingoPageGetMeta(BufferGetPage(_metaBuffer.getBuffer()));
+    BingoMetaPage meta_page = BingoPageGetMeta((Page)_metaBuffer.getPage());
     *meta_page = _metaInfo;
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
 }
 
 void BingoPgIndex::_initializeMetaPages(BingoPgConfig& bingo_config)
 {
-    /*
-     * Initialize meta buffer
-     */
+    _metaBuffer.setWalEnabled(false);
     _metaBuffer.writeNewBuffer(_index, BINGO_METAPAGE);
     _metaBuffer.formIndexTuple(&_metaInfo, sizeof(_metaInfo));
     _metaBuffer.changeAccess(BINGO_PG_NOLOCK);
     ++_metaInfo.n_pages;
-    /*
-     * Initialize config buffer
-     */
+
     indigo::Array<char> config_data;
     bingo_config.serialize(config_data);
     BingoPgBuffer config_buffer;
+    config_buffer.setWalEnabled(false);
     config_buffer.writeNewBuffer(_index, BINGO_CONFIG_PAGE);
     config_buffer.formIndexTuple(config_data.ptr(), config_data.sizeInBytes());
     config_buffer.clear();
     ++_metaInfo.n_pages;
-    /*
-     * Write section mapping buffers
-     * Fulfil by max size
-     */
+
     for (int block_idx = 0; block_idx < BINGO_SECTION_OFFSET_BLOCKS_NUM; ++block_idx)
     {
         BingoPgBuffer buffer;
+        buffer.setWalEnabled(false);
         buffer.writeNewBuffer(_index, _metaInfo.n_pages);
         buffer.formEmptyIndexTuple(BINGO_SECTION_OFFSET_PER_BLOCK * sizeof(int));
         buffer.clear();
@@ -190,14 +126,11 @@ void BingoPgIndex::_initializeMetaPages(BingoPgConfig& bingo_config)
     }
     _sectionOffsetBuffers.expand(BINGO_SECTION_OFFSET_BLOCKS_NUM);
 
-    /*
-     * Write dictionary buffers
-     * Fulfil by max size
-     */
     _metaInfo.offset_dictionary = _metaInfo.n_pages;
     for (int block_idx = 0; block_idx < BINGO_DICTIONARY_BLOCKS_NUM; ++block_idx)
     {
         BingoPgBuffer buffer;
+        buffer.setWalEnabled(false);
         buffer.writeNewBuffer(_index, _metaInfo.n_pages);
         buffer.formEmptyIndexTuple(BingoPgBufferCacheBin::BUFFER_SIZE);
         buffer.clear();
@@ -214,7 +147,6 @@ void BingoPgIndex::writeDictionary(BingoPgBuildEngine& fp_engine)
     const char* dict_buf = fp_engine.getDictionary(dict_size);
 
     _metaInfo.n_blocks_for_dictionary = 0;
-
     elog(DEBUG1, "bingo: index: update dictionary with size = %d", dict_size);
 
     if (dict_size == 0)
@@ -223,25 +155,15 @@ void BingoPgIndex::writeDictionary(BingoPgBuildEngine& fp_engine)
     if (dict_size > BingoPgBufferCacheBin::MAX_SIZE * BINGO_DICTIONARY_BLOCKS_NUM)
         throw Error("can not insert a dictionary with size = %d", dict_size);
 
-    /*
-     * Fulfil dictionary buffers
-     */
     indigo::Array<char> buffer_dict;
     int dict_offset = 0;
-    int dict_buf_size;
-
-    /*
-     * Set offset
-     */
-    dict_buf_size = std::min(static_cast<int>(BingoPgBufferCacheBin::MAX_SIZE), dict_size - dict_offset);
+    int dict_buf_size = std::min(static_cast<int>(BingoPgBufferCacheBin::MAX_SIZE), dict_size - dict_offset);
+    const bool wal_enabled = (_strategy != BUILDING_STRATEGY);
 
     while (dict_buf_size > 0)
     {
-        /*
-         * Write buffers immediately
-         */
         int blck_off = _metaInfo.offset_dictionary + _metaInfo.n_blocks_for_dictionary;
-        BingoPgBufferCacheBin buffer_cache(blck_off, _index, false);
+        BingoPgBufferCacheBin buffer_cache(blck_off, _index, false, wal_enabled);
         buffer_dict.copy(dict_buf + dict_offset, dict_buf_size);
         buffer_cache.writeBin(buffer_dict);
 
@@ -261,27 +183,29 @@ void BingoPgIndex::clearAllBuffers()
     _currentSectionIdx = -1;
 }
 
-/*
- * Initializes and fulfils a new section
- */
 void BingoPgIndex::_initializeNewSection()
 {
-    if (_currentSection.get() != 0)
+    if (_currentSection.get() != nullptr)
     {
         _metaInfo.n_pages += _currentSection->getPagesCount();
+        _currentSection.reset(nullptr);
     }
-    int section_offset = _metaInfo.n_pages;
-    /*
-     * Set up section offset mapping
-     */
-    _currentSectionIdx = _metaInfo.n_sections;
-    _setSectionOffset(_currentSectionIdx, section_offset);
+
+    const int section_offset = _metaInfo.n_pages;
+    const int section_idx = _metaInfo.n_sections;
+    _currentSectionIdx = section_idx;
 
     /*
-     * Prepare a new section
+     * Create every fixed page first. For an incremental rollover those page
+     * creations are individually WAL-logged. Only after the section is fully
+     * initialized do we publish its offset and increment n_sections.
      */
-    _currentSection = std::make_unique<BingoPgSection>(*this, BUILDING_STRATEGY, section_offset);
+    _currentSection = std::make_unique<BingoPgSection>(*this, _strategy, section_offset, true);
+    _setSectionOffset(section_idx, section_offset);
     ++_metaInfo.n_sections;
+
+    if (_strategy == UPDATING_STRATEGY)
+        writeMetaInfo();
 }
 
 void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
@@ -289,9 +213,6 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
     int data_len;
     int section_off_idx = section_idx % BINGO_SECTION_OFFSET_PER_BLOCK;
     BingoPgBuffer& off_buffer = _getOffsetBuffer(section_idx);
-    /*
-     * Update section offset mapping buffer
-     */
     off_buffer.changeAccess(BINGO_PG_WRITE);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
     section_offsets[section_off_idx] = section_offset;
@@ -301,78 +222,50 @@ void BingoPgIndex::_setSectionOffset(int section_idx, int section_offset)
 BingoPgBuffer& BingoPgIndex::_getOffsetBuffer(int section_idx)
 {
     int section_buf_idx = section_idx / BINGO_SECTION_OFFSET_PER_BLOCK;
-    /*
-     * There is the maximum limit of sections
-     */
     if (section_buf_idx >= BINGO_SECTION_OFFSET_BLOCKS_NUM)
         throw Error("internal error: can not add new section, max limit reached: %d", section_idx * BINGO_MOLS_PER_SECTION);
-    BingoPgBuffer* buffer = 0;
-    if (_sectionOffsetBuffers.getPtr(section_buf_idx) == 0)
+
+    BingoPgBuffer* buffer = nullptr;
+    if (_sectionOffsetBuffers.getPtr(section_buf_idx) == nullptr)
     {
         _sectionOffsetBuffers.set(section_buf_idx, new BingoPgBuffer());
         buffer = _sectionOffsetBuffers.getPtr(section_buf_idx);
+        buffer->setWalEnabled(_strategy != BUILDING_STRATEGY);
         buffer->readBuffer(_index, section_buf_idx + BINGO_METABLOCKS_NUM, BINGO_PG_NOLOCK);
     }
     buffer = _sectionOffsetBuffers.getPtr(section_buf_idx);
-
     return *buffer;
 }
 
 BingoPgSection& BingoPgIndex::_jumpToSection(int section_idx)
 {
-
-    /*
-     * Return if current section is already set
-     */
     if (_currentSectionIdx == section_idx)
         return *_currentSection;
+
     if (section_idx >= getSectionNumber())
     {
         if (_strategy == READING_STRATEGY)
-        {
             throw Error("could not get the buffer: section %d is out of bounds %d", section_idx, getSectionNumber());
-        }
-        else
-        {
-            /*
-             * If strategy is writing or updating then append new sections
-             */
-            while (section_idx >= getSectionNumber())
-            {
-                _initializeNewSection();
-            }
-            return *_currentSection;
-        }
+
+        while (section_idx >= getSectionNumber())
+            _initializeNewSection();
+        return *_currentSection;
     }
-    // profTimerStart(t0, "bingo_pg.read_section");
-    /*
-     * Read the section using offset mapping
-     */
+
     _currentSectionIdx = section_idx;
-
-    // profTimerStart(t1, "bingo_pg.get_offset");
     int offset = _getSectionOffset(section_idx);
-    // profTimerStop(t1);
     _currentSection = std::make_unique<BingoPgSection>(*this, _strategy, offset);
-
     return *_currentSection;
 }
 
 int BingoPgIndex::_getSectionOffset(int section_idx)
 {
-    /*
-     * Prepare section offset mapping
-     */
     int section_off_idx = section_idx % BINGO_SECTION_OFFSET_PER_BLOCK;
     int data_len;
-    int result;
     BingoPgBuffer& off_buffer = _getOffsetBuffer(section_idx);
-    /*
-     * Read mapping
-     */
     off_buffer.changeAccess(BINGO_PG_READ);
     int* section_offsets = (int*)off_buffer.getIndexData(data_len);
-    result = section_offsets[section_off_idx];
+    int result = section_offsets[section_off_idx];
     off_buffer.changeAccess(BINGO_PG_NOLOCK);
     return result;
 }
@@ -385,15 +278,9 @@ void BingoPgIndex::readDictionary(indigo::Array<char>& dictionary)
 
     indigo::Array<char> buffer_dict;
     int block_size = _metaInfo.n_blocks_for_dictionary + _metaInfo.offset_dictionary;
-    /*
-     * Read all buffers for dictionary
-     */
     for (int block_idx = _metaInfo.offset_dictionary; block_idx < block_size; ++block_idx)
     {
         BingoPgBufferCacheBin buffer_cache(block_idx, _index, false);
-        /*
-         * Read and concat buffers
-         */
         buffer_cache.readBin(0, buffer_dict);
         dictionary.concat(buffer_dict);
     }
@@ -401,52 +288,31 @@ void BingoPgIndex::readDictionary(indigo::Array<char>& dictionary)
 
 void BingoPgIndex::insertStructure(BingoPgFpData& data_item)
 {
-
-    /*
-     * Assuming that insert only for a write strategy
-     */
     if (_strategy == READING_STRATEGY)
         throw Error("can not insert a structure while reading");
-    /*
-     * Jump to the last section
-     */
+
     _jumpToSection(getSectionNumber() - 1);
-
-    /*
-     * If a structure can not be added to the current section then initialize the new
-     */
     if (!_currentSection->isExtended())
-    {
         _initializeNewSection();
-    }
-    elog(DEBUG1, "bingo: index: start adding a structure to the section %d", _currentSectionIdx);
-    // #ifdef BINGO_PG_INTEGRITY_DIR
-    //    Relation index = (Relation) _index;
-    //
-    //    BingoPgWrapper rel_wr;
-    //    const char* rel_name = rel_wr.getRelName(index->rd_id);
-    //
-    //    indigo::FileOutput fout(false, "%s/insert/%s_%d_%d_%d", BINGO_PG_INTEGRITY_DIR, rel_name, _currentSectionIdx, );
-    // #endif
-    /*
-     * Add a structure
-     */
-    _currentSection->addStructure(data_item);
 
+    elog(DEBUG1, "bingo: index: start adding a structure to the section %d", _currentSectionIdx);
+    _currentSection->addStructure(data_item);
     elog(DEBUG1, "bingo: index: finish adding a structure to the section %d", _currentSectionIdx);
 
-    /*
-     * Return cmf map to the output
-     */
     data_item.setSectionIdx(_currentSectionIdx);
-    /*
-     * Increment structures common number
-     */
     ++_metaInfo.n_molecules;
+
+    /*
+     * The section existence bit is already durable at this point. Persist the
+     * global count promptly instead of relying on BingoPgBuild destruction.
+     * A crash between the two can at worst leave this diagnostic count one
+     * behind; it cannot expose partially written structure content.
+     */
+    if (_strategy == UPDATING_STRATEGY)
+        writeMetaInfo();
+
     if (_metaInfo.n_molecules % 1000 == 0)
-    {
         elog(NOTICE, "bingo.index: %d structures processed", _metaInfo.n_molecules);
-    }
 }
 
 void BingoPgIndex::readTidItem(ItemPointerData& cmf_item, PG_OBJECT result_ptr)
@@ -456,36 +322,18 @@ void BingoPgIndex::readTidItem(ItemPointerData& cmf_item, PG_OBJECT result_ptr)
 
 void BingoPgIndex::readTidItem(int section_idx, int mol_idx, PG_OBJECT result_ptr)
 {
-    // profTimerStart(t0, "bingo_pg.read_tid");
-    /*
-     * Prepare info for reading
-     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
-
-    /*
-     * Prepare result item
-     */
     ItemPointerData& result_item = (ItemPointerData&)(*(ItemPointer)result_ptr);
     BingoPgBufferCacheMap& map_cache = current_section.getMapBufferCache(map_block_idx);
-    /*
-     * Read tid map
-     */
     map_cache.getTidItem(map_mol_idx, result_item);
 }
 
 void BingoPgIndex::andWithBitset(int section_idx, int fp_idx, BingoPgExternalBitset& ext_bitset)
 {
-    // profTimerStart(t0, "bingo_pg.read_fp_and_with");
-    /*
-     * Prepare info for reading
-     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     BingoPgBufferCacheFp& fp_buffer = current_section.getFpBufferCache(fp_idx);
-    /*
-     * And with a bitset
-     */
     fp_buffer.andWithBitset(ext_bitset);
 }
 
@@ -518,6 +366,8 @@ void BingoPgIndex::removeStructure(int section_idx, int mol_idx)
     BingoPgSection& current_section = _jumpToSection(section_idx);
     current_section.removeStructure(mol_idx);
     --_metaInfo.n_molecules;
+    if (_strategy == UPDATING_STRATEGY)
+        writeMetaInfo();
 }
 
 bool BingoPgIndex::isStructureRemoved(int section_idx, int mol_idx)
@@ -533,10 +383,6 @@ bool BingoPgIndex::isStructureRemoved(ItemPointerData& cmf_item)
 
 void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>& cmf_buf)
 {
-    // profTimerStart(t0, "bingo_pg.read_cmf");
-    /*
-     * Prepare info for reading
-     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
@@ -544,14 +390,8 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
 
     elog(DEBUG1, "bingo: index: read cmf: start read structure %d for section = %d", mol_idx, section_idx);
 
-    /*
-     * Get cmf item
-     */
     ItemPointerData cmf_item;
     map_cache.getCmfItem(map_mol_idx, cmf_item);
-    /*
-     * Check for correct block num
-     */
     dword block_num = ItemPointerGetBlockNumber(&cmf_item);
     if (block_num == InvalidBlockNumber)
     {
@@ -560,9 +400,6 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&cmf_item);
-    /*
-     * Read cmf buffer for a given offset
-     */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, cmf_buf);
     elog(DEBUG1, "bingo: index: read cmf: successfully read cmf of size %d for block %d offset %d", cmf_buf.size(), block_num, block_offset);
@@ -570,9 +407,6 @@ void BingoPgIndex::readCmfItem(int section_idx, int mol_idx, indigo::Array<char>
 
 void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>& xyz_buf)
 {
-    /*
-     * Prepare info for reading
-     */
     BingoPgSection& current_section = _jumpToSection(section_idx);
     int map_block_idx = mol_idx / BINGO_MOLS_PER_MAPBLOCK;
     int map_mol_idx = mol_idx % BINGO_MOLS_PER_MAPBLOCK;
@@ -580,14 +414,8 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
 
     elog(DEBUG1, "bingo: index: read xyz: start read structure %d for section = %d", mol_idx, section_idx);
 
-    /*
-     * Get xyz item
-     */
     ItemPointerData xyz_item;
     map_cache.getXyzItem(map_mol_idx, xyz_item);
-    /*
-     * Check for correct block num
-     */
     dword block_num = ItemPointerGetBlockNumber(&xyz_item);
     if (block_num == InvalidBlockNumber)
     {
@@ -596,9 +424,6 @@ void BingoPgIndex::readXyzItem(int section_idx, int mol_idx, indigo::Array<char>
         return;
     }
     unsigned short block_offset = ItemPointerGetOffsetNumber(&xyz_item);
-    /*
-     * Read xyz buffer for a given offset
-     */
     BingoPgBufferCacheBin& bin_cache = current_section.getBinBufferCache(block_num);
     bin_cache.readBin(block_offset, xyz_buf);
     elog(DEBUG1, "bingo: index: read xyz: successfully read xyz of size %d for block %d offset %d", xyz_buf.size(), block_num, block_offset);

--- a/bingo/postgres/src/pg_core/bingo_pg_index.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.h
@@ -58,6 +58,23 @@ public:
     void writeMetaInfo();
 
     /*
+     * Finalize and release the current section before build metadata and WAL
+     * publication. Returns the physical range that was released so the caller
+     * can validate it before declaring the build complete.
+     */
+    void finishCurrentSection(int& section_offset, int& section_pages)
+    {
+        if (_currentSection.get() == 0 || _currentSectionIdx < 0)
+            throw Error("internal error: no current bingo section to finish");
+
+        section_offset = _getSectionOffset(_currentSectionIdx);
+        _currentSection->finish();
+        section_pages = _currentSection->getPagesCount();
+        _currentSection.reset(nullptr);
+        _currentSectionIdx = -1;
+    }
+
+    /*
      * Getters
      */
     int getStructuresNumber() const

--- a/bingo/postgres/src/pg_core/bingo_pg_index.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.h
@@ -101,10 +101,11 @@ public:
     /*
      * Strategies
      */
-
     void setStrategy(INDEX_STRATEGY strategy)
     {
         _strategy = strategy;
+        _metaBuffer.setRawPageWal(true);
+        _metaBuffer.setWalEnabled(strategy != BUILDING_STRATEGY);
     }
 
     /*

--- a/bingo/postgres/src/pg_core/bingo_pg_index.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.h
@@ -101,6 +101,7 @@ public:
     /*
      * Strategies
      */
+
     void setStrategy(INDEX_STRATEGY strategy)
     {
         _strategy = strategy;

--- a/bingo/postgres/src/pg_core/bingo_pg_index.h
+++ b/bingo/postgres/src/pg_core/bingo_pg_index.h
@@ -13,7 +13,8 @@
 /*
  * Class for handling bingo meta info and sections
  * Bingo index block are the following:
- * meta info(1 block) | config (1 block) | section mapping (10 blocks) | dictionary(100 blocks) | sections
+ * meta info(1 block) | config (1 block) | section mapping (10 blocks) |
+ * dictionary(100 blocks) | sections
  */
 class BingoPgBuildEngine;
 class BingoPgConfig;

--- a/bingo/postgres/src/pg_core/mango_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/mango_pg_build_engine.cpp
@@ -83,9 +83,7 @@ bool MangoPgBuildEngine::processStructure(StructCache& struct_cache)
     }
     else
     {
-        elog(WARNING, "molecule build engine: internal error while processing record with ctid='(%d,%d)'::tid: see at the previous warning", block_number,
-             offset_number);
-        return false;
+        throw Error("internal error while reading prepared molecule data for ctid='(%d,%d)'::tid; see the previous warning", block_number, offset_number);
     }
     return true;
 }

--- a/bingo/postgres/src/pg_core/mango_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/mango_pg_build_engine.cpp
@@ -83,7 +83,9 @@ bool MangoPgBuildEngine::processStructure(StructCache& struct_cache)
     }
     else
     {
-        throw Error("internal error while reading prepared molecule data for ctid='(%d,%d)'::tid; see the previous warning", block_number, offset_number);
+        throw Error("internal error while reading prepared molecule data for "
+                    "ctid='(%d,%d)'::tid; see the previous warning",
+                    block_number, offset_number);
     }
     return true;
 }
@@ -127,7 +129,9 @@ void MangoPgBuildEngine::processStructures(PtrArray<StructCache>& struct_caches)
     //             ItemPointer item_ptr = &(struct_caches[id_n]->ptr);
     //             int block_number = ItemPointerGetBlockNumber(item_ptr);
     //             int offset_number = ItemPointerGetOffsetNumber(item_ptr);
-    //             CORE_HANDLE_ERROR_TID_NO_INDEX(bingo_res, 0, "molecule build engine: error while processing records", block_number, offset_number,
+    //             CORE_HANDLE_ERROR_TID_NO_INDEX(bingo_res, 0, "molecule build
+    //             engine: error while processing records", block_number,
+    //             offset_number,
     //                                            bingoCore.error.ptr());
     //         }
     //     }
@@ -142,7 +146,9 @@ void MangoPgBuildEngine::insertShadowInfo(BingoPgFpData& item_data)
     const char* shadow_hash_name = _shadowHashRelName.ptr();
     ItemPointerData* tid_ptr = &data.getTidItem();
 
-    BingoPgCommon::executeQuery("INSERT INTO %s(b_id,tid_map,mass,fragments,gross,cnt_C,cnt_N,cnt_O,cnt_P,cnt_S,cnt_H) VALUES ("
+    BingoPgCommon::executeQuery("INSERT INTO "
+                                "%s(b_id,tid_map,mass,fragments,gross,cnt_C,cnt_N,cnt_O,cnt_P,cnt_S,cnt_"
+                                "H) VALUES ("
                                 "'(%d, %d)'::tid, '(%d, %d)'::tid, %f, %d, %s)",
                                 shadow_rel_name, data.getSectionIdx(), data.getStructureIdx(), ItemPointerGetBlockNumber(tid_ptr),
                                 ItemPointerGetOffsetNumber(tid_ptr), data.getMass(), data.getFragmentsCount(), data.getGrossStr());
@@ -150,8 +156,9 @@ void MangoPgBuildEngine::insertShadowInfo(BingoPgFpData& item_data)
     const std::map<dword, int>& hashes = data.getHashes();
     for (const auto& pair : hashes)
     {
-        BingoPgCommon::executeQuery("INSERT INTO %s(b_id, ex_hash, f_count) VALUES ('(%d, %d)'::tid, %d, %d)", shadow_hash_name, data.getSectionIdx(),
-                                    data.getStructureIdx(), pair.first, pair.second);
+        BingoPgCommon::executeQuery("INSERT INTO %s(b_id, ex_hash, f_count) VALUES "
+                                    "('(%d, %d)'::tid, %d, %d)",
+                                    shadow_hash_name, data.getSectionIdx(), data.getStructureIdx(), pair.first, pair.second);
     }
 }
 
@@ -245,12 +252,15 @@ void MangoPgBuildEngine::_processResultCb(void* context)
             ItemPointer item_ptr = &(struct_caches[cache_idx].ptr);
             int block_number = ItemPointerGetBlockNumber(item_ptr);
             int offset_number = ItemPointerGetOffsetNumber(item_ptr);
-            elog(WARNING, "molecule build engine: internal error while processing record with ctid='(%d,%d)'::tid: see at the previous warning", block_number,
-                 offset_number);
+            elog(WARNING,
+                 "molecule build engine: internal error while processing record with "
+                 "ctid='(%d,%d)'::tid: see at the previous warning",
+                 block_number, offset_number);
         }
         else
         {
-            elog(WARNING, "molecule build engine: internal error while processing record: see at the previous warning");
+            elog(WARNING, "molecule build engine: internal error while processing "
+                          "record: see at the previous warning");
         }
     }
 }

--- a/bingo/postgres/src/pg_core/ringo_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/ringo_pg_build_engine.cpp
@@ -72,9 +72,7 @@ bool RingoPgBuildEngine::processStructure(StructCache& struct_cache)
     }
     else
     {
-        elog(WARNING, "reaction build engine: internal error while processing record with ctid='(%d,%d)'::tid: see at the previous warning", block_number,
-             offset_number);
-        return false;
+        throw Error("internal error while reading prepared reaction data for ctid='(%d,%d)'::tid; see the previous warning", block_number, offset_number);
     }
     return true;
 }

--- a/bingo/postgres/src/pg_core/ringo_pg_build_engine.cpp
+++ b/bingo/postgres/src/pg_core/ringo_pg_build_engine.cpp
@@ -72,7 +72,9 @@ bool RingoPgBuildEngine::processStructure(StructCache& struct_cache)
     }
     else
     {
-        throw Error("internal error while reading prepared reaction data for ctid='(%d,%d)'::tid; see the previous warning", block_number, offset_number);
+        throw Error("internal error while reading prepared reaction data for "
+                    "ctid='(%d,%d)'::tid; see the previous warning",
+                    block_number, offset_number);
     }
     return true;
 }
@@ -176,12 +178,15 @@ void RingoPgBuildEngine::_processResultCb(void* context)
             ItemPointer item_ptr = &(struct_caches[cache_idx].ptr);
             int block_number = ItemPointerGetBlockNumber(item_ptr);
             int offset_number = ItemPointerGetOffsetNumber(item_ptr);
-            elog(WARNING, "reaction build engine: internal error while processing record with ctid='(%d,%d)'::tid: see at the previous warning", block_number,
-                 offset_number);
+            elog(WARNING,
+                 "reaction build engine: internal error while processing record with "
+                 "ctid='(%d,%d)'::tid: see at the previous warning",
+                 block_number, offset_number);
         }
         else
         {
-            elog(WARNING, "reaction build engine: internal error while processing record: see at the previous warning");
+            elog(WARNING, "reaction build engine: internal error while processing "
+                          "record: see at the previous warning");
         }
     }
 }

--- a/bingo/tests/test_postgres_storage/test_postgres_storage.py
+++ b/bingo/tests/test_postgres_storage/test_postgres_storage.py
@@ -1,0 +1,191 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import psycopg2
+import pytest
+
+from ..constants import DB_POSTGRES
+from ..dbc.base import get_config
+
+
+SCHEMA = "bingo_pg_storage_regression"
+TABLE = f"{SCHEMA}.structures"
+BINGO_INDEX = f"{SCHEMA}.structures_molecule_bingo"
+PRODUCTION_UPDATE_VALUE = "O=C1c2ccccc2N=NN1COc1cc(Cl)c(F)cc1"
+
+
+def _connect(config):
+    return psycopg2.connect(
+        host=config["host"],
+        port=config["port"],
+        dbname=config["database"],
+        user=config["user"],
+        password=config["password"],
+    )
+
+
+def _reset_schema(connection, rows=4000):
+    with connection.cursor() as cursor:
+        cursor.execute(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE")
+        cursor.execute(f"CREATE SCHEMA {SCHEMA}")
+        cursor.execute(
+            f"""
+            CREATE TABLE {TABLE} (
+                id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                smiles_isomeric text NOT NULL,
+                smiles_indigo text NOT NULL
+            )
+            """
+        )
+        if rows:
+            cursor.execute(
+                f"""
+                INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+                SELECT repeat('C', (g %% 48) + 1), repeat('C', (g %% 48) + 1)
+                FROM generate_series(1, %s) AS g
+                """,
+                (rows,),
+            )
+        cursor.execute(
+            f"CREATE INDEX structures_smiles_indigo_idx ON {TABLE} (smiles_indigo)"
+        )
+        cursor.execute(
+            f"""
+            CREATE INDEX structures_molecule_bingo
+            ON {TABLE}
+            USING bingo_idx (smiles_isomeric bingo.molecule)
+            """
+        )
+
+
+def _assert_bingo_matches_heap(connection):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"SELECT count(*) FROM {TABLE} WHERE length(smiles_isomeric) >= 2"
+        )
+        expected = cursor.fetchone()[0]
+        cursor.execute(
+            f"""
+            SELECT count(*)
+            FROM {TABLE}
+            WHERE smiles_isomeric @ ('CC', '')::bingo.sub
+            """
+        )
+        actual = cursor.fetchone()[0]
+    assert actual == expected
+
+
+@pytest.fixture
+def postgres_storage(request):
+    if request.config.getoption("--db") != DB_POSTGRES:
+        pytest.skip("PostgreSQL-specific Bingo storage regression")
+
+    config = get_config()[DB_POSTGRES]
+    connection = _connect(config)
+    connection.autocommit = True
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT cvalue FROM bingo.bingo_config WHERE cname = 'NTHREADS'"
+        )
+        original_nthreads = cursor.fetchone()[0]
+        cursor.execute(
+            "UPDATE bingo.bingo_config SET cvalue = '1' WHERE cname = 'NTHREADS'"
+        )
+
+    try:
+        yield connection, config
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE")
+            cursor.execute(
+                "UPDATE bingo.bingo_config SET cvalue = %s WHERE cname = 'NTHREADS'",
+                (original_nthreads,),
+            )
+        connection.close()
+
+
+def test_non_hot_update_vacuum_and_reindex_preserve_bingo_results(postgres_storage):
+    connection, _ = postgres_storage
+    _reset_schema(connection)
+    _assert_bingo_matches_heap(connection)
+
+    # smiles_indigo has its own B-tree index, so changing it is non-HOT while
+    # the Bingo key (smiles_isomeric) remains unchanged. PostgreSQL still needs
+    # Bingo to represent the new heap TID.
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"UPDATE {TABLE} SET smiles_indigo = %s",
+            (PRODUCTION_UPDATE_VALUE,),
+        )
+        cursor.execute(f"VACUUM (INDEX_CLEANUP ON) {TABLE}")
+
+    _assert_bingo_matches_heap(connection)
+
+    with connection.cursor() as cursor:
+        cursor.execute(f"REINDEX INDEX {BINGO_INDEX}")
+
+    _assert_bingo_matches_heap(connection)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+            VALUES ('CCCCCCCCCCCCCCCCCCCC', 'CCCCCCCCCCCCCCCCCCCC')
+            """
+        )
+
+    _assert_bingo_matches_heap(connection)
+
+
+def test_concurrent_inserts_and_non_hot_updates_keep_bingo_index_consistent(
+    postgres_storage,
+):
+    connection, config = postgres_storage
+    _reset_schema(connection, rows=0)
+
+    workers = 8
+    rows_per_worker = 300
+
+    def insert_rows(worker):
+        worker_connection = _connect(config)
+        worker_connection.autocommit = True
+        try:
+            with worker_connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+                    SELECT repeat('C', ((g + {worker}) % 48) + 1),
+                           repeat('C', ((g + {worker}) % 48) + 1)
+                    FROM generate_series(1, {rows_per_worker}) AS g
+                    """
+                )
+        finally:
+            worker_connection.close()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        list(executor.map(insert_rows, range(workers)))
+
+    _assert_bingo_matches_heap(connection)
+
+    def update_rows(worker):
+        worker_connection = _connect(config)
+        worker_connection.autocommit = True
+        try:
+            with worker_connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    UPDATE {TABLE}
+                    SET smiles_indigo = smiles_indigo || 'C'
+                    WHERE (id % {workers}) = {worker}
+                    """
+                )
+        finally:
+            worker_connection.close()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        list(executor.map(update_rows, range(workers)))
+
+    with connection.cursor() as cursor:
+        cursor.execute(f"VACUUM (INDEX_CLEANUP ON) {TABLE}")
+
+    _assert_bingo_matches_heap(connection)

--- a/bingo/tests/test_postgres_storage/test_postgres_storage.py
+++ b/bingo/tests/test_postgres_storage/test_postgres_storage.py
@@ -6,11 +6,14 @@ import pytest
 from ..constants import DB_POSTGRES
 from ..dbc.base import get_config
 
-
 SCHEMA = "bingo_pg_storage_regression"
 TABLE = f"{SCHEMA}.structures"
 BINGO_INDEX = f"{SCHEMA}.structures_molecule_bingo"
+SHADOW_TABLE = f"{BINGO_INDEX}_shadow"
+SHADOW_HASH_TABLE = f"{BINGO_INDEX}_shadow_hash"
 PRODUCTION_UPDATE_VALUE = "O=C1c2ccccc2N=NN1COc1cc(Cl)c(F)cc1"
+INVALID_SMILES = "C1CC"
+VALID_EXACT_SMILES = "CCO"
 
 
 def _connect(config):
@@ -23,19 +26,41 @@ def _connect(config):
     )
 
 
-def _reset_schema(connection, rows=4000):
+def _create_bingo_index(
+    connection,
+    *,
+    nthreads=None,
+    reject_invalid_structures=None,
+):
+    options = []
+    if nthreads is not None:
+        options.append(f"NTHREADS = {nthreads}")
+    if reject_invalid_structures is not None:
+        options.append(
+            f"REJECT_INVALID_STRUCTURES = {reject_invalid_structures}"
+        )
+
+    with_clause = f"WITH ({', '.join(options)})" if options else ""
+    with connection.cursor() as cursor:
+        cursor.execute(f"""
+            CREATE INDEX structures_molecule_bingo
+            ON {TABLE}
+            USING bingo_idx (smiles_isomeric bingo.molecule)
+            {with_clause}
+            """)
+
+
+def _reset_schema(connection, rows=4000, create_bingo_index=True):
     with connection.cursor() as cursor:
         cursor.execute(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE")
         cursor.execute(f"CREATE SCHEMA {SCHEMA}")
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             CREATE TABLE {TABLE} (
                 id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 smiles_isomeric text NOT NULL,
                 smiles_indigo text NOT NULL
             )
-            """
-        )
+            """)
         if rows:
             cursor.execute(
                 f"""
@@ -48,13 +73,9 @@ def _reset_schema(connection, rows=4000):
         cursor.execute(
             f"CREATE INDEX structures_smiles_indigo_idx ON {TABLE} (smiles_indigo)"
         )
-        cursor.execute(
-            f"""
-            CREATE INDEX structures_molecule_bingo
-            ON {TABLE}
-            USING bingo_idx (smiles_isomeric bingo.molecule)
-            """
-        )
+
+    if create_bingo_index:
+        _create_bingo_index(connection)
 
 
 def _assert_bingo_matches_heap(connection):
@@ -63,15 +84,97 @@ def _assert_bingo_matches_heap(connection):
             f"SELECT count(*) FROM {TABLE} WHERE length(smiles_isomeric) >= 2"
         )
         expected = cursor.fetchone()[0]
+        cursor.execute(f"""
+            SELECT count(*)
+            FROM {TABLE}
+            WHERE smiles_isomeric @ ('CC', '')::bingo.sub
+            """)
+        actual = cursor.fetchone()[0]
+    assert actual == expected
+
+
+def _assert_bingo_matches_indexable_heap(connection):
+    with connection.cursor() as cursor:
+        cursor.execute(f"""
+            SELECT count(*)
+            FROM {TABLE}
+            WHERE length(smiles_isomeric) >= 2
+              AND bingo.checkmolecule(smiles_isomeric) IS NULL
+            """)
+        expected = cursor.fetchone()[0]
+        cursor.execute(f"""
+            SELECT count(*)
+            FROM {TABLE}
+            WHERE smiles_isomeric @ ('CC', '')::bingo.sub
+            """)
+        actual = cursor.fetchone()[0]
+    assert actual == expected
+
+
+def _assert_exact_count(connection, smiles, expected):
+    with connection.cursor() as cursor:
         cursor.execute(
             f"""
             SELECT count(*)
             FROM {TABLE}
-            WHERE smiles_isomeric @ ('CC', '')::bingo.sub
-            """
+            WHERE smiles_isomeric @ (%s, '')::bingo.exact
+            """,
+            (smiles,),
         )
         actual = cursor.fetchone()[0]
     assert actual == expected
+
+
+def _shadow_counts(connection):
+    with connection.cursor() as cursor:
+        cursor.execute(f"SELECT count(*) FROM {SHADOW_TABLE}")
+        shadow_count = cursor.fetchone()[0]
+        cursor.execute(f"SELECT count(*) FROM {SHADOW_HASH_TABLE}")
+        shadow_hash_count = cursor.fetchone()[0]
+    return shadow_count, shadow_hash_count
+
+
+def _assert_no_zero_pages(connection):
+    with connection.cursor() as cursor:
+        cursor.execute("CHECKPOINT")
+        cursor.execute(
+            """
+            WITH relation AS (
+                SELECT pg_relation_filepath(%s::regclass) AS path,
+                       pg_relation_size(%s::regclass) AS relation_size,
+                       current_setting('block_size')::integer AS block_size
+            ),
+            blocks AS (
+                SELECT path,
+                       block_size,
+                       generate_series(
+                           0,
+                           (relation_size / block_size) - 1
+                       ) AS block_no
+                FROM relation
+            )
+            SELECT count(*)
+            FROM blocks
+            WHERE pg_read_binary_file(
+                      path,
+                      block_no * block_size,
+                      block_size
+                  ) = decode(repeat('00', block_size), 'hex')
+            """,
+            (BINGO_INDEX, BINGO_INDEX),
+        )
+        zero_pages = cursor.fetchone()[0]
+    assert zero_pages == 0
+
+
+def _top_memory_bytes(connection):
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT COALESCE(sum(total_bytes), 0)
+            FROM pg_backend_memory_contexts
+            WHERE name = 'TopMemoryContext'
+            """)
+        return cursor.fetchone()[0]
 
 
 @pytest.fixture
@@ -104,7 +207,9 @@ def postgres_storage(request):
         connection.close()
 
 
-def test_non_hot_update_vacuum_and_reindex_preserve_bingo_results(postgres_storage):
+def test_non_hot_update_vacuum_and_reindex_preserve_bingo_results(
+    postgres_storage,
+):
     connection, _ = postgres_storage
     _reset_schema(connection)
     _assert_bingo_matches_heap(connection)
@@ -127,12 +232,10 @@ def test_non_hot_update_vacuum_and_reindex_preserve_bingo_results(postgres_stora
     _assert_bingo_matches_heap(connection)
 
     with connection.cursor() as cursor:
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
             VALUES ('CCCCCCCCCCCCCCCCCCCC', 'CCCCCCCCCCCCCCCCCCCC')
-            """
-        )
+            """)
 
     _assert_bingo_matches_heap(connection)
 
@@ -151,14 +254,12 @@ def test_concurrent_inserts_and_non_hot_updates_keep_bingo_index_consistent(
         worker_connection.autocommit = True
         try:
             with worker_connection.cursor() as cursor:
-                cursor.execute(
-                    f"""
+                cursor.execute(f"""
                     INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
                     SELECT repeat('C', ((g + {worker}) % 48) + 1),
                            repeat('C', ((g + {worker}) % 48) + 1)
                     FROM generate_series(1, {rows_per_worker}) AS g
-                    """
-                )
+                    """)
         finally:
             worker_connection.close()
 
@@ -172,13 +273,11 @@ def test_concurrent_inserts_and_non_hot_updates_keep_bingo_index_consistent(
         worker_connection.autocommit = True
         try:
             with worker_connection.cursor() as cursor:
-                cursor.execute(
-                    f"""
+                cursor.execute(f"""
                     UPDATE {TABLE}
                     SET smiles_indigo = smiles_indigo || 'C'
                     WHERE (id % {workers}) = {worker}
-                    """
-                )
+                    """)
         finally:
             worker_connection.close()
 
@@ -189,3 +288,187 @@ def test_concurrent_inserts_and_non_hot_updates_keep_bingo_index_consistent(
         cursor.execute(f"VACUUM (INDEX_CLEANUP ON) {TABLE}")
 
     _assert_bingo_matches_heap(connection)
+
+
+@pytest.mark.parametrize("nthreads", [-1, 2])
+def test_parallel_build_skips_invalid_structures_and_finishes_cleanly(
+    postgres_storage,
+    nthreads,
+):
+    connection, _ = postgres_storage
+    _reset_schema(connection, rows=2505, create_bingo_index=False)
+
+    # MAX_CACHE_SIZE is 1000. Put malformed structures around flush boundaries
+    # and in the final partial batch so rejection and finalization are both
+    # exercised by the parallel build path.
+    invalid_ids = (1000, 1001, 2001, 2505)
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            UPDATE {TABLE}
+            SET smiles_isomeric = %s,
+                smiles_indigo = %s
+            WHERE id = ANY(%s)
+            """,
+            (INVALID_SMILES, INVALID_SMILES, list(invalid_ids)),
+        )
+
+    _create_bingo_index(
+        connection,
+        nthreads=nthreads,
+        reject_invalid_structures=0,
+    )
+
+    _assert_bingo_matches_indexable_heap(connection)
+    _assert_no_zero_pages(connection)
+
+    shadow_before_invalid = _shadow_counts(connection)
+    assert shadow_before_invalid[0] == 2505 - len(invalid_ids)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+            VALUES (%s, %s)
+            """,
+            (INVALID_SMILES, INVALID_SMILES),
+        )
+
+    assert _shadow_counts(connection) == shadow_before_invalid
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+            VALUES (%s, %s)
+            """,
+            (VALID_EXACT_SMILES, VALID_EXACT_SMILES),
+        )
+
+    shadow_after_valid = _shadow_counts(connection)
+    assert shadow_after_valid[0] == shadow_before_invalid[0] + 1
+    assert shadow_after_valid[1] > shadow_before_invalid[1]
+    _assert_exact_count(connection, VALID_EXACT_SMILES, 1)
+    _assert_no_zero_pages(connection)
+
+    with connection.cursor() as cursor:
+        cursor.execute(f"REINDEX INDEX {BINGO_INDEX}")
+
+    _assert_bingo_matches_indexable_heap(connection)
+    _assert_exact_count(connection, VALID_EXACT_SMILES, 1)
+    _assert_no_zero_pages(connection)
+
+
+def test_reject_invalid_structures_aborts_build_without_publishing_index(
+    postgres_storage,
+):
+    connection, _ = postgres_storage
+    _reset_schema(connection, rows=100, create_bingo_index=False)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            UPDATE {TABLE}
+            SET smiles_isomeric = %s,
+                smiles_indigo = %s
+            WHERE id = 50
+            """,
+            (INVALID_SMILES, INVALID_SMILES),
+        )
+
+    with pytest.raises(psycopg2.Error):
+        _create_bingo_index(
+            connection,
+            nthreads=2,
+            reject_invalid_structures=1,
+        )
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT to_regclass(%s)", (BINGO_INDEX,))
+        assert cursor.fetchone()[0] is None
+        cursor.execute("SELECT to_regclass(%s)", (SHADOW_TABLE,))
+        assert cursor.fetchone()[0] is None
+        cursor.execute("SELECT to_regclass(%s)", (SHADOW_HASH_TABLE,))
+        assert cursor.fetchone()[0] is None
+        cursor.execute(f"""
+            UPDATE {TABLE}
+            SET smiles_isomeric = 'CC',
+                smiles_indigo = 'CC'
+            WHERE id = 50
+            """)
+
+    _create_bingo_index(
+        connection,
+        nthreads=2,
+        reject_invalid_structures=1,
+    )
+    _assert_bingo_matches_heap(connection)
+    _assert_no_zero_pages(connection)
+
+    shadow_before_invalid = _shadow_counts(connection)
+    with pytest.raises(psycopg2.Error):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+                VALUES (%s, %s)
+                """,
+                (INVALID_SMILES, INVALID_SMILES),
+            )
+
+    assert _shadow_counts(connection) == shadow_before_invalid
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            SELECT count(*)
+            FROM {TABLE}
+            WHERE smiles_isomeric = %s
+            """,
+            (INVALID_SMILES,),
+        )
+        assert cursor.fetchone()[0] == 0
+        cursor.execute(
+            f"""
+            INSERT INTO {TABLE} (smiles_isomeric, smiles_indigo)
+            VALUES (%s, %s)
+            """,
+            (VALID_EXACT_SMILES, VALID_EXACT_SMILES),
+        )
+
+    shadow_after_valid = _shadow_counts(connection)
+    assert shadow_after_valid[0] == shadow_before_invalid[0] + 1
+    assert shadow_after_valid[1] > shadow_before_invalid[1]
+    _assert_exact_count(connection, VALID_EXACT_SMILES, 1)
+    _assert_no_zero_pages(connection)
+
+
+def test_repeated_checkmolecule_does_not_grow_top_memory_context(
+    postgres_storage,
+):
+    connection, _ = postgres_storage
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT count(*)
+            FROM generate_series(1, 10) AS g
+            WHERE bingo.checkmolecule(
+                CASE WHEN g % 2 = 0 THEN 'CC' ELSE 'CCC' END
+            ) IS NULL
+            """)
+        assert cursor.fetchone()[0] == 10
+
+    before = _top_memory_bytes(connection)
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT count(*)
+            FROM generate_series(1, 50000) AS g
+            WHERE bingo.checkmolecule(
+                CASE WHEN g % 2 = 0 THEN 'CC' ELSE 'CCC' END
+            ) IS NULL
+            """)
+        assert cursor.fetchone()[0] == 50000
+
+    after = _top_memory_bytes(connection)
+    assert after - before < 1024 * 1024


### PR DESCRIPTION
## Summary

Fixes several Bingo PostgreSQL index durability and corruption issues found during concurrent writes, large update workloads, interrupted index builds, and crash recovery.

The main changes are:

- WAL-log Bingo index mutations so committed changes survive PostgreSQL crash recovery.
- Serialize writes to the same Bingo index to avoid concurrent page and metadata corruption.
- Make VACUUM use the same WAL-backed mutation path.
- Finalize `CREATE INDEX` / `REINDEX` explicitly and verify the completed physical index before publishing build metadata.
- Make parallel builds distinguish intentionally rejected structures from unresolved processing failures.
- Correct PostgreSQL reloption handling, including `NTHREADS=-1`.
- Fix repeated `checkmolecule()` calls accumulating backend cursor and callback state.

## Testing

Added PostgreSQL regression coverage for:

- concurrent inserts and non-HOT updates;
- VACUUM and REINDEX;
- parallel builds with `NTHREADS=-1` and explicit worker counts;
- malformed SMILES during parallel builds, including batch boundaries and the final partial batch;
- strict and tolerant invalid-structure handling;
- continued valid inserts and exact searches after rejected structures;
- shadow-table consistency;
- completed indexes containing no all-zero pages;
- repeated `checkmolecule()` calls without unbounded backend memory growth.

The original corruption cases were reproduced against Bingo 1.45 on PostgreSQL 17. The same scenarios no longer reproduce with this patch.

The existing Bingo PostgreSQL functional suite was also run successfully with **34,152 tests passing**.

## Related issues

- Addresses #108
- May also address the corruption / `unknown index type 0` behavior reported in #2922
- May be related to #1456, although that issue was not directly reproduced

## Note

This PR was mostly authored by AI