### PR TITLE
#3863 – canonicalSmiles() fails with "SMILES saver: bad cycle number: 100" for highly cyclic valid SMILES

### DIFF
--- a/api/tests/integration/tests/basic/canonical_smiles_large_ring_numbers.py
+++ b/api/tests/integration/tests/basic/canonical_smiles_large_ring_numbers.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.append(
+    os.path.normpath(
+        os.path.join(os.path.abspath(__file__), "..", "..", "..", "common")
+    )
+)
+from env_indigo import *  # noqa
+
+indigo = Indigo()
+
+PUBCHEM_CID_20652954_SMILES = (
+    "C1C2C3C4C5C6C7C8C9C%10CC%11C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99"
+    "C%10%10C%11C%11C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11"
+    "C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11C%10%10C99C88C77"
+    "C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11C%10%10C99C88C77C66C55C44C33C22"
+    "C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55"
+    "C66C77C88C99C%10%10C%11C%11C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99"
+    "C%10%10C%11C%11C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11"
+    "C%10%10C99C88C77C66C55C44C33C22C1C1C22C33C44C55C66C77C88C99C%10%10C%11C%11C%10%10C99C88C77"
+    "C66C55C44C33C22C1CC2C3C4C5C6C7C8C9C%10C%11"
+)
+
+molecule = indigo.loadMolecule(PUBCHEM_CID_20652954_SMILES)
+assert molecule.countAtoms() == 231
+assert molecule.countBonds() == 430
+
+ordinary = molecule.smiles()
+canonical = molecule.canonicalSmiles()
+
+assert "%(100)" in canonical
+assert indigo.loadMolecule(canonical).canonicalSmiles() == canonical
+assert indigo.loadMolecule(ordinary).canonicalSmiles() == canonical
+
+extended = indigo.loadMolecule("C%(100)CC%(100)")
+assert extended.countAtoms() == 3
+assert extended.countBonds() == 3

--- a/core/indigo-core/molecule/smiles_loader.h
+++ b/core/indigo-core/molecule/smiles_loader.h
@@ -176,6 +176,7 @@ namespace indigo
 
         void _loadMolecule();
         void _parseMolecule();
+        int _readCycleNumber(int first_char);
         void _loadParsedMolecule();
         void _validateStereoCenters();
 

--- a/core/indigo-core/molecule/src/smiles_loader_parsers.cpp
+++ b/core/indigo-core/molecule/src/smiles_loader_parsers.cpp
@@ -1169,6 +1169,45 @@ void SmilesLoader::_readOtherStuff()
         _bmol->removeAtoms(to_remove);
 }
 
+int SmilesLoader::_readCycleNumber(int first_char)
+{
+    if (isdigit(first_char))
+    {
+        _scanner.skip(1);
+        return first_char - '0';
+    }
+
+    if (first_char != '%')
+        throw Error("cycle number expected");
+
+    _scanner.skip(1);
+
+    if (_scanner.lookNext() != '(')
+        return _scanner.readIntFix(2);
+
+    _scanner.skip(1);
+
+    int number = 0;
+    int digits = 0;
+
+    while (!_scanner.isEOF() && isdigit(_scanner.lookNext()))
+    {
+        if (digits == 5)
+            throw Error("cycle number is too large");
+
+        number = number * 10 + (_scanner.readChar() - '0');
+        digits++;
+    }
+
+    if (digits == 0 || _scanner.isEOF() || _scanner.readChar() != ')')
+        throw Error("invalid extended cycle number");
+
+    if (number < 1)
+        throw Error("cycle number %d is not allowed", number);
+
+    return number;
+}
+
 void SmilesLoader::_parseMolecule()
 {
     _cycles.clear();
@@ -1192,13 +1231,7 @@ void SmilesLoader::_parseMolecule()
         {
             while (isdigit(next) || next == '%')
             {
-                int number;
-
-                _scanner.skip(1);
-                if (next == '%')
-                    number = _scanner.readIntFix(2);
-                else
-                    number = next - '0';
+                int number = _readCycleNumber(next);
 
                 while (_cycles.size() <= number)
                     _cycles.push().clear();
@@ -1375,13 +1408,7 @@ void SmilesLoader::_parseMolecule()
             {
                 if (isdigit(next) || next == '%')
                 {
-                    int number;
-                    _scanner.skip(1);
-
-                    if (next == '%')
-                        number = _scanner.readIntFix(2);
-                    else
-                        number = next - '0';
+                    int number = _readCycleNumber(next);
 
                     // closing some previous numbered atom, like the last '1' in C1C=CC=CC=1
                     if (number >= 0 && number < _cycles.size() && _cycles[number].beg >= 0)

--- a/core/indigo-core/molecule/src/smiles_saver.cpp
+++ b/core/indigo-core/molecule/src/smiles_saver.cpp
@@ -757,6 +757,8 @@ void SmilesSaver::_writeCycleNumber(int n) const
         _output.printf("%d", n);
     else if (n >= 10 && n < 100)
         _output.printf("%%%2d", n);
+    else if (n >= 100 && n <= 99999)
+        _output.printf("%%(%d)", n);
     else
         throw Error("bad cycle number: %d", n);
 }


### PR DESCRIPTION
Fixes #3863.

`canonicalSmiles()` can require more than 99 ring closure labels for highly cyclic molecules, even when the same molecule can be serialized successfully with `smiles()`. `SmilesSaver` previously rejected ring closure numbers above 99, causing canonical SMILES generation to fail with `bad cycle number: 100`.

This change adds support for extended ring closure numbers using the `%(n)` form. Existing output remains unchanged for ring closure numbers below 100:

* `1`–`9` continue to use the single-digit form.
* `10`–`99` continue to use the existing `%nn` form.
* `100` and above use `%(n)`.

The %(n) notation is also supported by RDKit and specified by IUPAC SMILES+ for extended ring closure numbers, rather than being an Indigo-specific representation or a Daylight SMILES representation.
https://www.rdkit.org/docs/RDKit_Book.html#ring-closures

The SMILES loader is updated to read the same extended form so generated SMILES can be parsed and round-tripped correctly.

A regression test covers PubChem CID 20652954 from #3863. It verifies the molecule loads with the expected 231 atoms and 430 bonds, canonical SMILES generation succeeds, the resulting extended ring closure syntax can be parsed again, and both ordinary and canonical SMILES round-trip to the same canonical representation.

Existing canonical SMILES regression tests continue to pass unchanged.

This PR was authored using AI.

## Generic request

* [x] PR name follows the pattern `#1234 – issue name`
* [x] branch name does not contain '#'
* [x] base branch (master or release/xx) is correct
* [x] PR is linked with the issue
* [ ] task status changed to "Code review"
* [x] code follows product standards
* [x] regression tests updated

### Optional

* [ ] unit-tests written
* [ ] documentation updated
